### PR TITLE
Bug fix: QuickPulseTelemetryProcessor leaks QuickPulse dependencies before collection starts.

### DIFF
--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -8,7 +8,7 @@
     <SemanticVersionMajor>2</SemanticVersionMajor>
     <SemanticVersionMinor>1</SemanticVersionMinor>
     <SemanticVersionPatch>0</SemanticVersionPatch>
-    <PreReleaseMilestone>beta1</PreReleaseMilestone>
+    <PreReleaseMilestone>beta2</PreReleaseMilestone>
 
     <!-- 
       Date when Semantic Version was changed. 

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseDefaults.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseDefaults.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse
+{
+    using System;
+
+    internal static class QuickPulseDefaults
+    {
+        private static readonly Uri QuickPulseServiceEndpoint = new Uri("https://rt.services.visualstudio.com/QuickPulseService.svc");
+
+        public static Uri ServiceEndpoint
+        {
+            get
+            {
+                return QuickPulseServiceEndpoint;
+            }
+        }
+    }
+}

--- a/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
+++ b/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
@@ -26,8 +26,6 @@
 
         private readonly object collectedSamplesLock = new object();
 
-        private readonly Uri serviceUriDefault = new Uri("https://rt.services.visualstudio.com/QuickPulseService.svc");
-
         private readonly LinkedList<QuickPulseDataSample> collectedSamples = new LinkedList<QuickPulseDataSample>();
 
         private readonly LinkedList<IQuickPulseTelemetryProcessor> telemetryProcessors = new LinkedList<IQuickPulseTelemetryProcessor>();
@@ -269,7 +267,7 @@
             if (string.IsNullOrWhiteSpace(this.QuickPulseServiceEndpoint))
             {
                 // endpoint is not specified in configuration, use the default one
-                serviceEndpointUri = this.serviceUriDefault;
+                serviceEndpointUri = QuickPulseDefaults.ServiceEndpoint;
             }
             else
             {

--- a/Src/PerformanceCollector/Shared/QuickPulseTelemetryProcessor.cs
+++ b/Src/PerformanceCollector/Shared/QuickPulseTelemetryProcessor.cs
@@ -18,7 +18,7 @@
     {
         private IQuickPulseDataAccumulatorManager dataAccumulatorManager = null;
 
-        private Uri serviceEndpoint = null;
+        private Uri serviceEndpoint = QuickPulseDefaults.ServiceEndpoint;
 
         private TelemetryConfiguration config = null;
 
@@ -51,7 +51,7 @@
             /*
             The configuration that is being passed into this method is the configuration that is the reason
             why this instance of telemetry processor was created. Regardless of which instrumentation key is passed in,
-            this telemetry processor will only collect for whichever instrumentation key is specified by the module in SetParameters call.
+            this telemetry processor will only collect for whichever instrumentation key is specified by the module in StartCollection call.
             */
 
             this.Register();

--- a/Src/PerformanceCollector/Shared/Shared.projitems
+++ b/Src/PerformanceCollector/Shared/Shared.projitems
@@ -14,7 +14,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseCollectionTimeSlotManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\IQuickPulseDataAccumulatorManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\IQuickPulseServiceClient.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseThreadState.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseDefaults.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseThreadState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulsePerfCounters.cs">
       <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
     </Compile>

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTelemetryModuleTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTelemetryModuleTests.cs
@@ -107,7 +107,7 @@
             IQuickPulseServiceClient serviceClient = (IQuickPulseServiceClient)QuickPulseTestHelper.GetPrivateField(module, "serviceClient");
 
             Assert.IsInstanceOfType(serviceClient, typeof(QuickPulseServiceClient));
-            Assert.AreEqual(QuickPulseTestHelper.GetPrivateField(module, "serviceUriDefault"), serviceClient.ServiceUri);
+            Assert.AreEqual(QuickPulseDefaults.ServiceEndpoint, serviceClient.ServiceUri);
         }
 
         [TestMethod]

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
@@ -368,19 +368,15 @@
         }
 
         [TestMethod]
-        public void QuickPulseTelemetryProcessorFiltersOutDependencyCallsToQuickPulseServiceInIdleMode()
+        public void QuickPulseTelemetryProcessorFiltersOutDependencyCallsToDefaultQuickPulseServiceEndpointInIdleMode()
         {
             // ARRANGE
             var simpleTelemetryProcessorSpy = new SimpleTelemetryProcessorSpy();
             var telemetryProcessor = new QuickPulseTelemetryProcessor(simpleTelemetryProcessorSpy);
-            ((IQuickPulseTelemetryProcessor)telemetryProcessor).StartCollection(
-                new QuickPulseDataAccumulatorManager(),
-                new Uri("https://qps.cloudapp.net/endpoint.svc"),
-                new TelemetryConfiguration() { InstrumentationKey = "some ikey" });
-
+            
             // ACT
             telemetryProcessor.Process(new DependencyTelemetry() { Name = "http://microsoft.ru" });
-            telemetryProcessor.Process(new DependencyTelemetry() { Name = "http://qps.cloudapp.net/blabla" });
+            telemetryProcessor.Process(new DependencyTelemetry() { Name = "http://rt.services.visualstudio.com/blabla" });
             telemetryProcessor.Process(new DependencyTelemetry() { Name = "https://bing.com" });
 
             // ASSERT


### PR DESCRIPTION
Bug fix: QuickPulseTelemetryProcessor leaks QuickPulse dependencies before collection starts