### PR TITLE
QuickPulse module is now sending stream id

### DIFF
--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseServiceClient.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseServiceClient.cs
@@ -22,6 +22,8 @@
 
         private readonly string instanceName;
 
+        private readonly string streamId;
+
         private readonly string version;
 
         private readonly TimeSpan timeout = TimeSpan.FromSeconds(3);
@@ -32,10 +34,11 @@
 
         private readonly DataContractJsonSerializer serializerDataPointArray = new DataContractJsonSerializer(typeof(MonitoringDataPoint[]));
 
-        public QuickPulseServiceClient(Uri serviceUri, string instanceName, string version, Clock timeProvider, TimeSpan? timeout = null)
+        public QuickPulseServiceClient(Uri serviceUri, string instanceName, string streamId, string version, Clock timeProvider, TimeSpan? timeout = null)
         {
             this.ServiceUri = serviceUri;
             this.instanceName = instanceName;
+            this.streamId = streamId;
             this.version = version;
             this.timeProvider = timeProvider;
             this.timeout = timeout ?? this.timeout;
@@ -95,6 +98,7 @@
                 Version = this.version,
                 //InstrumentationKey = instrumentationKey, // ikey is currently set in query string parameter
                 Instance = this.instanceName,
+                StreamId = this.streamId,
                 Timestamp = timestamp.UtcDateTime
             };
 
@@ -172,6 +176,7 @@
                                         Version = this.version,
                                         InstrumentationKey = instrumentationKey,
                                         Instance = this.instanceName,
+                                        StreamId = this.streamId,
                                         Timestamp = sample.EndTimestamp.UtcDateTime,
                                         Metrics = metricPoints.ToArray()
                                     };

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/Service contract/MonitoringDataPoint.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/Service contract/MonitoringDataPoint.cs
@@ -16,6 +16,9 @@
         public string Instance { get; set; }
 
         [DataMember]
+        public string StreamId { get; set; }
+
+        [DataMember]
         public DateTime Timestamp { get; set; }
 
         [DataMember]

--- a/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
+++ b/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
@@ -289,8 +289,9 @@
 
             // create the default production implementation of the service client with the best service endpoint we could get
             string instanceName = GetInstanceName(configuration);
+            string streamId = GetStreamId();
             var assemblyVersion = SdkVersionUtils.GetAssemblyVersion();
-            this.serviceClient = new QuickPulseServiceClient(serviceEndpointUri, instanceName, assemblyVersion, this.timeProvider);
+            this.serviceClient = new QuickPulseServiceClient(serviceEndpointUri, instanceName, streamId, assemblyVersion, this.timeProvider);
 
             QuickPulseEventSource.Log.TroubleshootingMessageEvent(
                 string.Format(
@@ -316,6 +317,11 @@
             }
 
             return string.IsNullOrWhiteSpace(fakeItem.Context?.Cloud?.RoleInstance) ? Environment.MachineName : fakeItem.Context.Cloud.RoleInstance;
+        }
+
+        private static string GetStreamId()
+        {
+            return Guid.NewGuid().ToString("N");
         }
 
         private void StateThreadWorker(object state)

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -23,6 +23,8 @@
 
         private readonly List<Tuple<DateTimeOffset, MonitoringDataPoint>> samples = new List<Tuple<DateTimeOffset, MonitoringDataPoint>>();
 
+        private readonly List<Tuple<DateTimeOffset, MonitoringDataPoint>> pings = new List<Tuple<DateTimeOffset, MonitoringDataPoint>>();
+
         private Action<HttpListenerResponse> pingResponse;
 
         private Action<HttpListenerResponse> submitResponse;
@@ -85,7 +87,7 @@
             string instance = Guid.NewGuid().ToString();
             var timestamp = DateTimeOffset.UtcNow;
 
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, instance, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, instance, instance, string.Empty, new Clock());
 
             // ACT
             serviceClient.Ping(string.Empty, timestamp);
