### PR TITLE
Fixes to unit tests:

### DIFF
--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -174,6 +174,8 @@
         [TestMethod]
         public void OnEndTracksRequest()
         {
+            var context = HttpModuleHelper.GetFakeHttpContext();
+
             var sendItems = new List<ITelemetry>();
             var stubTelemetryChannel = new StubTelemetryChannel { OnSend = item => sendItems.Add(item) };
             var configuration = new TelemetryConfiguration
@@ -184,8 +186,8 @@
 
             var module = this.RequestTrackingTelemetryModuleFactory();
             module.Initialize(configuration);
-            module.OnBeginRequest(null);
-            module.OnEndRequest(null);
+            module.OnBeginRequest(context);
+            module.OnEndRequest(context);
 
             Assert.Equal(1, sendItems.Count);
         }
@@ -386,7 +388,7 @@
 
         private RequestTrackingTelemetryModule RequestTrackingTelemetryModuleFactory()
         {
-            var module = this.RequestTrackingTelemetryModuleFactory();
+            var module = new RequestTrackingTelemetryModule();
             module.OverrideCorrelationIdLookupHelper(this.correlationIdLookupHelper);
 
             return module;


### PR DESCRIPTION
1. Removes a infinite regressions caused by a replace all.
2. I saw a test that was not decorated by [TestMethod] attribute from the very begning of this codebase. Realized that someone might have accidentally missed putting the attribute - so I added it in one of my earlier check-ins. Turns out since the code has changed a lot since the test was first written - it needed to be updated to work.