### PR TITLE
AzureSDK functional test additional check for version

### DIFF
--- a/Test/DependencyCollector/FunctionalTests/FuncTest/HttpTests.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/HttpTests.cs
@@ -579,6 +579,9 @@
                         TimeSpan accessTime = TimeSpan.Parse(httpItem.data.baseData.duration);
                         Assert.IsTrue(accessTime.TotalMilliseconds >= 0, "Access time should be above zero for azure calls");
 
+                        string actualSdkVersion = httpItem.tags[new ContextTagKeys().InternalSdkVersion];
+                        Assert.IsTrue(actualSdkVersion.Contains(DeploymentAndValidationTools.ExpectedSDKPrefix), "Actual version:" + actualSdkVersion);
+
                         var url = httpItem.data.baseData.data;
                         if (url.Contains(expectedUrl))
                         {


### PR DESCRIPTION
rddp vs rddf check.

Fixes:
https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/216