@@ -103,7 +105,7 @@
         {
             // ARRANGE
             var now = DateTimeOffset.UtcNow;
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
             var sample1 =
                 new QuickPulseDataSample(
                     new QuickPulseDataAccumulator { AIRequestSuccessCount = 5, StartTimestamp = now, EndTimestamp = now.AddSeconds(1) },
@@ -139,7 +141,7 @@
             var dummy = new Dictionary<string, Tuple<PerformanceCounterData, float>>();
             var timeProvider = new ClockMock();
 
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, timeProvider);
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, timeProvider);
             var sample1 =
                 new QuickPulseDataSample(
                     new QuickPulseDataAccumulator { StartTimestamp = timeProvider.UtcNow.AddSeconds(-1), EndTimestamp = timeProvider.UtcNow },
@@ -176,7 +178,7 @@
         {
             // ARRANGE
             var now = DateTimeOffset.UtcNow;
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
             var sample1 =
                 new QuickPulseDataSample(
                     new QuickPulseDataAccumulator { AIRequestSuccessCount = 1, StartTimestamp = now, EndTimestamp = now.AddSeconds(3) },
@@ -196,7 +198,7 @@
         {
             // ARRANGE
             var now = DateTimeOffset.UtcNow;
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
             var sample1 =
                 new QuickPulseDataSample(
                     new QuickPulseDataAccumulator
@@ -232,7 +234,7 @@
         public void QuickPulseServiceClientInterpretsPingResponseCorrectlyWhenHeaderTrue()
         {
             // ARRANGE
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
 
             // ACT
             this.pingResponse = r => { r.AddHeader("x-ms-qps-subscribed", true.ToString()); };
@@ -248,7 +250,7 @@
         public void QuickPulseServiceClientInterpretsPingResponseCorrectlyWhenHeaderFalse()
         {
             // ARRANGE
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
 
             // ACT
             this.pingResponse = r => { r.AddHeader("x-ms-qps-subscribed", false.ToString()); };
@@ -264,7 +266,7 @@
         public void QuickPulseServiceClientInterpretsPingResponseCorrectlyWhenHeaderInvalid()
         {
             // ARRANGE
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
 
             // ACT
             this.pingResponse = r => { r.AddHeader("x-ms-qps-subscribed", "bla"); };
@@ -280,7 +282,7 @@
         public void QuickPulseServiceClientInterpretsPingResponseCorrectlyWhenHeaderMissing()
         {
             // ARRANGE
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
 
             // ACT
             this.pingResponse = r => { };
@@ -296,7 +298,7 @@
         public void QuickPulseServiceClientInterpretsSubmitSamplesResponseCorrectlyWhenHeaderTrue()
         {
             // ARRANGE
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
 
             // ACT
             this.submitResponse = r => { r.AddHeader("x-ms-qps-subscribed", true.ToString()); };
@@ -312,7 +314,7 @@
         public void QuickPulseServiceClientInterpretsSubmitSamplesResponseCorrectlyWhenHeaderFalse()
         {
             // ARRANGE
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
 
             // ACT
             this.submitResponse = r => { r.AddHeader("x-ms-qps-subscribed", false.ToString()); };
@@ -328,7 +330,7 @@
         public void QuickPulseServiceClientInterpretsSubmitSamplesResponseCorrectlyWhenHeaderInvalid()
         {
             // ARRANGE
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
 
             // ACT
             this.submitResponse = r => { r.AddHeader("x-ms-qps-subscribed", "bla"); };
@@ -344,7 +346,7 @@
         public void QuickPulseServiceClientInterpretsSubmitSamplesResponseCorrectlyWhenHeaderMissing()
         {
             // ARRANGE
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
 
             // ACT
             this.submitResponse = r => { };
@@ -362,6 +364,7 @@
             // ARRANGE
             var serviceClient = new QuickPulseServiceClient(
                 this.serviceEndpoint,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 new Clock(),
@@ -386,6 +389,7 @@
                 this.serviceEndpoint,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 TimeSpan.FromMilliseconds(50));
 
@@ -401,12 +405,29 @@
         }
 
         [TestMethod]
-        public void QuickPulseServiceClientSubmitsInstanceNameToService()
+        public void QuickPulseServiceClientSubmitsInstanceNameToServiceWithPing()
+        {
+            // ARRANGE
+            var instanceName = "this instance";
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, instanceName, instanceName, string.Empty, new Clock());
+
+            // ACT
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
+
+            // ASSERT
+            this.listener.Stop();
+
+            Assert.AreEqual(1, this.pings.Count);
+            Assert.AreEqual(instanceName, this.pings[0].Item2.Instance);
+        }
+
+        [TestMethod]
+        public void QuickPulseServiceClientSubmitsInstanceNameToServiceWithSubmitSamples()
         {
             // ARRANGE
             var now = DateTimeOffset.UtcNow;
             var instanceName = "this instance";
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, instanceName, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, instanceName, instanceName, string.Empty, new Clock());
             var sample = new QuickPulseDataSample(
                 new QuickPulseDataAccumulator { StartTimestamp = now, EndTimestamp = now.AddSeconds(1) },
                 new Dictionary<string, Tuple<PerformanceCounterData, float>>());
@@ -422,12 +443,50 @@
         }
 
         [TestMethod]
+        public void QuickPulseServiceClientSubmitsStreamIdToServiceWithPing()
+        {
+            // ARRANGE
+            var streamId = "this stream";
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, streamId, string.Empty, new Clock());
+
+            // ACT
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
+
+            // ASSERT
+            this.listener.Stop();
+
+            Assert.AreEqual(1, this.pings.Count);
+            Assert.AreEqual(streamId, this.pings[0].Item2.StreamId);
+        }
+
+        [TestMethod]
+        public void QuickPulseServiceClientSubmitsStreamIdToServiceWithSubmitSamples()
+        {
+            // ARRANGE
+            var now = DateTimeOffset.UtcNow;
+            var streamId = "this stream";
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, streamId, string.Empty, new Clock());
+            var sample = new QuickPulseDataSample(
+                new QuickPulseDataAccumulator { StartTimestamp = now, EndTimestamp = now.AddSeconds(1) },
+                new Dictionary<string, Tuple<PerformanceCounterData, float>>());
+
+            // ACT
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty);
+
+            // ASSERT
+            this.listener.Stop();
+
+            Assert.AreEqual(1, this.samples.Count);
+            Assert.AreEqual(streamId, this.samples[0].Item2.StreamId);
+        }
+
+        [TestMethod]
         public void QuickPulseServiceClientSubmitsVersionToServiceWithPing()
         {
             // ARRANGE
             var now = DateTimeOffset.UtcNow;
             var version = "this version";
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, version, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, version, new Clock());
 
             // ACT
             serviceClient.Ping("some ikey", now);
@@ -445,7 +504,7 @@
             // ARRANGE
             var now = DateTimeOffset.UtcNow;
             var version = "this version";
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, version, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, version, new Clock());
             var sample = new QuickPulseDataSample(
                 new QuickPulseDataAccumulator { StartTimestamp = now, EndTimestamp = now.AddSeconds(1) },
                 new Dictionary<string, Tuple<PerformanceCounterData, float>>());
@@ -466,7 +525,7 @@
             // ARRANGE
             var now = DateTimeOffset.UtcNow;
             var ikey = "some ikey";
-            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, new Clock());
+            var serviceClient = new QuickPulseServiceClient(this.serviceEndpoint, string.Empty, string.Empty, string.Empty, new Clock());
             var sample = new QuickPulseDataSample(
                 new QuickPulseDataAccumulator { StartTimestamp = now, EndTimestamp = now.AddSeconds(1) },
                 new Dictionary<string, Tuple<PerformanceCounterData, float>>());
@@ -480,7 +539,7 @@
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(ikey, this.samples[0].Item2.InstrumentationKey);
         }
-
+        
         public void Dispose()
         {
             ((IDisposable)this.listener).Dispose();
@@ -505,6 +564,9 @@
                     this.pingResponse(context.Response);
 
                     var dataPoint = (MonitoringDataPoint)serializerDataPoint.ReadObject(context.Request.InputStream);
+                    var transmissionTime = long.Parse(context.Request.Headers["x-ms-qps-transmission-time"], CultureInfo.InvariantCulture);
+
+                    this.pings.Add(Tuple.Create(new DateTimeOffset(transmissionTime, TimeSpan.Zero), dataPoint));
 
                     this.lastPingTimestamp = dataPoint.Timestamp;
                     this.lastPingInstance = dataPoint.Instance;


### PR DESCRIPTION
Currently, QuickPulse is only sending an instance name (which is either a role name or a machine name) with its samples. This leaves a gap when hosting the same application multiple times on the same machine (in different IIS Web Sites, possibly) - those streams will have the same instance name and will be identified as one by the server. Stream Id is solving this problem by introducing an additional identifier to differentiate between such streams (currently a GUID generated at start-up time).