### PR TITLE
Fix functional tests

### DIFF
--- a/Test/Web/FunctionalTests/FunctionalTests/Functional.csproj
+++ b/Test/Web/FunctionalTests/FunctionalTests/Functional.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))\Global.props" />
@@ -71,6 +71,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DiagnosticsTest.cs" />
+    <Compile Include="Helpers\AppIdRequestHttpListener.cs" />
+    <Compile Include="Helpers\AppIdResult.cs" />
     <Compile Include="Helpers\Debugger\IOleMessageFilter.cs" />
     <Compile Include="Helpers\Debugger\MessageFilter.cs" />
     <Compile Include="Helpers\Debugger\ProcessBasicInformation.cs" />
@@ -83,9 +85,10 @@
     <Compile Include="Helpers\Debugger\StartupInfo.cs" />
     <Compile Include="Helpers\Debugger\VsDebugger.cs" />
     <Compile Include="Helpers\EtwEventSession.cs" />
+    <Compile Include="Helpers\TelemetryHttpListenerObservable.cs" />
     <Compile Include="TestBase\ExceptionStatisticsTestBase.cs" />
     <Compile Include="Helpers\Extensions.cs" />
-    <Compile Include="Helpers\HttpListenerObservable.cs" />
+    <Compile Include="Helpers\HttpListenerObservableBase.cs" />
     <Compile Include="TestBase\ExceptionTelemetryTestBase.cs" />
     <Compile Include="TestBase\RequestTelemetryTestBase.cs" />
     <Compile Include="TestBase\SingleWebHostTestBase.cs" />

--- a/Test/Web/FunctionalTests/FunctionalTests/Helpers/AppIdRequestHttpListener.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/Helpers/AppIdRequestHttpListener.cs
@@ -1,0 +1,29 @@
+﻿namespace Functional.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class AppIdRequestHttpListener : HttpListenerObservableBase<AppIdResult>
+    {
+        public AppIdRequestHttpListener(string url) : base(url)
+        {
+        }
+
+        protected override IEnumerable<AppIdResult> CreateNewItemsFromContext(HttpListenerContext context)
+        {
+            try
+            {
+                // We expect a get app id context request here. Let's return a random guid as an appId.
+                return new[] { new AppIdResult { AppId = Guid.NewGuid().ToString() } };
+            }
+            finally
+            {
+                context.Response.Close();
+            }
+        }
+    }
+}

--- a/Test/Web/FunctionalTests/FunctionalTests/Helpers/AppIdResult.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/Helpers/AppIdResult.cs
@@ -1,0 +1,13 @@
+﻿namespace Functional.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class AppIdResult
+    {
+        public string AppId { get; set; }
+    }
+}

--- a/Test/Web/FunctionalTests/FunctionalTests/Helpers/HttpListenerObservableBase.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/Helpers/HttpListenerObservableBase.cs
@@ -1,0 +1,87 @@
+﻿namespace Functional.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Reactive.Linq;
+    using System.Reactive.Threading.Tasks;
+    using System.Threading.Tasks;
+
+    public abstract class HttpListenerObservableBase<T> : IObservable<T>, IDisposable
+    {
+        private readonly HttpListener listener;
+        private IObservable<T> stream;
+
+        public HttpListenerObservableBase(string url)
+        {
+            this.listener = new HttpListener();
+            this.listener.Prefixes.Add(url);
+        }
+
+        public void Start()
+        {
+            OnStart();
+            if (this.stream != null)
+            {
+                this.Stop();
+            }
+
+            if (!this.listener.IsListening)
+            {
+                this.listener.Start();
+            }
+
+            this.stream = this.CreateStream();
+        }
+
+        protected virtual void OnStart()
+        { }
+
+        public void Stop()
+        {
+            this.Dispose();
+        }
+
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (this.stream == null)
+            {
+                throw new InvalidOperationException("Call HttpListenerObservable.Start before subscribing to the stream");
+            }
+
+            return this.stream
+                .Subscribe(observer);
+        }
+
+        public void Dispose()
+        {
+            if (listener != null && listener.IsListening)
+            {
+                listener.Stop();
+                listener.Close();
+                this.stream = null;
+            }
+        }
+
+        private IObservable<T> CreateStream()
+        {
+            return Observable
+                .Create<T>
+                (obs =>
+                    Task.Factory.FromAsync(
+                        (a, c) => this.listener.BeginGetContext(a, c),
+                        ar => this.listener.EndGetContext(ar),
+                        null)
+                        .ToObservable()
+                        .SelectMany(this.CreateNewItemsFromContext)
+                        .Subscribe(obs)
+                )
+              .Repeat()
+              .Publish()
+              .RefCount();
+        }
+
+        protected abstract IEnumerable<T> CreateNewItemsFromContext(HttpListenerContext context);
+    }
+}

--- a/Test/Web/FunctionalTests/FunctionalTests/Helpers/SingleWebHostTestConfiguration.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/Helpers/SingleWebHostTestConfiguration.cs
@@ -50,6 +50,11 @@ namespace Functional.Helpers
             get { return string.Format(LocalhostUriTemplate, TelemetryListenerPort) + "/v2/track/"; }
         }
 
