### PR TITLE
Correct UnitTests to proper use of higher precision clock

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
@@ -133,7 +133,8 @@
                 expectedName: GetResourceNameForStoredProcedure(command),
                 expectedSuccess: true,
                 expectedResultCode: "0",
-                timeBetweenBeginEndInMs: stopwatch.ElapsedMilliseconds);
+                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);
+            
         }
 
         [TestMethod]
@@ -156,7 +157,7 @@
                 expectedName: GetResourceNameForStoredProcedure(command),
                 expectedSuccess: true,
                 expectedResultCode: "0",
-                timeBetweenBeginEndInMs: stopwatch.ElapsedMilliseconds);
+                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);
         }
 
         [TestMethod]
@@ -179,7 +180,7 @@
                 expectedName: GetResourceNameForStoredProcedure(command),
                 expectedSuccess: true,
                 expectedResultCode: "0",
-                timeBetweenBeginEndInMs: stopwatch.ElapsedMilliseconds);
+                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);
         }
         
         [TestMethod]
@@ -202,7 +203,7 @@
                 expectedName: GetResourceNameForStoredProcedure(command),
                 expectedSuccess: false,
                 expectedResultCode: "10",
-                timeBetweenBeginEndInMs: stopwatch.ElapsedMilliseconds);
+                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);
         }
 
         [TestMethod]
@@ -226,7 +227,7 @@
                 expectedName: GetResourceNameForStoredProcedure(command),
                 expectedSuccess: false,
                 expectedResultCode: "10",
-                timeBetweenBeginEndInMs: stopwatch.ElapsedMilliseconds);
+                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);
         }
 
         [TestMethod]
@@ -251,7 +252,7 @@
                 expectedName: GetResourceNameForStoredProcedure(command),
                 expectedSuccess: false,
                 expectedResultCode: "10",
-                timeBetweenBeginEndInMs: stopwatch.ElapsedMilliseconds);
+                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);
         }
 
         [TestMethod]

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
@@ -133,8 +133,7 @@
                 expectedName: GetResourceNameForStoredProcedure(command),
                 expectedSuccess: true,
                 expectedResultCode: "0",
-                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);
-            
+                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);            
         }
 
         [TestMethod]


### PR DESCRIPTION
Correct UnitTests to use StopWatch's Elapsed propert, and then get totalmsec from it, rather than directly getting milliseconds which is less accurate.