### PR TITLE
Putting instance name, machine name, and stream id into ping's header…

### DIFF
--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseConstants.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseConstants.cs
@@ -14,5 +14,20 @@
         /// Transmission time header.
         /// </summary>
         internal const string XMsQpsTransmissionTimeHeaderName = "x-ms-qps-transmission-time";
+
+        /// <summary>
+        /// Instance name header.
+        /// </summary>
+        internal const string XMsQpsInstanceNameHeaderName = "x-ms-qps-instance-name";
+
+        /// <summary>
+        /// Stream id header.
+        /// </summary>
+        internal const string XMsQpsStreamIdHeaderName = "x-ms-qps-stream-id";
+
+        /// <summary>
+        /// Machine name header.
+        /// </summary>
+        internal const string XMsQpsMachineNameHeaderName = "x-ms-qps-machine-name";
     }
 }

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseServiceClient.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseServiceClient.cs
@@ -51,7 +51,7 @@
         public bool? Ping(string instrumentationKey, DateTimeOffset timestamp)
         {
             var path = string.Format(CultureInfo.InvariantCulture, "ping?ikey={0}", Uri.EscapeUriString(instrumentationKey));
-            HttpWebResponse response = this.SendRequest(WebRequestMethods.Http.Post, path, stream => this.WritePingData(timestamp, stream));
+            HttpWebResponse response = this.SendRequest(WebRequestMethods.Http.Post, path, true, stream => this.WritePingData(timestamp, stream));
 
             if (response == null)
             {
@@ -67,6 +67,7 @@
             HttpWebResponse response = this.SendRequest(
                 WebRequestMethods.Http.Post,
                 path,
+                false,
                 stream => this.WriteSamples(samples, instrumentationKey, stream));
 
             if (response == null)
@@ -204,7 +205,7 @@
             this.serializerDataPointArray.WriteObject(stream, monitoringPoints.ToArray());
         }
 
-        private HttpWebResponse SendRequest(string httpVerb, string path, Action<Stream> onWriteBody)
+        private HttpWebResponse SendRequest(string httpVerb, string path, bool includeHeaders, Action<Stream> onWriteBody)
         {
             var requestUri = string.Format(CultureInfo.InvariantCulture, "{0}/{1}", this.ServiceUri.AbsoluteUri.TrimEnd('/'), path.TrimStart('/'));
 
@@ -214,6 +215,13 @@
                 request.Method = httpVerb;
                 request.Timeout = (int)this.timeout.TotalMilliseconds;
                 request.Headers.Add(QuickPulseConstants.XMsQpsTransmissionTimeHeaderName, this.timeProvider.UtcNow.Ticks.ToString(CultureInfo.InvariantCulture));
+
+                if (includeHeaders)
+                {
+                    request.Headers.Add(QuickPulseConstants.XMsQpsInstanceNameHeaderName, this.instanceName);
+                    request.Headers.Add(QuickPulseConstants.XMsQpsStreamIdHeaderName, this.streamId);
+                    request.Headers.Add(QuickPulseConstants.XMsQpsMachineNameHeaderName, this.machineName);
+                }
 
                 onWriteBody?.Invoke(request.GetRequestStream());
 


### PR DESCRIPTION
…s for QPS's convenience. Allows QPS not to read the content of every Ping request.