### PR TITLE
Include port number into dependency target for non standard ports

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/DependencyCollector.Shared.Tests.projitems
+++ b/Src/DependencyCollector/Shared.Tests/DependencyCollector.Shared.Tests.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)HttpDependenciesParsingTelemetryInitializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ClientServerDependencyTrackerTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\DependencyTargetNameHelperTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\Operation\CacheBasedOperationHolderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\Operation\ObjectInstanceBasedOperationHolderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WebRequestDependencyTrackingHelpersTests.cs" />

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyTargetNameHelperTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyTargetNameHelperTest.cs
@@ -1,0 +1,24 @@
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class DependencyTargetNameHelperTest
+    {
+        [TestMethod]
+        public void DependencyTargetNameHelperTests()
+        {
+            Uri httpPortDefaultUri = new Uri("http://www.microsoft.com");
+            Uri httpsPortDefaultUri = new Uri("https://www.microsoft.com");
+            Uri httpPortExplicitUri = new Uri("http://www.microsoft.com:80");
+            Uri httpsPortExplicitUri = new Uri("http://www.microsoft.com:443");
+            Uri randomPortExplicitUri = new Uri("http://www.microsoft.com:1010");
+            Assert.AreEqual(httpPortDefaultUri.Host, DependencyTargetNameHelper.GetDependencyTargetName(httpPortDefaultUri));
+            Assert.AreEqual(httpsPortDefaultUri.Host, DependencyTargetNameHelper.GetDependencyTargetName(httpsPortDefaultUri));
+            Assert.AreEqual(httpPortExplicitUri.Host, DependencyTargetNameHelper.GetDependencyTargetName(httpPortExplicitUri));
+            Assert.AreEqual(httpsPortExplicitUri.Host, DependencyTargetNameHelper.GetDependencyTargetName(httpsPortExplicitUri));
+            Assert.AreEqual(randomPortExplicitUri.Host + ":" + randomPortExplicitUri.Port, DependencyTargetNameHelper.GetDependencyTargetName(randomPortExplicitUri));
+        }
+    }
+}

--- a/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
@@ -23,6 +23,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     {
         #region Fields
         private const string TestUrl = "http://www.microsoft.com/";
+        private const string TestUrlNonStandardPort = "http://www.microsoft.com:911/";
         private const int TimeAccuracyMilliseconds = 50;
         private int sleepTimeMsecBetweenBeginAndEnd = 100;       
         private TelemetryConfiguration configuration;
@@ -205,6 +206,19 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             var actual = this.sendItems[0] as DependencyTelemetry;
 
             Assert.IsFalse(actual.Success.Value);
+        }
+
+        [TestMethod]
+        public void HttpProcessorSetsTargetForNonStandardPort()
+        {
+            Uri testUrl = new Uri(TestUrlNonStandardPort);
+            this.httpProcessingFramework.OnBeginHttpCallback(100, TestUrlNonStandardPort);
+            this.httpProcessingFramework.OnEndHttpCallback(100, null, false, 500);
+
+            Assert.AreEqual(1, this.sendItems.Count, "Exactly one telemetry item should be sent");
+            DependencyTelemetry receivedItem = (DependencyTelemetry)this.sendItems[0];
+            string expectedTarget = testUrl.Host + ":" + testUrl.Port;
+            Assert.AreEqual(expectedTarget, receivedItem.Target, "HttpProcessingFramework returned incorrect target for non standard port.");
         }
 
         #endregion //BeginEndCallBacks

--- a/Src/DependencyCollector/Shared/DependencyCollector.Shared.projitems
+++ b/Src/DependencyCollector/Shared/DependencyCollector.Shared.projitems
@@ -14,6 +14,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)HttpDependenciesParsingTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ClientServerDependencyTracker.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\DependencyTargetNameHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerSqlConnectionProcessing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerSqlCommandProcessing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WebRequestDependencyTrackingHelpers.cs" />

--- a/Src/DependencyCollector/Shared/Implementation/DependencyTargetNameHelper.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyTargetNameHelper.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
-    using System;   
+    using System;
+    using System.Globalization;
 
     /// <summary>
     /// Dependency TargetName helper.
@@ -14,18 +15,18 @@
         /// Returns dependency target name from the given Uri.
         /// Port name is included in target for non-standard ports.
         /// </summary>
-        /// <param name="uri">Dependency url from which target is to be extracted.</param>        
+        /// <param name="uri">Dependency uri from which target is to be extracted.</param>        
         /// <returns>Dependency target name.</returns>
         internal static string GetDependencyTargetName(Uri uri)
         {
             if (uri.Port != HttpPort && uri.Port != HttpsPort)
             {
-                return uri.Host + ":" + uri.Port;
+                return string.Format(CultureInfo.InvariantCulture, "{0}:{1}", uri.Host, uri.Port);
             }
             else
             {
                 return uri.Host;
             }
         }      
-    }
+    } 
 }

--- a/Src/DependencyCollector/Shared/Implementation/DependencyTargetNameHelper.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyTargetNameHelper.cs
@@ -1,0 +1,31 @@
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;   
+
+    /// <summary>
+    /// Dependency TargetName helper.
+    /// </summary>
+    internal static class DependencyTargetNameHelper
+    {
+        private const int HttpPort = 80;
+        private const int HttpsPort = 443;
+
+        /// <summary>
+        /// Returns dependency target name from the given Uri.
+        /// Port name is included in target for non-standard ports.
+        /// </summary>
+        /// <param name="uri">Dependency url from which target is to be extracted.</param>        
+        /// <returns>Dependency target name.</returns>
+        internal static string GetDependencyTargetName(Uri uri)
+        {
+            if (uri.Port != HttpPort && uri.Port != HttpsPort)
+            {
+                return uri.Host + ":" + uri.Port;
+            }
+            else
+            {
+                return uri.Host;
+            }
+        }      
+    }
+}

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -88,7 +88,7 @@
 
                 telemetry.Type = RemoteDependencyConstants.HTTP;
                 telemetry.Name = url.AbsolutePath;
-                telemetry.Target = url.Host;
+                telemetry.Target = DependencyTargetNameHelper.GetDependencyTargetName(url);
                 telemetry.Data = url.OriginalString;
 
                 this.TelemetryTable.Store(id, new Tuple<DependencyTelemetry, bool>(telemetry, isCustomCreated));

--- a/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
@@ -268,7 +268,7 @@
                 var telemetry = ClientServerDependencyTracker.BeginTracking(this.telemetryClient);
 
                 telemetry.Name = resourceName;
-                telemetry.Target = url.Host;
+                telemetry.Target = DependencyTargetNameHelper.GetDependencyTargetName(url);
                 telemetry.Type = RemoteDependencyConstants.HTTP;
                 telemetry.Data = url.OriginalString;
 


### PR DESCRIPTION
Fix:
https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/285