### PR TITLE
Fixing assembly load location for AzureRoleEnvironmentContextReader

### DIFF
--- a/Src/WindowsServer/WindowsServer.Shared.Tests/AzureRoleEnvironmentTelemetryInitializerTest.cs
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/AzureRoleEnvironmentTelemetryInitializerTest.cs
@@ -111,19 +111,18 @@
                 new System.EnterpriseServices.Internal.Publish().GacInstall(dllPath);
 
                 // Validate that the dll is not loaded to test AppDomaion to begin with.
-                var retrievedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(item => string.Equals(item.GetName().Name, "Newtonsoft.Json", StringComparison.OrdinalIgnoreCase));
+                var retrievedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(item => string.Equals(item.GetName().Name, "Microsoft.ApplicationInsights.Log4NetAppender", StringComparison.OrdinalIgnoreCase));
                 Assert.Null(retrievedAssembly);
-
-                // Create initializer - this will internally create separate appdomain and load assembly into it.
-                AzureRoleEnvironmentContextReader.BaseDirectory = AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
-
-                // TestAssemblyLoader will load a random assembly (newtonsoft.json.dll) and populate TestRoleName, TestRoleInstanceId into the fields.
+                
+                // TestAssemblyLoader will load a random assembly (Microsoft.ApplicationInsights.Log4NetAppender.dll) and populate TestRoleName, TestRoleInstanceId into the fields.
                 AzureRoleEnvironmentContextReader.AssemblyLoaderType = typeof(TestAzureServiceRuntimeAssemblyLoader);
                 AzureRoleEnvironmentContextReader.Instance = null;
+
+                // Create initializer - this will internally create separate appdomain and load assembly into it.
                 AzureRoleEnvironmentTelemetryInitializer initializer = new AzureRoleEnvironmentTelemetryInitializer();
 
                 // Validate that the dll is still not loaded to current appdomain.
-                retrievedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(item => string.Equals(item.GetName().Name, "Newtonsoft.Json", StringComparison.OrdinalIgnoreCase));
+                retrievedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(item => string.Equals(item.GetName().Name, "Microsoft.ApplicationInsights.Log4NetAppender", StringComparison.OrdinalIgnoreCase));
                 Assert.Null(retrievedAssembly);
 
                 // Validate that initializer has populated expected context properties. (set by TestAssemblyLoader)

--- a/Src/WindowsServer/WindowsServer.Shared/Implementation/WindowsServerEventSource.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/Implementation/WindowsServerEventSource.cs
@@ -185,11 +185,11 @@
 
         [Event(
            20,
-           Message = "AzureRoleEnvironmentContextReader initialize successfully completed reading context.",
+           Message = "AzureRoleEnvironmentContextReader initialize successfully completed reading context. RoleName: {0}, RoleInstanceName: {1}",
            Level = EventLevel.Informational)]
-        public void AzureRoleEnvironmentContextReaderInitializedSuccess(string applicationName = "Incorrect")
+        public void AzureRoleEnvironmentContextReaderInitializedSuccess(string roleName, string roleInstanceName, string applicationName = "Incorrect")
         {
-            this.WriteEvent(20, this.ApplicationName);
+            this.WriteEvent(20, roleName, roleInstanceName, this.ApplicationName);
         }
 
         [Event(


### PR DESCRIPTION
Fixed the location where AzureRoleEnvironmentContextReader loads the AssemlyLoader assembly from.

Another typo fix.

This should have been part of:
https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/305