### PR TITLE
Renaming AI dependency from "Application Insights" to "Http (tracked component)"

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/RemoteDependencyConstants.cs
+++ b/Src/DependencyCollector/Shared/Implementation/RemoteDependencyConstants.cs
@@ -4,7 +4,7 @@
     {
         public const string SQL = "SQL";
         public const string HTTP = "Http";
-        public const string AI = "Application Insights";
+        public const string AI = "Http (tracked component)";
 
         public const string AzureBlob = "Azure blob";
         public const string AzureTable = "Azure table";


### PR DESCRIPTION
Issue: https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/323