### PR TITLE
Only add the cross component correlation key if the key does not rema…

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
@@ -45,13 +45,7 @@
         [TestInitialize]
         public void TestInitialize()
         {
-            this.configuration = new TelemetryConfiguration();
-            this.configuration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
-            this.sendItems = new List<ITelemetry>();
-            this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
-            this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
-            this.httpProcessingProfiler = new ProfilerHttpProcessing(this.configuration, null, new ObjectInstanceBasedOperationHolder(), /*setCorrelationHeaders*/ true, new List<string>());
-            this.ex = new Exception();
+            this.Initialize(Guid.NewGuid().ToString());
         }
 
         [TestCleanup]
@@ -105,21 +99,34 @@
         [Description("Validates if DependencyTelemetry sent contains the cross component IKey hash.")]
         public void RddTestHttpProcessingProfilerOnEndAddsIkeyToTargetField()
         {
+            // Here is a sample IKey Hash, since the test initialize method adds a random ikey. This will not match the hash for current ikey. Hence represents an external component.
             string hashedIkey = "vwuSMCFBLdIHSdeEXvFnmiXPO5ilQRqw9kO/SE5ino4=";
 
-            var request = WebRequest.Create(this.testUrl);
-
-            Dictionary<string, string> headers = new Dictionary<string, string>();
-            headers.Add(RequestResponseHeaders.TargetInstrumentationKeyHeader, hashedIkey);
-
-            var returnObjectPassed = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK, headers);
-            returnObjectPassed.Headers[RequestResponseHeaders.TargetInstrumentationKeyHeader] = hashedIkey;
-
-            this.httpProcessingProfiler.OnBeginForGetResponse(request);
-            var objectReturned = this.httpProcessingProfiler.OnEndForGetResponse(null, returnObjectPassed, request);
+            this.SimulateWebRequestResponseWithIKeyHash(hashedIkey);
 
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             Assert.AreEqual(this.testUrl.Host + " | " + hashedIkey, ((DependencyTelemetry)this.sendItems[0]).Target);
+        }
+
+        /// <summary>
+        /// Validates if DependencyTelemetry sent contains the cross component instrumentation key hash.
+        /// </summary>
+        [TestMethod]
+        [Description("Validates DependencyTelemetry does not sends IKey hash if the IKey is not from a different component.")]
+        public void RddTestHttpProcessingProfilerOnEndDoesNotAddIkeyToTargetFieldForInternalComponents()
+        {
+            // Initialize the test with a given instrumentation key.
+            this.Initialize("b3eb14d6-bb32-4542-9b93-473cd94aaedf");
+            
+            // Here is the equivalent generated IKey Hash
+            string hashedIkey = "o05HMrc4Og8W1Jyy60JPDPxxQy3bOKyuaj6HudZHTjE=";
+
+            this.SimulateWebRequestResponseWithIKeyHash(hashedIkey);
+
+            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
+
+            // As opposed to this.testUrl.Host + " | " + hashedIkey
+            Assert.AreEqual(this.testUrl.Host, ((DependencyTelemetry)this.sendItems[0]).Target);
         }
 
         /// <summary>
@@ -730,7 +737,7 @@
         #endregion Disposable
 
         #region Helpers
-        
+
         private static void ValidateTelemetryPacket(
             DependencyTelemetry remoteDependencyTelemetryActual, Uri uri, string type, bool success, double expectedValue, string resultCode)
         {
@@ -753,6 +760,31 @@
 
             string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModuleTest), prefix: "rddp:");
             Assert.AreEqual(expectedVersion, remoteDependencyTelemetryActual.Context.GetInternalContext().SdkVersion);
+        }
+
+        private void SimulateWebRequestResponseWithIKeyHash(string hashedIkey)
+        {
+            var request = WebRequest.Create(this.testUrl);
+
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            headers.Add(RequestResponseHeaders.TargetInstrumentationKeyHeader, hashedIkey);
+
+            var returnObjectPassed = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK, headers);
+            returnObjectPassed.Headers[RequestResponseHeaders.TargetInstrumentationKeyHeader] = hashedIkey;
+
+            this.httpProcessingProfiler.OnBeginForGetResponse(request);
+            var objectReturned = this.httpProcessingProfiler.OnEndForGetResponse(null, returnObjectPassed, request);
+        }
+
+        private void Initialize(string instrumentationKey)
+        {
+            this.configuration = new TelemetryConfiguration();
+            this.configuration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
+            this.sendItems = new List<ITelemetry>();
+            this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
+            this.configuration.InstrumentationKey = instrumentationKey;
+            this.httpProcessingProfiler = new ProfilerHttpProcessing(this.configuration, null, new ObjectInstanceBasedOperationHolder(), /*setCorrelationHeaders*/ true, new List<string>());
+            this.ex = new Exception();
         }
         #endregion Helpers
     }

