### PR TITLE
AzureWebAppRoleEnvironmentTelemetryInitializer fix

### DIFF
--- a/Src/WindowsServer/WindowsServer.Shared.Tests/AzureWebAppRoleEnvironmentTelemetryInitializerTest.cs
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/AzureWebAppRoleEnvironmentTelemetryInitializerTest.cs
@@ -21,7 +21,7 @@
             var telemetryItem = new EventTelemetry();
 
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "TestRoleName");
-            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "TestRoleInstanceName");
+            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "TestRoleInstanceName");
 
             var initializer = new AzureWebAppRoleEnvironmentTelemetryInitializer();
             initializer.Initialize(telemetryItem);
@@ -31,14 +31,14 @@
             Assert.Equal("TestRoleInstanceName", telemetryItem.Context.GetInternalContext().NodeName);
 
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
-            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
         }
 
         [TestMethod]
         public void AzureWebAppRoleEnvironmentTelemetryInitializerDoesNotOverrideRoleName()
         {
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "TestRoleName");
-            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "TestRoleInstanceName");
+            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "TestRoleInstanceName");
 
             var telemetryItem = new EventTelemetry();
             telemetryItem.Context.Cloud.RoleName = "Test";
@@ -51,14 +51,14 @@
             Assert.Equal("TestRoleInstanceName", telemetryItem.Context.GetInternalContext().NodeName);
 
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
-            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
         }
 
         [TestMethod]
         public void AzureWebAppRoleEnvironmentTelemetryInitializerDoesNotOverrideRoleInstance()
         {
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "TestRoleName");
-            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "TestRoleInstanceName");
+            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "TestRoleInstanceName");
 
             var telemetryItem = new EventTelemetry();
             telemetryItem.Context.Cloud.RoleInstance = "Test";
@@ -71,14 +71,14 @@
             Assert.Equal("TestRoleInstanceName", telemetryItem.Context.GetInternalContext().NodeName);
 
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
-            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
         }
 
         [TestMethod]
         public void AzureWebAppRoleEnvironmentTelemetryInitializerDoesNotOverrideNodeName()
         {
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "TestRoleName");
-            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "TestRoleInstanceName");
+            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "TestRoleInstanceName");
 
             var telemetryItem = new EventTelemetry();
             telemetryItem.Context.GetInternalContext().NodeName = "Test";
@@ -91,14 +91,14 @@
             Assert.Equal("Test", telemetryItem.Context.GetInternalContext().NodeName);
 
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
-            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
         }
 
         [TestMethod]
         public void AzureWebAppRoleEnvironmentTelemetryInitializerEmptyVariable()
         {
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
-            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
 
             var telemetryItem = new EventTelemetry();
 

--- a/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
@@ -16,8 +16,8 @@
         /// <summary>Azure Web App name corresponding to the resource name.</summary>
         private const string WebAppNameEnvironmentVariable = "WEBSITE_SITE_NAME";
 
-        /// <summary>Azure Web App host that contains site name and slot: site-slot.</summary>
-        private const string WebAppHostNameEnvironmentVariable = "WEBSITE_HOSTNAME";
+        /// <summary>Azure Web App Instance Id representing the VM. Each instance will have different id.</summary>
+        private const string WebAppInstanceNameEnvironmentVariable = "WEBSITE_INSTANCE_ID";
 
         private string roleInstanceName;
         private string roleName;
@@ -62,7 +62,7 @@
 
         private string GetRoleInstanceName()
         {
-            return Environment.GetEnvironmentVariable(WebAppHostNameEnvironmentVariable) ?? string.Empty;
+            return Environment.GetEnvironmentVariable(WebAppInstanceNameEnvironmentVariable) ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
AzureWebAppRoleEnvironmentTelemetryInitializer populated roleinstanceid from env var WEBSITE_HOSTNAME, which is same acros instances, leading to AI backend not able to distinguish between instances.
This fix populates roleInstance name from WEBSITEINSTANCEID which is unique across instances.

Fixes the below bug:
https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/226