### PR TITLE
Revert to old state of test cleanup.

### DIFF
--- a/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
@@ -84,25 +84,17 @@
 
         public void Stop()
         {
-            const int processExitWaitTimeout = 10000;
+            const int processExitWaitTimeout = 15000;
 
-            Trace.TraceInformation("Killing iisexpress.exe: pid={0}", this.hostProcess.Id);
+            Trace.TraceInformation("Stopping iisexpress.exe: pid={0}", this.hostProcess.Id);
 
-            try
-            {
-                this.hostProcess.Kill();
-            }
-            catch(InvalidOperationException ex)
-            {
-                // The process has already exited most likely if this exception.
-                Trace.TraceWarning("Kill threw exception. {0}" , ex.Message);
-            }
+            SendStopMessageToProcess(this.hostProcess.Id);
 
-            Trace.TraceInformation("Kill invoked. Waiting for exit of iisexpress.exe: pid={0}", this.hostProcess.Id);
+            Trace.TraceInformation("Waiting for exit of iisexpress.exe: pid={0}", this.hostProcess.Id);
             if (false == this.hostProcess.WaitForExit(processExitWaitTimeout))
             {
                 Trace.TraceWarning("iisexpress.exe process hasn't exited during expected time, terminating!");
-                throw new Exception("IISExpress.exe process has not exited!");
+                this.hostProcess.Kill();
             }
             else
             {

--- a/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/IisExpress/IISExpress.cs
@@ -88,7 +88,15 @@
 
             Trace.TraceInformation("Killing iisexpress.exe: pid={0}", this.hostProcess.Id);
 
-            this.hostProcess.Kill();
+            try
+            {
+                this.hostProcess.Kill();
+            }
+            catch(InvalidOperationException ex)
+            {
+                // The process has already exited most likely if this exception.
+                Trace.TraceWarning("Kill threw exception. {0}" , ex.Message);
+            }
 
             Trace.TraceInformation("Kill invoked. Waiting for exit of iisexpress.exe: pid={0}", this.hostProcess.Id);
             if (false == this.hostProcess.WaitForExit(processExitWaitTimeout))


### PR DESCRIPTION
Revert to old behaviour for IISExpress, but with increased timeout.
This is unblock beta 2 release and needs proper investigation later.

(my attempt to fix the test cleanup caused more issues, and I need to unblock me/everyone fast, hence the revert)