### PR TITLE
SDK sends transmission timestamp along with the sample batch.

### DIFF
--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/IQuickPulseServiceClient.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/IQuickPulseServiceClient.cs
@@ -24,7 +24,8 @@
         /// </summary>
         /// <param name="samples">Data samples.</param>
         /// <param name="instrumentationKey">InstrumentationKey for which to submit data samples.</param>
+        /// <param name="timerProvider">Time provider.</param>
         /// <returns><b>true</b> if the client is expected to keep sending data samples, <b>false</b> otherwise.</returns>
-        bool? SubmitSamples(IEnumerable<QuickPulseDataSample> samples, string instrumentationKey);
+        bool? SubmitSamples(IEnumerable<QuickPulseDataSample> samples, string instrumentationKey, Clock timerProvider);
     }
 }

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
@@ -128,7 +128,7 @@
                     return this.DetermineBackOffs();
                 }
 
-                bool? keepCollecting = this.serviceClient.SubmitSamples(dataSamplesToSubmit, instrumentationKey);
+                bool? keepCollecting = this.serviceClient.SubmitSamples(dataSamplesToSubmit, instrumentationKey, this.timeProvider);
 
                 QuickPulseEventSource.Log.SampleSubmittedEvent(keepCollecting.ToString());
 

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/Service contract/MonitoringBatch.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/Service contract/MonitoringBatch.cs
@@ -1,0 +1,15 @@
+﻿namespace Microsoft.ManagementServices.RealTimeDataProcessing.QuickPulseService
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [DataContract]
+    internal struct MonitoringBatch
+    {
+        [DataMember]
+        public DateTime Timestamp { get; set; }
+
+        [DataMember]
+        public MonitoringDataPoint[] DataPoints { get; set; }
+    }
+}

--- a/Src/PerformanceCollector/Shared/Shared.projitems
+++ b/Src/PerformanceCollector/Shared/Shared.projitems
@@ -14,7 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseCollectionTimeSlotManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\IQuickPulseDataAccumulatorManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\IQuickPulseServiceClient.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseThreadState.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseThreadState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulsePerfCounters.cs">
       <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
     </Compile>
@@ -37,6 +37,7 @@
       <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\Service contract\MetricPoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\Service contract\MonitoringBatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\Service contract\MonitoringDataPoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\SdkVersionUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IQuickPulseTelemetryProcessor.cs" />


### PR DESCRIPTION
SDK sends transmission timestamp along with the sample batch. This is a prerequisite for implementing a better clock synchronization method on the server side.