### PR TITLE
Fixed CPU Metric disappearing in AzureWebApp

### DIFF
--- a/Src/PerformanceCollector/Shared/Implementation/PerformanceCollectorEventSource.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/PerformanceCollectorEventSource.cs
@@ -177,9 +177,9 @@
         }
 
         [Event(19, Level = EventLevel.Error, Message = @"Web App CPU Usage has unexpected (negative) value. Last Collected Value:{0} Previous Value:{1}. To avoid negative CPU percentage, this will be reported as zero instead.")]
-        public void WebAppCPUUsedNegativeValue(double lastCollectedValue, double previouslyCollectedValue, string applicationName = "dummy")
+        public void WebAppCPUUsedNegativeValue(string lastCollectedValue, string previouslyCollectedValue, string applicationName = "dummy")
         {
-            this.WriteEvent(19, lastCollectedValue.ToString(), previouslyCollectedValue.ToString(), this.ApplicationName);
+            this.WriteEvent(19, lastCollectedValue, previouslyCollectedValue, this.ApplicationName);
         }
 
         #endregion

--- a/Src/PerformanceCollector/Shared/Implementation/PerformanceCollectorEventSource.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/PerformanceCollectorEventSource.cs
@@ -177,7 +177,7 @@
         }
 
         [Event(19, Level = EventLevel.Error, Message = @"CounterName:{2} has unexpected (negative) value. Last Collected Value:{0} Previous Value:{1}. To avoid negative value, this will be reported as zero instead.")]
-        public void WebAppCounterNegativeValue(string lastCollectedValue, string previouslyCollectedValue, string counterName, string applicationName = "dummy")
+        public void WebAppCounterNegativeValue(double lastCollectedValue, double previouslyCollectedValue, string counterName, string applicationName = "dummy")
         {
             this.WriteEvent(19, lastCollectedValue, previouslyCollectedValue, counterName, this.ApplicationName);
         }

--- a/Src/PerformanceCollector/Shared/Implementation/PerformanceCollectorEventSource.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/PerformanceCollectorEventSource.cs
@@ -176,10 +176,10 @@
             this.WriteEvent(18, e, counter, this.ApplicationName);
         }
 
-        [Event(19, Level = EventLevel.Error, Message = @"Web App CPU Usage has unexpected (negative) value. Last Collected Value:{0} Previous Value:{1}. To avoid negative CPU percentage, this will be reported as zero instead.")]
-        public void WebAppCPUUsedNegativeValue(string lastCollectedValue, string previouslyCollectedValue, string applicationName = "dummy")
+        [Event(19, Level = EventLevel.Error, Message = @"CounterName:{2} has unexpected (negative) value. Last Collected Value:{0} Previous Value:{1}. To avoid negative value, this will be reported as zero instead.")]
+        public void WebAppCounterNegativeValue(string lastCollectedValue, string previouslyCollectedValue, string counterName, string applicationName = "dummy")
         {
-            this.WriteEvent(19, lastCollectedValue, previouslyCollectedValue, this.ApplicationName);
+            this.WriteEvent(19, lastCollectedValue, previouslyCollectedValue, counterName, this.ApplicationName);
         }
 
         #endregion

--- a/Src/PerformanceCollector/Shared/Implementation/PerformanceCollectorEventSource.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/PerformanceCollectorEventSource.cs
@@ -176,6 +176,12 @@
             this.WriteEvent(18, e, counter, this.ApplicationName);
         }
 
