### PR TITLE
Cut HTTP support in 4.5.2

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
@@ -99,27 +99,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             ValidateTelemetryPacket(this.sendItems[0] as DependencyTelemetry, TestUrl, RemoteDependencyKind.Http, false, true, 1, this.sleepTimeMsecBetweenBeginAndEnd, "500");
         }
 
-        /// <summary>
-        /// Validates HttpProcessingFramework sends correct telemetry on calling OnEndHttpCallback with no success flag passed.
-        /// </summary>
         [TestMethod]
-        [Description("Validates HttpProcessingFramework sends correct telemetry on calling OnEndHttpCallback with no success flag passed.")]
-        [Owner("cithomas")]
-        [TestCategory("CVT")]
-        public void RddTestHttpProcessingFrameworkOnEndHttpCallbackEmptySuccessFlag()
-        {
-            var id = 100;
-            this.httpProcessingFramework.OnBeginHttpCallback(id, TestUrl);
-            Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
-            Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
-            this.httpProcessingFramework.OnEndHttpCallback(id, null, false, null);
-
-            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
-            ValidateTelemetryPacket(this.sendItems[0] as DependencyTelemetry, TestUrl, RemoteDependencyKind.Http, true, true, 1, this.sleepTimeMsecBetweenBeginAndEnd, string.Empty);
-        }
-
-        [TestMethod]
-        public void IfNoStatusCodeSuccessIsTrue()
+        public void IfNoStatusCodeItemIsNotTracked()
         {
             int? statusCode = null;
 
@@ -127,9 +108,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
             this.httpProcessingFramework.OnEndHttpCallback(100, null, false, statusCode);
 
-            var dependency = this.sendItems[0] as DependencyTelemetry;
-            Assert.IsTrue(dependency.Success.Value);
-            Assert.AreEqual(string.Empty, dependency.ResultCode);
+            Assert.AreEqual(0, this.sendItems.Count);
         }
 
         [TestMethod]
@@ -221,20 +200,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             var actual = this.sendItems[0] as DependencyTelemetry;
 
             Assert.IsFalse(actual.Success.Value);
-        }
-
-        [TestMethod]
-        public void OnEndHttpCallbackSetsStatusCodeToEmptyIfNotProvided()
-        {
-            int? statusCode = null;
-           
-            this.httpProcessingFramework.OnBeginHttpCallback(100, TestUrl);
-            this.httpProcessingFramework.OnEndHttpCallback(100, true, false, statusCode);
-
-            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
-            var actual = this.sendItems[0] as DependencyTelemetry;
-
-            Assert.AreEqual(string.Empty, actual.ResultCode);
         }
 
         #endregion //BeginEndCallBacks

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
@@ -142,15 +142,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 // .NET 4.6 onwards will be passing the following additional params.
                 if (eventData.Payload.Count >= 4)
                 {
+                    // Payload[1] = success
+                    // Payload[2] = synchronous
+                    // Payload[3] = statusCode
                     if (eventData.Payload[1] != null)
                     {
                         success = Convert.ToBoolean(eventData.Payload[1], CultureInfo.InvariantCulture);
                     }
-
-                    ////if (eventData.Payload[2] != null)
-                    ////{
-                    ////    synchronous = Convert.ToBoolean(eventData.Payload[2], CultureInfo.InvariantCulture);
-                    ////}
 
                     if (eventData.Payload[3] != null)
                     {

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
@@ -137,7 +137,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 long id = Convert.ToInt64(eventData.Payload[0], CultureInfo.InvariantCulture);
 
                 bool? success = null;
-                bool synchronous = false;
                 int? statusCode = null;
 
                 // .NET 4.6 onwards will be passing the following additional params.
@@ -148,10 +147,10 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         success = Convert.ToBoolean(eventData.Payload[1], CultureInfo.InvariantCulture);
                     }
 
-                    if (eventData.Payload[2] != null)
-                    {
-                        synchronous = Convert.ToBoolean(eventData.Payload[2], CultureInfo.InvariantCulture);
-                    }
+                    ////if (eventData.Payload[2] != null)
+                    ////{
+                    ////    synchronous = Convert.ToBoolean(eventData.Payload[2], CultureInfo.InvariantCulture);
+                    ////}
 
                     if (eventData.Payload[3] != null)
                     {
@@ -161,14 +160,12 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 }
                 else
                 {
-                    // In previous versions - .NET 4.5.1-4.5.2 - we cannot differentiate whether it's sync or async, 
-                    // but we know that we collect only async dependency calls
-                    synchronous = false;
+                    // This case is for .NET 4.5.1-4.5.2
                 }
 
                 if (this.HttpProcessingFramework != null)
                 {                    
-                    this.HttpProcessingFramework.OnEndHttpCallback(id, success, synchronous, statusCode);
+                    this.HttpProcessingFramework.OnEndHttpCallback(id, success, false, statusCode);
                 }
             }
         }

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -110,15 +110,17 @@
 
                 if (!statusCode.HasValue)
                 {
-                    statusCode = -1;
+                    // No statuscode from framework in 4.5.2
+                    telemetry.Success = success ?? true;
                 }
