### PR TITLE
Change WebApp initializer 

### DIFF
--- a/Src/WindowsServer/WindowsServer.Shared.Tests/AzureWebAppRoleEnvironmentTelemetryInitializerTest.cs
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/AzureWebAppRoleEnvironmentTelemetryInitializerTest.cs
@@ -21,24 +21,23 @@
             var telemetryItem = new EventTelemetry();
 
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "TestRoleName");
-            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "TestRoleInstanceName");
+            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "TestRoleInstanceName");
 
             var initializer = new AzureWebAppRoleEnvironmentTelemetryInitializer();
             initializer.Initialize(telemetryItem);
 
-            Assert.Equal("TestRoleName", telemetryItem.Context.Cloud.RoleName);
-            Assert.Equal("TestRoleInstanceName", telemetryItem.Context.Cloud.RoleInstance);
+            Assert.Equal("TestRoleName", telemetryItem.Context.Cloud.RoleName);            
             Assert.Equal("TestRoleInstanceName", telemetryItem.Context.GetInternalContext().NodeName);
 
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
-            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
+            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
         }
 
         [TestMethod]
         public void AzureWebAppRoleEnvironmentTelemetryInitializerDoesNotOverrideRoleName()
         {
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "TestRoleName");
-            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "TestRoleInstanceName");
+            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "TestRoleInstanceName");
 
             var telemetryItem = new EventTelemetry();
             telemetryItem.Context.Cloud.RoleName = "Test";
@@ -46,19 +45,18 @@
             var initializer = new AzureWebAppRoleEnvironmentTelemetryInitializer();
             initializer.Initialize(telemetryItem);
 
-            Assert.Equal("Test", telemetryItem.Context.Cloud.RoleName);
-            Assert.Equal("TestRoleInstanceName", telemetryItem.Context.Cloud.RoleInstance);
+            Assert.Equal("Test", telemetryItem.Context.Cloud.RoleName);            
             Assert.Equal("TestRoleInstanceName", telemetryItem.Context.GetInternalContext().NodeName);
 
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
-            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
+            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
         }
 
         [TestMethod]
         public void AzureWebAppRoleEnvironmentTelemetryInitializerDoesNotOverrideRoleInstance()
         {
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "TestRoleName");
-            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "TestRoleInstanceName");
+            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "TestRoleInstanceName");
 
             var telemetryItem = new EventTelemetry();
             telemetryItem.Context.Cloud.RoleInstance = "Test";
@@ -71,27 +69,24 @@
             Assert.Equal("TestRoleInstanceName", telemetryItem.Context.GetInternalContext().NodeName);
 
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
-            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
+            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
         }
 
         [TestMethod]
         public void AzureWebAppRoleEnvironmentTelemetryInitializerDoesNotOverrideNodeName()
         {
             Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "TestRoleName");
-            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "TestRoleInstanceName");
-
+            
             var telemetryItem = new EventTelemetry();
             telemetryItem.Context.GetInternalContext().NodeName = "Test";
 
             var initializer = new AzureWebAppRoleEnvironmentTelemetryInitializer();
             initializer.Initialize(telemetryItem);
 
-            Assert.Equal("TestRoleName", telemetryItem.Context.Cloud.RoleName);
-            Assert.Equal("TestRoleInstanceName", telemetryItem.Context.Cloud.RoleInstance);
+            Assert.Equal("TestRoleName", telemetryItem.Context.Cloud.RoleName);            
             Assert.Equal("Test", telemetryItem.Context.GetInternalContext().NodeName);
 
-            Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
-            Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
+            Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);            
         }
 
         [TestMethod]

--- a/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
@@ -16,8 +16,8 @@
         /// <summary>Azure Web App name corresponding to the resource name.</summary>
         private const string WebAppNameEnvironmentVariable = "WEBSITE_SITE_NAME";
 
-        /// <summary>Azure Web App Instance Id representing the VM. Each instance will have a different id.</summary>
-        private const string WebAppInstanceNameEnvironmentVariable = "WEBSITE_INSTANCE_ID";
+        /// <summary>Azure Web App Hostname. This will include the deployment slot, but will be same across instances of same slot.</summary>
+        private const string WebAppHostNameEnvironmentVariable = "WEBSITE_HOSTNAME";
 
         private string roleInstanceName;
         private string roleName;
@@ -42,15 +42,9 @@
                 telemetry.Context.Cloud.RoleName = name;
             }
 
-            if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleInstance))
-            {
-                string name = LazyInitializer.EnsureInitialized(ref this.roleInstanceName, this.GetRoleInstanceName);
-                telemetry.Context.Cloud.RoleInstance = name;
-            }
-
             if (string.IsNullOrEmpty(telemetry.Context.GetInternalContext().NodeName))
             {
-                string name = LazyInitializer.EnsureInitialized(ref this.roleInstanceName, this.GetRoleInstanceName);
+                string name = LazyInitializer.EnsureInitialized(ref this.roleInstanceName, this.GetNodeName);
                 telemetry.Context.GetInternalContext().NodeName = name;
             }
         }
@@ -60,9 +54,9 @@
             return Environment.GetEnvironmentVariable(WebAppNameEnvironmentVariable) ?? string.Empty;
         }
 
-        private string GetRoleInstanceName()
+        private string GetNodeName()
         {
-            return Environment.GetEnvironmentVariable(WebAppInstanceNameEnvironmentVariable) ?? string.Empty;
+            return Environment.GetEnvironmentVariable(WebAppHostNameEnvironmentVariable) ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
Node name is populated from webapphostname as it includes slot. 
Roleinstance is not populated as it will be populated by base sdk with machine name.

Fix:
https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/248