### PR TITLE
processExitWaitTimeout for FunctionalTest increase

### DIFF
--- a/Test/PerformanceCollector/FunctionalTests/IisExpress/IISExpress.cs
+++ b/Test/PerformanceCollector/FunctionalTests/IisExpress/IISExpress.cs
@@ -97,6 +97,7 @@
                 try
                 {
                     this.hostProcess.Kill();
+                    Trace.TraceWarning("Successfully terminated IISProcess with Kill call.");
                 }
                 catch (Win32Exception e)
                 {

--- a/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
@@ -97,6 +97,7 @@
                 try
                 {
                     this.hostProcess.Kill();
+                    Trace.TraceWarning("Successfully terminated IISProcess with Kill call.");
                 }
                 catch (Win32Exception e)
                 {

--- a/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
@@ -84,7 +84,7 @@
 
         public void Stop()
         {
-            const int processExitWaitTimeout = 5000;
+            const int processExitWaitTimeout = 10000;
 
             Trace.TraceInformation("Stopping iisexpress.exe: pid={0}", this.hostProcess.Id);
 


### PR DESCRIPTION
processExitWaitTimeout - increased from 5 to 10 seconds max. On our 4.5Functional Test machine, the tests are failing because of of timeout.
Please note that this is max timeout - if the process dies in 1 sec we wont wait any further.!