+        [Event(19, Level = EventLevel.Error, Message = @"Web App CPU Usage has unexpected (negative) value. Last Collected Value:{0} Previous Value:{1}. To avoid negative CPU percentage, this will be reported as zero instead.")]
+        public void WebAppCPUUsedNegativeValue(double lastCollectedValue, double previouslyCollectedValue, string applicationName = "dummy")
+        {
+            this.WriteEvent(19, lastCollectedValue.ToString(), previouslyCollectedValue.ToString(), this.ApplicationName);
+        }
+
         #endregion
 
         [NonEvent]

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CPUPercenageGauge.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CPUPercenageGauge.cs
@@ -53,9 +53,10 @@
 
                 if (diff < 0)
                 {
-                    PerformanceCollectorEventSource.Log.WebAppCPUUsedNegativeValue(
+                    PerformanceCollectorEventSource.Log.WebAppCounterNegativeValue(
                     this.lastCollectedValue.ToString(CultureInfo.InvariantCulture),
-                    previouslyCollectedValue.ToString(CultureInfo.InvariantCulture));                    
+                    previouslyCollectedValue.ToString(CultureInfo.InvariantCulture),
+                    this.name);                    
                 }
                 else
                 {

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CPUPercenageGauge.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CPUPercenageGauge.cs
@@ -1,7 +1,8 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.WebAppPerformanceCollector
 {
     using System;
-    using DataContracts;
+    using System.Globalization;
+    using DataContracts;    
 
     /// <summary>
     /// Gauge that computes the CPU percentage utilized by a process by utilizing the last computed time.
@@ -53,8 +54,8 @@
                 if (diff < 0)
                 {
                     PerformanceCollectorEventSource.Log.WebAppCPUUsedNegativeValue(
-                    this.lastCollectedValue,
-                    previouslyCollectedValue);                    
+                    this.lastCollectedValue.ToString(CultureInfo.InvariantCulture),
+                    previouslyCollectedValue.ToString(CultureInfo.InvariantCulture));                    
                 }
                 else
                 {

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CPUPercenageGauge.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CPUPercenageGauge.cs
@@ -48,7 +48,18 @@
                 var baseValue = this.lastCollectedTime.Ticks - previouslyCollectedTime.Ticks;
                 baseValue = baseValue != 0 ? baseValue : 1;
 
-                value = (float)((this.lastCollectedValue - previouslyCollectedValue) / baseValue * 100.0);
+                var diff = this.lastCollectedValue - previouslyCollectedValue;
+
+                if (diff < 0)
+                {
+                    PerformanceCollectorEventSource.Log.WebAppCPUUsedNegativeValue(
+                    this.lastCollectedValue,
+                    previouslyCollectedValue);                    
+                }
+                else
+                {
+                    value = (double)(diff * 100.0 / baseValue);
+                }
             }
 
             return value;

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CPUPercenageGauge.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CPUPercenageGauge.cs
@@ -54,8 +54,8 @@
                 if (diff < 0)
                 {
                     PerformanceCollectorEventSource.Log.WebAppCounterNegativeValue(
-                    this.lastCollectedValue.ToString(CultureInfo.InvariantCulture),
-                    previouslyCollectedValue.ToString(CultureInfo.InvariantCulture),
+                    this.lastCollectedValue,
+                    previouslyCollectedValue,
                     this.name);                    
                 }
                 else

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CacheHelper.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CacheHelper.cs
@@ -59,7 +59,7 @@
 
             if (!double.TryParse(valueString.ToString(), out value))
             {
-                throw new System.InvalidCastException("The value of the counter cannot be converted to double type. value:"+ valueString);
+                throw new System.InvalidCastException("The value of the counter cannot be converted to double type. Value:" + valueString);
             }
 
             return value;

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CacheHelper.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CacheHelper.cs
@@ -38,7 +38,7 @@
         /// <param name="performanceCounterName"> The name of the performance counter.</param>
         /// <param name="json"> String containing the JSON.</param>
         /// <returns> Value of the performance counter.</returns>
-        public int PerformanceCounterValue(string performanceCounterName, string json)
+        public double PerformanceCounterValue(string performanceCounterName, string json)
         {
             if (json.IndexOf(performanceCounterName, StringComparison.OrdinalIgnoreCase) == -1)
             {
@@ -48,7 +48,7 @@
             string jsonSubstring = json.Substring(json.IndexOf(performanceCounterName, StringComparison.OrdinalIgnoreCase), json.Length - json.IndexOf(performanceCounterName, StringComparison.OrdinalIgnoreCase));
 
             int startingIndex = jsonSubstring.IndexOf(" ", StringComparison.Ordinal) + 1;
-            int value;
+            double value;
             StringBuilder valueString = new StringBuilder();
 
             while (char.IsDigit(jsonSubstring[startingIndex]))
@@ -57,9 +57,9 @@
                 startingIndex++;
             }
 
-            if (!int.TryParse(valueString.ToString(), out value))
+            if (!double.TryParse(valueString.ToString(), out value))
             {
-                throw new System.InvalidCastException("The value of the counter cannot be converted to integer type.");
+                throw new System.InvalidCastException("The value of the counter cannot be converted to double type. value:"+ valueString);
             }
 
             return value;
@@ -74,7 +74,7 @@
         /// <param name="name">Cache key and name of the counter to be selected from JSON.</param>
         /// <param name="environmentVariable">Identifier of the environment variable.</param>
         /// <returns>Value from cache.</returns>
-        public int GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable)
+        public double GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable)
         {
             if (!CacheHelper.Instance.IsInCache(name))
             {
@@ -90,7 +90,7 @@
             }
 
             string json = this.GetFromCache(name).ToString();
-            int value = this.PerformanceCounterValue(name, json);
+            double value = this.PerformanceCounterValue(name, json);
 
             return value;
         }

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CacheHelper.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/CacheHelper.cs
@@ -38,7 +38,7 @@
         /// <param name="performanceCounterName"> The name of the performance counter.</param>
         /// <param name="json"> String containing the JSON.</param>
         /// <returns> Value of the performance counter.</returns>