--- a/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
@@ -384,7 +384,9 @@
                             if (responseObj.Headers != null)
                             {
                                 var targetIkeyHash = responseObj.Headers[RequestResponseHeaders.TargetInstrumentationKeyHeader];
-                                if (!string.IsNullOrEmpty(targetIkeyHash))
+                                
+                                // We only add the cross component correlation key if the key does not remain the current component.
+                                if (!string.IsNullOrEmpty(targetIkeyHash) && targetIkeyHash != InstrumentationKeyHashLookupHelper.GetInstrumentationKeyHash(telemetry.Context.InstrumentationKey))
                                 {
                                     telemetry.Type = RemoteDependencyConstants.AI;
                                     telemetry.Target += " | " + targetIkeyHash;

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -274,6 +274,29 @@
         }
 
         [TestMethod]
+        public void OnEndDoesNotAddSourceFieldForRequestForSameComponent()
+        {
+            string instrumentationKey = "b3eb14d6-bb32-4542-9b93-473cd94aaedf";
+
+            // Here is the equivalent generated IKey Hash
+            string hashedIkey = "o05HMrc4Og8W1Jyy60JPDPxxQy3bOKyuaj6HudZHTjE=";
+
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            headers.Add(RequestResponseHeaders.SourceInstrumentationKeyHeader, hashedIkey);
+
+            var context = HttpModuleHelper.GetFakeHttpContext(headers);
+
+            var module = new RequestTrackingTelemetryModule();
+            var config = TelemetryConfiguration.CreateDefault();
+            config.InstrumentationKey = instrumentationKey;
+            module.Initialize(config);
+            module.OnBeginRequest(context);
+            module.OnEndRequest(context);
+
+            Assert.True(string.IsNullOrEmpty(context.GetRequestTelemetry().Source));
+        }
+
+        [TestMethod]
         public void OnEndAddsSourceFieldForRequestWithSourceIkey()
         {
             string hashedIkey = "vwuSMCFBLdIHSdeEXvFnmiXPO5ilQRqw9kO/SE5ino4=";
@@ -284,7 +307,9 @@
             var context = HttpModuleHelper.GetFakeHttpContext(headers);
 
             var module = new RequestTrackingTelemetryModule();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
+            var config = TelemetryConfiguration.CreateDefault();
+            config.InstrumentationKey = Guid.NewGuid().ToString();
+            module.Initialize(config);
             module.OnBeginRequest(context);
             module.OnEndRequest(context);
 

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -102,12 +102,21 @@
                 requestTelemetry.Url = context.Request.UnvalidatedGetUrl();
             }
 
+            if (string.IsNullOrEmpty(requestTelemetry.Context.InstrumentationKey))
+            {
+                // Instrumentation key is probably empty, because the context has not yet had a chance to associate the requestTelemetry to the telemetry client yet.
+                // and get they instrumentation key from all possible sources in the process. Let's do that now.
+                this.telemetryClient.Initialize(requestTelemetry);
+            }
+
             if (context.Request.Headers != null)
             {
-                // If the source header is present on the incoming request, use that to populate the source field.
                 string sourceIkey = context.Request.Headers[RequestResponseHeaders.SourceInstrumentationKeyHeader];
 
-                if (!string.IsNullOrEmpty(sourceIkey))
+                // If the source header is present on the incoming request, and it is an external component (not the same ikey as the one used by the current component), populate the source field.
+                if (!string.IsNullOrEmpty(sourceIkey)
+                    && !string.IsNullOrEmpty(requestTelemetry.Context.InstrumentationKey)
+                    && sourceIkey != InstrumentationKeyHashLookupHelper.GetInstrumentationKeyHash(requestTelemetry.Context.InstrumentationKey))
                 {
                     requestTelemetry.Source = sourceIkey;
                 }


### PR DESCRIPTION
…in the current component.

This avoid self references for which there isn't any nice experience in the viewing experience.

Adds unit tests to verify additional checks.