-
-                telemetry.ResultCode = statusCode.Value > 0 ? statusCode.Value.ToString(CultureInfo.InvariantCulture) : string.Empty;
-
-                // We calculate success on the base of http code and do not use the 'success' method argument
-                // because framework returns true all the time if you use HttpClient to create a request
-                // statusCode == -1 if there is no Response
-                telemetry.Success = (statusCode > 0) && (statusCode < 400);
+                else
+                {
+                    // We calculate success on the base of http code and do not use the 'success' method argument
+                    // because framework returns true all the time if you use HttpClient to create a request
+                    // statusCode == -1 if there is no Response
+                    telemetry.Success = (statusCode > 0) && (statusCode < 400);
+                    telemetry.ResultCode = statusCode.Value > 0 ? statusCode.Value.ToString(CultureInfo.InvariantCulture) : string.Empty;
+                }
 
                 ClientServerDependencyTracker.EndTracking(this.telemetryClient, telemetry);
             }

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -120,10 +120,10 @@
                 }
                 else
                 {
-                    // This case is for For 4.5.2
-                    // We never not collected statusCode or success
-                    // We also have duplicates if runtime is also 4.5.2 (4.6 runtime has no such problem)
-                    // So starting 2.1.0-beta4 we are cutting support of http dependencies for 4.5.2
+                    // This case is for 4.5.2
+                    // We never collected statusCode or success before 2.1.0-beta4
+                    // We also had duplicates if runtime is also 4.5.2 (4.6 runtime has no such problem)
+                    // So starting with 2.1.0-beta4 we are cutting support for HTTP dependencies in .NET 4.5.2.
                 }
             }
         }   

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -108,21 +108,23 @@
                 DependencyTelemetry telemetry = telemetryTuple.Item1;
                 telemetry.DependencyKind = RemoteDependencyKind.Http.ToString();
 
-                if (!statusCode.HasValue)
-                {
-                    // No statuscode from framework in 4.5.2
-                    telemetry.Success = success ?? true;
-                }
-                else
+                if (statusCode.HasValue)
                 {
                     // We calculate success on the base of http code and do not use the 'success' method argument
                     // because framework returns true all the time if you use HttpClient to create a request
                     // statusCode == -1 if there is no Response
                     telemetry.Success = (statusCode > 0) && (statusCode < 400);
                     telemetry.ResultCode = statusCode.Value > 0 ? statusCode.Value.ToString(CultureInfo.InvariantCulture) : string.Empty;
-                }
 
-                ClientServerDependencyTracker.EndTracking(this.telemetryClient, telemetry);
+                    ClientServerDependencyTracker.EndTracking(this.telemetryClient, telemetry);
+                }
+                else
+                {
+                    // This case is for For 4.5.2
+                    // We never not collected statusCode or success
+                    // We also have duplicates if runtime is also 4.5.2 (4.6 runtime has no such problem)
+                    // So starting 2.1.0-beta4 we are cutting support of http dependencies for 4.5.2
+                }
             }
         }   
 


### PR DESCRIPTION
Cutting support completely because not only we do not have success and status code we also see duplicates. This cannot be fixed on our side since it is framework implementation. 4.6 does not have this problem so for monitoring applications that are compiled as 4.5.2 there are 2 options
- Install StatusMonitor
- Run application on the server that has 4.6 installed

Partially resolving #67 