-        public double PerformanceCounterValue(string performanceCounterName, string json)
+        public long PerformanceCounterValue(string performanceCounterName, string json)
         {
             if (json.IndexOf(performanceCounterName, StringComparison.OrdinalIgnoreCase) == -1)
             {
@@ -48,7 +48,7 @@
             string jsonSubstring = json.Substring(json.IndexOf(performanceCounterName, StringComparison.OrdinalIgnoreCase), json.Length - json.IndexOf(performanceCounterName, StringComparison.OrdinalIgnoreCase));
 
             int startingIndex = jsonSubstring.IndexOf(" ", StringComparison.Ordinal) + 1;
-            double value;
+            long value;
             StringBuilder valueString = new StringBuilder();
 
             while (char.IsDigit(jsonSubstring[startingIndex]))
@@ -57,9 +57,9 @@
                 startingIndex++;
             }
 
-            if (!double.TryParse(valueString.ToString(), out value))
+            if (!long.TryParse(valueString.ToString(), out value))
             {
-                throw new System.InvalidCastException("The value of the counter cannot be converted to double type. Value:" + valueString);
+                throw new System.InvalidCastException("The value of the counter cannot be converted to long type. Value:" + valueString);
             }
 
             return value;
@@ -74,7 +74,7 @@
         /// <param name="name">Cache key and name of the counter to be selected from JSON.</param>
         /// <param name="environmentVariable">Identifier of the environment variable.</param>
         /// <returns>Value from cache.</returns>
-        public double GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable)
+        public long GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable)
         {
             if (!CacheHelper.Instance.IsInCache(name))
             {
@@ -90,7 +90,7 @@
             }
 
             string json = this.GetFromCache(name).ToString();
-            double value = this.PerformanceCounterValue(name, json);
+            long value = this.PerformanceCounterValue(name, json);
 
             return value;
         }

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/ICachedEnvironmentVariableAccess.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/ICachedEnvironmentVariableAccess.cs
@@ -11,6 +11,6 @@
         /// <param name="name"> Name of the counter.</param>
         /// <param name="environmentVariable"> Identifier of the corresponding environment variable.</param>
         /// <returns> Counter value.</returns>
-        double GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable);
+        long GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable);
     }
 }

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/ICachedEnvironmentVariableAccess.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/ICachedEnvironmentVariableAccess.cs
@@ -11,6 +11,6 @@
         /// <param name="name"> Name of the counter.</param>
         /// <param name="environmentVariable"> Identifier of the corresponding environment variable.</param>
         /// <returns> Counter value.</returns>
