### PR TITLE
Working around TelemetryProcessorChain being recreated on Build()

### DIFF
--- a/Src/PerformanceCollector/Shared/IQuickPulseTelemetryProcessor.cs
+++ b/Src/PerformanceCollector/Shared/IQuickPulseTelemetryProcessor.cs
@@ -1,14 +1,11 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse
 {
     using System;
-
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse;
 
-    internal interface IQuickPulseTelemetryProcessor : ITelemetryProcessor
+    internal interface IQuickPulseTelemetryProcessor
     {
-        void Initialize(Uri serviceEndpoint, TelemetryConfiguration configuration);
-
-        void StartCollection(IQuickPulseDataAccumulatorManager accumulatorManager);
+        void StartCollection(IQuickPulseDataAccumulatorManager accumulatorManager, Uri serviceEndpoint, TelemetryConfiguration configuration);
 
         void StopCollection();
     }

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -58,12 +58,6 @@
         {
             this.WriteEvent(6, e ?? string.Empty, counter ?? string.Empty, this.ApplicationName);
         }
-
-        [Event(7, Keywords = Keywords.UserActionable, Level = EventLevel.Error, Message = @"QuickPulseTelemetryProcessor could not locate a QuickPulseTelemetryModule in configuration. QuickPulse data will not be available. Make sure both QuickPulseTelemetryProcessor and QuickPulseTelemetryModule are in ApplicationInsights.config or otherwise present.")]
-        public void CouldNotObtainQuickPulseTelemetryModuleEvent(string applicationName = "dummy")
-        {
-            this.WriteEvent(7, this.ApplicationName);
-        }
         #endregion
 
         #region Data reading - success
@@ -136,6 +130,12 @@
         public void SampleStoredEvent(int bufferLength, string applicationName = "dummy")
         {
             this.WriteEvent(19, bufferLength, this.ApplicationName);
+        }
+
+        [Event(7, Level = EventLevel.Verbose, Message = @"QuickPulseTelemetryModule has received a registration request from a QuickPulseTelemetryProcessor.")]
+        public void ProcessorRegistered(int count, string applicationName = "dummy")
+        {
+            this.WriteEvent(7, count, this.ApplicationName);
         }
 
         #endregion

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -133,7 +133,7 @@
         }
 
         [Event(7, Level = EventLevel.Verbose, Message = @"QuickPulseTelemetryModule has received a registration request from a QuickPulseTelemetryProcessor.")]
-        public void ProcessorRegistered(int count, string applicationName = "dummy")
+        public void ProcessorRegistered(string count, string applicationName = "dummy")
         {
             this.WriteEvent(7, count, this.ApplicationName);
         }

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -59,8 +59,8 @@
             this.WriteEvent(6, e ?? string.Empty, counter ?? string.Empty, this.ApplicationName);
         }
 
-        [Event(7, Keywords = Keywords.UserActionable, Level = EventLevel.Error, Message = @"QuickPulseTelemetryModule could not locate a QuickPulseTelemetryProcessor in configuration. QuickPulse data will not be available. Make sure QuickPulseTelemetryProcessor is in ApplicationInsights.config or otherwise present.")]
-        public void CouldNotObtainQuickPulseTelemetryProcessorEvent(string applicationName = "dummy")
+        [Event(7, Keywords = Keywords.UserActionable, Level = EventLevel.Error, Message = @"QuickPulseTelemetryProcessor could not locate a QuickPulseTelemetryModule in configuration. QuickPulse data will not be available. Make sure both QuickPulseTelemetryProcessor and QuickPulseTelemetryModule are in ApplicationInsights.config or otherwise present.")]
+        public void CouldNotObtainQuickPulseTelemetryModuleEvent(string applicationName = "dummy")
         {
             this.WriteEvent(7, this.ApplicationName);
         }

