### PR TITLE
AppDomainName fix for tests

### DIFF
--- a/Test/Web/FunctionalTests/FunctionalTests/Helpers/EtwEventSession.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/Helpers/EtwEventSession.cs
@@ -102,7 +102,7 @@
                 if ((id > 0) && (id < 65534))
                 {
                     string domainName = data.PayloadString(data.PayloadNames.Length - 1);
-                    result = domainName.StartsWith("/LM/W3SVC") || domainName.StartsWith("ConsoleApp");
+                    result = domainName.StartsWith("/LM/W3SVC") || domainName.StartsWith("ConsoleApp") || domainName.StartsWith("AppInsightsDomain");
                 }
             }
             else


### PR DESCRIPTION
There is [a place in our code](https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/Src/WindowsServer/WindowsServer.Shared/Implementation/AzureRoleEnvironmentContextReader.cs#L72) where we create new AppDomain.

This AppDomain is unaccounted for in our Functional Tests.
Recently these tests failed when they detected Trace Message from the unknown domain.
We have no direct proof that this particular AppDomain is the root cause but it makes sense to add it into this test anyway.