### PR TITLE
Fix a randomly failing FunctionalTest

### DIFF
--- a/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
@@ -94,7 +94,14 @@
             if (false == this.hostProcess.WaitForExit(processExitWaitTimeout))
             {
                 Trace.TraceWarning("iisexpress.exe process hasn't exited during expected time, terminating!");
-                this.hostProcess.Kill();
+                try
+                {
+                    this.hostProcess.Kill();
+                }
+                catch (Win32Exception e)
+                {
+                    Trace.TraceWarning("failed to kill iisexpress.exe: " + e.GetType().FullName + ": " + e.Message);
+                }
             }
             else
             {


### PR DESCRIPTION
Catch and trace exception if killing IISExpress process fails instead of failing test as a whole with unhandled exception.

(Perfcounter module already does this and has been running fine. Web func tests did not handle this exception and has been failing randomnly)