--- a/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
+++ b/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
@@ -168,6 +168,8 @@
                 const int MaxTelemetryProcessorCount = 100;
                 if (!this.telemetryProcessors.Contains(quickPulseTelemetryProcessor) && this.telemetryProcessors.Count < MaxTelemetryProcessorCount)
                 {
+                    QuickPulseEventSource.Log.ProcessorRegistered(this.telemetryProcessors.Count);
+
                     this.telemetryProcessors.Add(quickPulseTelemetryProcessor);
                 }
             }

--- a/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
+++ b/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
@@ -175,7 +175,7 @@
                         this.telemetryProcessors.RemoveFirst();
                     }
 
-                    QuickPulseEventSource.Log.ProcessorRegistered(this.telemetryProcessors.Count);
+                    QuickPulseEventSource.Log.ProcessorRegistered(this.telemetryProcessors.Count.ToString(CultureInfo.InvariantCulture));
                 }
             }
         }

--- a/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
+++ b/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
@@ -30,7 +30,7 @@
 
         private readonly LinkedList<QuickPulseDataSample> collectedSamples = new LinkedList<QuickPulseDataSample>();
 
-        private readonly List<IQuickPulseTelemetryProcessor> telemetryProcessors = new List<IQuickPulseTelemetryProcessor>();
+        private readonly LinkedList<IQuickPulseTelemetryProcessor> telemetryProcessors = new LinkedList<IQuickPulseTelemetryProcessor>();
 
         private TelemetryConfiguration config;
 
@@ -166,11 +166,16 @@
             lock (this.telemetryProcessorsLock)
             {
                 const int MaxTelemetryProcessorCount = 100;
-                if (!this.telemetryProcessors.Contains(quickPulseTelemetryProcessor) && this.telemetryProcessors.Count < MaxTelemetryProcessorCount)
+                if (!this.telemetryProcessors.Contains(quickPulseTelemetryProcessor))
                 {
-                    QuickPulseEventSource.Log.ProcessorRegistered(this.telemetryProcessors.Count);
+                    this.telemetryProcessors.AddLast(quickPulseTelemetryProcessor);
 
-                    this.telemetryProcessors.Add(quickPulseTelemetryProcessor);
+                    if (this.telemetryProcessors.Count > MaxTelemetryProcessorCount)
+                    {
+                        this.telemetryProcessors.RemoveFirst();
+                    }
+
+                    QuickPulseEventSource.Log.ProcessorRegistered(this.telemetryProcessors.Count);
                 }
             }
         }

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseEventSourceTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseEventSourceTests.cs
@@ -17,7 +17,7 @@
             QuickPulseEventSource.Log.CounterRegisteredEvent("counter");
             QuickPulseEventSource.Log.CounterRegistrationFailedEvent("Test exception", "counter");
             QuickPulseEventSource.Log.CounterParsingFailedEvent("Test exception", "counter");
-            QuickPulseEventSource.Log.ProcessorRegistered(0);
+            QuickPulseEventSource.Log.ProcessorRegistered("count");
             QuickPulseEventSource.Log.CounterReadingFailedEvent("Test exception", "counter");
             QuickPulseEventSource.Log.ServiceCommunicationFailedEvent("Test exception");
             QuickPulseEventSource.Log.UnknownErrorEvent("Test exception");

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseEventSourceTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseEventSourceTests.cs
@@ -17,7 +17,7 @@
             QuickPulseEventSource.Log.CounterRegisteredEvent("counter");
             QuickPulseEventSource.Log.CounterRegistrationFailedEvent("Test exception", "counter");
             QuickPulseEventSource.Log.CounterParsingFailedEvent("Test exception", "counter");
