### PR TITLE
Exclude azure storage calls from cross component correlation

### DIFF
--- a/Src/DependencyCollector/NuGet/ApplicationInsights.config.install.xdt
+++ b/Src/DependencyCollector/NuGet/ApplicationInsights.config.install.xdt
@@ -3,6 +3,15 @@
     <Add xdt:Transform="InsertIfMissing" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.DependencyCollector.HttpDependenciesParsingTelemetryInitializer, Microsoft.AI.DependencyCollector" />
   </TelemetryInitializers>
   <TelemetryModules xdt:Transform="InsertIfMissing">
-    <Add xdt:Transform="InsertIfMissing" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector" />
+    <Add xdt:Transform="InsertIfMissing" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector">
+      <ExcludeComponentCorrelationHttpHeadersOnDomains>
+        <!-- 
+        Requests to the following hostnames will not be modified by adding correlation headers. 
+        Add entries here to exclude additional hostnames.
+        NOTE: this configuration will be lost upon NuGet upgrade.
+        -->
+        <Add>core.windows.net</Add>
+      </ExcludeComponentCorrelationHttpHeadersOnDomains>
+    </Add>
   </TelemetryModules>
 </ApplicationInsights>

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
@@ -33,7 +33,7 @@
         #region Fields
         private const int TimeAccuracyMilliseconds = 150; // this may be big number when under debugger
         private TelemetryConfiguration configuration;
-        private Uri testUrl = new Uri("http://www.microsoft.com/");        
+        private Uri testUrl = new Uri("http://www.microsoft.com/");
         private List<ITelemetry> sendItems;
         private int sleepTimeMsecBetweenBeginAndEnd = 100;
         private Exception ex;

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
@@ -214,7 +214,7 @@
                 Assert.IsNull(request.Headers[RequestResponseHeaders.SourceInstrumentationKeyHeader]);
                 var httpProcessingProfiler = new ProfilerHttpProcessing(this.configuration, null, new ObjectInstanceBasedOperationHolder(), /*setCorrelationHeaders*/ true, emptyExclusionList);
                 httpProcessingProfiler.OnBeginForGetResponse(request);
-                Assert.IsNull(request.Headers[RequestResponseHeaders.SourceInstrumentationKeyHeader], "Url tested: "+ azureStorageHost);
+                Assert.IsNull(request.Headers[RequestResponseHeaders.SourceInstrumentationKeyHeader], "Url tested: " + azureStorageHost);
             }
         }
 

--- a/Src/DependencyCollector/Shared/SanitizedHostList.cs
+++ b/Src/DependencyCollector/Shared/SanitizedHostList.cs
@@ -65,11 +65,14 @@
         public bool Contains(string item)
         {
             // Exclude every call to Azure storage, which has host name storageaccountname.<table/blob/queue>.core.windows.net
-            if(item.Contains("core.windows.net"))
+            if (item.Contains("core.windows.net"))
             {
                 return true;
             }
-            else return this.hostList.Contains(item);
+            else
+            {
+                return this.hostList.Contains(item);
+            }
         }
 
         public void CopyTo(string[] array, int arrayIndex)

--- a/Src/DependencyCollector/Shared/SanitizedHostList.cs
+++ b/Src/DependencyCollector/Shared/SanitizedHostList.cs
@@ -64,7 +64,12 @@
 
         public bool Contains(string item)
         {
-            return this.hostList.Contains(item);
+            // Exclude every call to Azure storage, which has host name storageaccountname.<table/blob/queue>.core.windows.net
+            if(item.Contains("core.windows.net"))
+            {
+                return true;
+            }
+            else return this.hostList.Contains(item);
         }
 
         public void CopyTo(string[] array, int arrayIndex)

--- a/Src/DependencyCollector/Shared/SanitizedHostList.cs
+++ b/Src/DependencyCollector/Shared/SanitizedHostList.cs
@@ -63,16 +63,16 @@
         }
 
         public bool Contains(string item)
-        {
-            // Exclude every call to Azure storage, which has host name storageaccountname.<table/blob/queue>.core.windows.net
-            if (item.Contains("core.windows.net"))
+        {            
+            foreach (string hostName in this.hostList)
             {
-                return true;
+                if (item.Contains(hostName))
+                {
+                    return true;
+                }
             }
-            else
-            {
-                return this.hostList.Contains(item);
-            }
+
+            return false;
         }
 
         public void CopyTo(string[] array, int arrayIndex)


### PR DESCRIPTION
Do not modify headers for component correlation if the target host is any of the standard azure storage calls. This is hard-coded into product.