-        int GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable);
+        double GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable);
     }
 }

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/RateCounterGauge.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/RateCounterGauge.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.WebAppPerformanceCollector
 {
     using System;
+    using System.Globalization;
 
     /// <summary>
     /// Struct for metrics dependant on time.
@@ -24,14 +25,17 @@
 
         private ICounterValue counter;
 
-        private double? lastValue;
+        /// <summary>
+        /// To keep track of the value read last time this metric was retrieved.
+        /// </summary>
+        private double lastValue;
 
         private ICachedEnvironmentVariableAccess cacheHelper;
 
         /// <summary>
         /// DateTime object to keep track of the last time this metric was retrieved.
         /// </summary>
-        private DateTimeOffset dateTime;
+        private DateTimeOffset lastCollectedTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RateCounterGauge"/> class.
@@ -69,39 +73,31 @@
         /// <returns>The value of the target metric.</returns>
         public double GetValueAndReset()
         {
-            DateTimeOffset currentTime = System.DateTimeOffset.Now;
+            double previouslyCollectedValue = this.lastValue;
+            this.lastValue = (this.counter == null) ? this.cacheHelper.GetCounterValue(this.jsonId, this.environmentVariable) : this.counter.GetValueAndReset();
 
-            var timeDifferenceInSeconds = currentTime.Subtract(this.dateTime).Seconds;
+            var previouslyCollectedTime = this.lastCollectedTime;
+            this.lastCollectedTime = DateTimeOffset.UtcNow;
+
             double value = 0;
-
-            if (this.lastValue == null)
+            if (previouslyCollectedTime != DateTimeOffset.MinValue)
             {
-                if (this.counter == null)
+                var timeDifferenceInSeconds = this.lastCollectedTime.Subtract(previouslyCollectedTime).Seconds;                
+
+                var diff = this.lastValue - previouslyCollectedValue;
+
+                if (diff < 0)
                 {
-                    this.lastValue = this.cacheHelper.GetCounterValue(this.jsonId, this.environmentVariable);
+                    PerformanceCollectorEventSource.Log.WebAppCounterNegativeValue(
+                    this.lastValue.ToString(CultureInfo.InvariantCulture),
+                    previouslyCollectedValue.ToString(CultureInfo.InvariantCulture),
+                    this.name);
                 }
                 else
-                {
-                    this.lastValue = this.counter.GetValueAndReset();
+                {                    
+                    value = timeDifferenceInSeconds != 0 ? (double)(diff * 100.0 / timeDifferenceInSeconds) : 0;
                 }
-
-                this.dateTime = currentTime;
-
-                return value;
             }
-
-            if (this.counter == null)
-            {
-                value = (timeDifferenceInSeconds != 0) ? (this.cacheHelper.GetCounterValue(this.jsonId, this.environmentVariable) - (float)this.lastValue) / timeDifferenceInSeconds : 0;
-                this.lastValue = this.cacheHelper.GetCounterValue(this.jsonId, this.environmentVariable);
-            }
-            else
-            {
-                value = (timeDifferenceInSeconds != 0) ? (this.counter.GetValueAndReset() - (float)this.lastValue) / timeDifferenceInSeconds : 0;
-                this.lastValue = this.counter.GetValueAndReset();
-            }
-
-            this.dateTime = currentTime;
 
             return value;
         }

--- a/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/RateCounterGauge.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/WebAppPerformanceCollector/RateCounterGauge.cs
@@ -89,13 +89,13 @@
                 if (diff < 0)
                 {
                     PerformanceCollectorEventSource.Log.WebAppCounterNegativeValue(
-                    this.lastValue.ToString(CultureInfo.InvariantCulture),
-                    previouslyCollectedValue.ToString(CultureInfo.InvariantCulture),
+                    this.lastValue,
+                    previouslyCollectedValue,
                     this.name);
                 }
                 else
-                {                    
-                    value = timeDifferenceInSeconds != 0 ? (double)(diff * 100.0 / timeDifferenceInSeconds) : 0;
+                {
+                    value = timeDifferenceInSeconds != 0 ? (double)(diff / timeDifferenceInSeconds) : 0;
                 }
             }
 

--- a/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/CacheHelperTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/CacheHelperTests.cs
@@ -16,7 +16,7 @@
         /// </summary>
         /// <param name="name"> Name of the counter to be selected from JSON.</param>
         /// <returns> Value of the counter.</returns>
-        public double GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable)
+        public long GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable)
         {
             if (this.returnJsonOne)
             {

--- a/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/CacheHelperTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/CacheHelperTests.cs
@@ -16,7 +16,7 @@
         /// </summary>
         /// <param name="name"> Name of the counter to be selected from JSON.</param>
         /// <returns> Value of the counter.</returns>
-        public int GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable)
+        public double GetCounterValue(string name, AzureWebApEnvironmentVariables environmentVariable)
         {
             if (this.returnJsonOne)
             {

--- a/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/RateCounterTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/RateCounterTests.cs
@@ -1,7 +1,8 @@
 ﻿namespace Unit.Tests
 {
+    using System.Globalization;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.WebAppPerformanceCollector;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;    
 
     [TestClass]
     public class RateCounterTests
@@ -12,13 +13,17 @@
             RateCounterGauge privateBytesRate = new RateCounterGauge(@"\Process(??APP_WIN32_PROC??)\Private Bytes", "privateBytes", AzureWebApEnvironmentVariables.App, null, new CacheHelperTests());
 
             double value = privateBytesRate.GetValueAndReset();
+
+            // Initial read - so rate is expected to be zero. Also the actual raw value of the counter is 10000 from RemoteEnvironmentVariablesAllSampleOne.json
             Assert.IsTrue(value == 0);
 
             System.Threading.Thread.Sleep(System.TimeSpan.FromSeconds(7));
 
+            // Second read, the actual raw value of the counter is 200000 from RemoteEnvironmentVariablesAllSampleTwo.json
+            // Rate should be (200000-10000)/ 7 secs  = ~14000
             value = privateBytesRate.GetValueAndReset();
 
-            Assert.IsTrue(value != 0);
+            Assert.IsTrue(value >= 10000 && value <= 20000, string.Format(CultureInfo.InvariantCulture, "ActualRate:{0}, is not within expected range", value));
         }
     }
 }

--- a/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/RateCounterTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/RateCounterTests.cs
@@ -2,7 +2,7 @@
 {
     using System.Globalization;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.WebAppPerformanceCollector;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;    
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class RateCounterTests

--- a/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/SampleFiles/RemoteEnvironmentVariablesAllSampleOne.json
+++ b/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/SampleFiles/RemoteEnvironmentVariablesAllSampleOne.json
@@ -114,7 +114,7 @@
     "readIoBytes": 11764011,
     "writeIoBytes": 10951999,
     "otherIoBytes": 1450405,
-    "privateBytes": 5943296,
+    "privateBytes": 100000,
     "handles": 691,
     "contextSwitches": 1079139
   },

--- a/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/SampleFiles/RemoteEnvironmentVariablesAllSampleTwo.json
+++ b/Src/PerformanceCollector/Unit.Tests/WebAppPerformanceCollector/SampleFiles/RemoteEnvironmentVariablesAllSampleTwo.json
@@ -114,7 +114,7 @@
     "readIoBytes": 11764011,
     "writeIoBytes": 10951999,
     "otherIoBytes": 1543592,
-    "privateBytes": 8908800,
+    "privateBytes": 200000,
     "handles": 675,
     "contextSwitches": 1091106
   },

--- a/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
@@ -16,7 +16,7 @@
         /// <summary>Azure Web App name corresponding to the resource name.</summary>
         private const string WebAppNameEnvironmentVariable = "WEBSITE_SITE_NAME";
 
-        /// <summary>Azure Web App Instance Id representing the VM. Each instance will have different id.</summary>
+        /// <summary>Azure Web App Instance Id representing the VM. Each instance will have a different id.</summary>
         private const string WebAppInstanceNameEnvironmentVariable = "WEBSITE_INSTANCE_ID";
 
         private string roleInstanceName;


### PR DESCRIPTION
Fixed an issue which caused CPU metric to be missing in azurewebapp due to overflow of int variable used to read cpu times.

https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/225