### PR TITLE
Dependency FuncTest -fail fast if initialization failed

### DIFF
--- a/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/TestWebApplication.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/TestWebApplication.cs
@@ -106,11 +106,12 @@ namespace FuncTest.Helpers
                 this.ExternalCall = string.Format("http://localhost:{0}/ExternalCalls.aspx", this.Port);
                 this.IsFirstTest = true;
                 if (Directory.Exists(this.AppFolder))
-                    ACLTools.GetEveryoneAccessToPath(this.AppFolder);
+                    ACLTools.GetEveryoneAccessToPath(this.AppFolder);                
             }
             catch (Exception ex)
             {
-                Trace.TraceError("Exception occured while attempting to deploy application {0}: {1}.", this.AppName, ex);
+                Trace.TraceError("Exception occured while attempting to deploy application {0}: {1}. Tests wont continue as they are guaranteed to fail.", this.AppName, ex);
+                 throw ex;
             }
         }
 

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/TestWebApplication.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/TestWebApplication.cs
@@ -106,12 +106,12 @@ namespace FuncTest.Helpers
                 this.ExternalCall = string.Format("http://localhost:{0}/ExternalCalls.aspx", this.Port);
                 this.IsFirstTest = true;
                 if (Directory.Exists(this.AppFolder))
-                    ACLTools.GetEveryoneAccessToPath(this.AppFolder);                
+                    ACLTools.GetEveryoneAccessToPath(this.AppFolder);
             }
             catch (Exception ex)
             {
                 Trace.TraceError("Exception occured while attempting to deploy application {0}: {1}. Tests wont continue as they are guaranteed to fail.", this.AppName, ex);
-                 throw ex;
+                throw ex;
             }
         }
 

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/TestWebApplication.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/TestWebApplication.cs
@@ -110,7 +110,7 @@ namespace FuncTest.Helpers
             }
             catch (Exception ex)
             {
-                Trace.TraceError("Exception occured while attempting to deploy application {0}: {1}. Tests wont continue as they are guaranteed to fail.", this.AppName, ex);
+                Trace.TraceError("Exception occured while attempting to deploy application {0}: {1}. Tests will not continue as they are guaranteed to fail.", this.AppName, ex);
                 throw ex;
             }
         }


### PR DESCRIPTION
If the test app failed to deploy, its better to fail fast. Instead of hiding exception, throw it, and let tests fail fast.