+        public string AppIdListenerUri
+        {
+            get { return string.Format(LocalhostUriTemplate, TelemetryListenerPort) + "/api/profiles/"; }
+        }
+
         public string IKey { get; set; }
     }
 }

--- a/Test/Web/FunctionalTests/FunctionalTests/Serialization/TelemetryExtensions.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/Serialization/TelemetryExtensions.cs
@@ -10,13 +10,14 @@ namespace Functional.Helpers
     using System.IO;
     using System.Linq;
     using System.Reactive.Linq;
-    
+
     using AI;
+    using System.Diagnostics;
 
     public static class TelemetryExtensions
     {
         public static Envelope[] ReceiveItems(
-            this HttpListenerObservable listener,
+            this TelemetryHttpListenerObservable listener,
             int count,
             int timeOut)
         {
@@ -41,7 +42,7 @@ namespace Functional.Helpers
         }
 
         public static T[] ReceiveItemsOfType<T>(
-            this HttpListenerObservable listener,
+            this TelemetryHttpListenerObservable listener,
             int count,
             int timeOut)
         {
@@ -62,7 +63,7 @@ namespace Functional.Helpers
         }
 
         public static Envelope[] ReceiveItemsOfTypes<T1, T2>(
-            this HttpListenerObservable listener,
+            this TelemetryHttpListenerObservable listener,
             int count,
             int timeOut)
         {
@@ -82,7 +83,7 @@ namespace Functional.Helpers
         }
 
         public static Envelope[] ReceiveAllItemsDuringTime(
-            this HttpListenerObservable listener,
+            this TelemetryHttpListenerObservable listener,
             int timeOut)
         {
             if (null == listener)
@@ -98,7 +99,7 @@ namespace Functional.Helpers
         }
 
         public static T[] ReceiveAllItemsDuringTimeOfType<T>(
-            this HttpListenerObservable listener,
+            this TelemetryHttpListenerObservable listener,
             int timeOut)
         {
             if (null == listener)
@@ -115,7 +116,7 @@ namespace Functional.Helpers
         }
 
         public static Envelope[] ReceiveAllItemsDuringTimeOfType<T1, T2>(
-            this HttpListenerObservable listener,
+            this TelemetryHttpListenerObservable listener,
             int timeOut)
         {
             if (null == listener)

--- a/Test/Web/FunctionalTests/FunctionalTests/TestBase/SingleWebHostTestBase.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/TestBase/SingleWebHostTestBase.cs
@@ -25,7 +25,9 @@ namespace Functional.Helpers
 
         protected HttpClient HttpClient { get; private set; }
 
-        protected HttpListenerObservable Listener { get; private set; }
+        protected TelemetryHttpListenerObservable Listener { get; private set; }
+
+        protected AppIdRequestHttpListener AppIdRequestListener { get; private set; }
 
         protected SingleWebHostTestConfiguration Config { get; private set; }
 
@@ -50,8 +52,11 @@ namespace Functional.Helpers
                 BaseAddress = new Uri(configuration.ApplicationUri)
             };
 
-            this.Listener = new HttpListenerObservable(configuration.TelemetryListenerUri);
+            this.Listener = new TelemetryHttpListenerObservable(configuration.TelemetryListenerUri);
             this.Listener.Start();
+
+            this.AppIdRequestListener = new AppIdRequestHttpListener(configuration.AppIdListenerUri);
+            this.AppIdRequestListener.Start();
 
             this.EtwSession = new EtwEventSession();
             this.EtwSession.Start();
@@ -60,8 +65,10 @@ namespace Functional.Helpers
         protected void StopWebAppHost(bool treatTraceErrorsAsFailures = true)
         {
             this.Listener.Stop();
+            this.AppIdRequestListener.Stop();
             this.Server.Stop();
             this.HttpClient.Dispose();
+            this.AppIdRequestListener.Dispose();
 
             if (treatTraceErrorsAsFailures && this.EtwSession.FailureDetected || this.Listener.FailureDetected)
             {

--- a/Test/Web/FunctionalTests/FunctionalTests/TestsUnhandledExceptionsFW40.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/TestsUnhandledExceptionsFW40.cs
@@ -16,7 +16,7 @@
 
         private const int TestListenerTimeoutInMs = 30000;
 
-        protected HttpListenerObservable Listener { get; private set; }
+        protected TelemetryHttpListenerObservable Listener { get; private set; }
 
         protected EtwEventSession EtwSession { get; private set; }
 
@@ -31,7 +31,7 @@
 
             Trace.WriteLine("Application directory:" + this.applicationDirectory);
 
-            this.Listener = new HttpListenerObservable("http://localhost:4002/v2/track/");
+            this.Listener = new TelemetryHttpListenerObservable("http://localhost:4002/v2/track/");
             this.Listener.Start();
 
             this.EtwSession = new EtwEventSession();


### PR DESCRIPTION
We recently made a product change where cross component correlation code depends on an endpoint provided by breeze to return appId.

This change add a new listener for that appId endpoint, so that the tests don't fail when they can't reach that endpoint.