-            QuickPulseEventSource.Log.CouldNotObtainQuickPulseTelemetryModuleEvent();
+            QuickPulseEventSource.Log.ProcessorRegistered(0);
             QuickPulseEventSource.Log.CounterReadingFailedEvent("Test exception", "counter");
             QuickPulseEventSource.Log.ServiceCommunicationFailedEvent("Test exception");
             QuickPulseEventSource.Log.UnknownErrorEvent("Test exception");

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseEventSourceTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseEventSourceTests.cs
@@ -17,7 +17,7 @@
             QuickPulseEventSource.Log.CounterRegisteredEvent("counter");
             QuickPulseEventSource.Log.CounterRegistrationFailedEvent("Test exception", "counter");
             QuickPulseEventSource.Log.CounterParsingFailedEvent("Test exception", "counter");
-            QuickPulseEventSource.Log.CouldNotObtainQuickPulseTelemetryProcessorEvent();
+            QuickPulseEventSource.Log.CouldNotObtainQuickPulseTelemetryModuleEvent();
             QuickPulseEventSource.Log.CounterReadingFailedEvent("Test exception", "counter");
             QuickPulseEventSource.Log.ServiceCommunicationFailedEvent("Test exception");
             QuickPulseEventSource.Log.UnknownErrorEvent("Test exception");

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTestHelper.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTestHelper.cs
@@ -1,0 +1,36 @@
+﻿namespace Unit.Tests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    internal static class QuickPulseTestHelper
+    {
+        public static object GetPrivateField(object obj, string fieldName)
+        {
+            var t = new PrivateObject(obj);
+            return t.GetField(fieldName);
+        }
+
+        public static void SetPrivateStaticField(Type type, string fieldName, object value)
+        {
+            PrivateType t = new PrivateType(type);
+            t.SetStaticField(fieldName, value);
+        }
+
+        public static List<IQuickPulseTelemetryProcessor> GetTelemetryProcessors(QuickPulseTelemetryModule module)
+        {
+            return GetPrivateField(module, "telemetryProcessors") as List<IQuickPulseTelemetryProcessor>;
+        }
+
+        public static void ClearEnvironment()
+        {
+            SetPrivateStaticField(typeof(TelemetryConfiguration), "active", null);
+            TelemetryModules.Instance.Modules.Clear();
+        }
+    }
+}

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTestHelper.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTestHelper.cs
@@ -22,9 +22,9 @@
             t.SetStaticField(fieldName, value);
         }
 
-        public static List<IQuickPulseTelemetryProcessor> GetTelemetryProcessors(QuickPulseTelemetryModule module)
+        public static LinkedList<IQuickPulseTelemetryProcessor> GetTelemetryProcessors(QuickPulseTelemetryModule module)
         {
-            return GetPrivateField(module, "telemetryProcessors") as List<IQuickPulseTelemetryProcessor>;
+            return GetPrivateField(module, "telemetryProcessors") as LinkedList<IQuickPulseTelemetryProcessor>;
         }
 
         public static void ClearEnvironment()

--- a/Src/PerformanceCollector/Unit.Tests/Unit.Tests.csproj
+++ b/Src/PerformanceCollector/Unit.Tests/Unit.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="QuickPulse\QuickPulseServiceClientTests.cs" />
     <Compile Include="QuickPulse\QuickPulseTelemetryModuleTests.cs" />
     <Compile Include="Mocks\StubTelemetryChannel.cs" />
+    <Compile Include="QuickPulse\QuickPulseTestHelper.cs" />
     <Compile Include="TelemetryAction.cs" />
     <Compile Include="QuickPulse\QuickPulseTelemetryProcessorTests.cs" />
   </ItemGroup>


### PR DESCRIPTION
Whenever a customer adds his own TelemetryProcessor from code, SDK will re-instantiate all TelemetryProcessors, leaving QuickPulseTelemetryProcessor hanging without any telemetry items going through it. To remedy the issue, QuickPulseTelemetryProcessor now registers itself with QuickPulseTelemetryModule, not the other way around, so that when the processor is recreated, it will either automatically find the module and register with it (ApplicationInsights.config scenario), or the customer will manually call module.RegisterTelemetryProcessor() if the module is created in code.