### PR TITLE
[WIP] Dependency correlation part1: Mimic correlation protocol

### DIFF
--- a/Src/Common/AppInsightsActivity.cs
+++ b/Src/Common/AppInsightsActivity.cs
@@ -1,0 +1,64 @@
+﻿namespace Microsoft.ApplicationInsights.Common
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+
+    //this is a temporary solution that mimics System.DiagnosticSource,Activity and Correlation HTTP protocol:
+    //https://github.com/lmolkova/correlation/blob/master/http_protocol_proposal_v1.md
+    //It does not implement 
+    // - Request-Id length limitation and overflow
+    internal class AppInsightsActivity
+    {
+        internal static string GetRootId(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(requestId));
+            if (requestId[0] == '|')
+            {
+                var rootEnd = requestId.IndexOf('.');
+                var rootId = requestId.Substring(1, rootEnd - 1);
+                return rootId;
+            }
+            return requestId;
+        }
+
+
+        internal static string GenerateNewId()
+        {
+            if (_machinePrefix == null)
+                Interlocked.CompareExchange(ref _machinePrefix, Environment.MachineName + "-" + ((int)Stopwatch.GetTimestamp()).ToString("x"), null);
+            return '|' + _machinePrefix + '-' + Interlocked.Increment(ref _currentOperationNum).ToString("x") + '.';
+        }
+
+        internal static string GenerateRequestId(string parentRequestId, string telemetryId)
+        {
+            if (parentRequestId != null)
+            {
+                var childRequestId = parentRequestId[0] != '|' ? '|' + parentRequestId : parentRequestId;
+                if (childRequestId[childRequestId.Length - 1] != '.')
+                    childRequestId += '.';
+
+                return GenerateChildTelemetryId(childRequestId, telemetryId, '_');
+            }
+            return GenerateNewId();
+        }
+
+        internal static string GenerateDependencyId(string parentRequestId, string telemetryId)
+        {
+            if (parentRequestId != null)
+                return GenerateChildTelemetryId(parentRequestId, telemetryId, '.');
+
+            return GenerateNewId();
+        }
+
+        private static string _machinePrefix;
+        private static long _currentOperationNum = BitConverter.ToUInt32(Guid.NewGuid().ToByteArray(), 12);
+
+        private static string GenerateChildTelemetryId(string parentId, string telemetryId, char delimiter)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(parentId));
+            Debug.Assert(!string.IsNullOrEmpty(telemetryId));
+            return parentId + telemetryId + delimiter;
+        }
+    }
+}

--- a/Src/Common/Common.projitems
+++ b/Src/Common/Common.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CrossComponentCorrelationEventSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AppInsightsActivity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RequestResponseHeaders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CorrelationIdLookupHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WebHeaderCollectionExtensions.cs" />

--- a/Src/Common/RequestResponseHeaders.cs
+++ b/Src/Common/RequestResponseHeaders.cs
@@ -21,13 +21,23 @@
         public const string RequestContextTargetKey = "appId"; // Although the name of Source and Target key is the same - appId. Conceptually they are different and hence, we intentionally have two constants here. Makes for better reading of the code.
 
         /// <summary>
-        /// Standard parent Id header.
+        /// Legacy parent Id header.
         /// </summary>
         public const string StandardParentIdHeader = "x-ms-request-id";
 
         /// <summary>
-        /// Standard root id header.
+        /// Legacy root id header.
         /// </summary>
         public const string StandardRootIdHeader = "x-ms-request-root-id";
+
+        /// <summary>
+        /// Standard Request-Id Id header.
+        /// </summary>
+        public const string RequestIdHeader = "Request-Id";
+
+        /// <summary>
+        /// Standard Correlation-Context header
+        /// </summary>
+        public const string CorrelationContextHeader = "Correlation-Context";
     }
 }

--- a/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
@@ -2,8 +2,10 @@
 {
     using System;
     using System.Data.SqlClient;
+    using System.Diagnostics;
     using System.Net;
     using Microsoft.ApplicationInsights.DataContracts;
+    using Common;
 
     internal static class ClientServerDependencyTracker
     {
@@ -21,6 +23,11 @@
             var telemetry = new DependencyTelemetry();
             telemetry.Start();
             telemetryClient.Initialize(telemetry);
+
+            //TODO: move Id generation to Base SDK
+            telemetry.Id = AppInsightsActivity.GenerateDependencyId(telemetry.Context.Operation.ParentId, telemetry.Id);
+
+            Debug.WriteLine($"dependency id {telemetry.Id} parent { telemetry.Context.Operation.ParentId}, root {telemetry.Context.Operation.Id}");
             PretendProfilerIsAttached = false;
             return telemetry;
         }

--- a/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
@@ -278,7 +278,6 @@
                 bool isCustomCreated = false;
 
                 var telemetry = ClientServerDependencyTracker.BeginTracking(this.telemetryClient);
-
                 telemetry.Name = resourceName;
                 telemetry.Target = DependencyTargetNameHelper.GetDependencyTargetName(url);
                 telemetry.Type = RemoteDependencyConstants.HTTP;
@@ -323,9 +322,12 @@
 
                     // Add the parent ID
                     var parentId = telemetry.Id;
-                    if (!string.IsNullOrEmpty(parentId) && webRequest.Headers[RequestResponseHeaders.StandardParentIdHeader] == null)
+                    if (!string.IsNullOrEmpty(parentId))
                     {
-                        webRequest.Headers.Add(RequestResponseHeaders.StandardParentIdHeader, parentId);
+                        if (webRequest.Headers[RequestResponseHeaders.StandardParentIdHeader] == null)
+                            webRequest.Headers.Add(RequestResponseHeaders.StandardParentIdHeader, parentId);
+                        if (webRequest.Headers[RequestResponseHeaders.RequestIdHeader] == null)
+                            webRequest.Headers.Add(RequestResponseHeaders.RequestIdHeader, telemetry.Id);
                     }
                 }
             }

--- a/Src/Web/Web.Shared.Net.Tests/AccountIdTelemetryInitializerTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/AccountIdTelemetryInitializerTests.cs
@@ -33,7 +33,7 @@
             // Arrange
             var eventTelemetry = new EventTelemetry("name");
             var source = new TestableAccountIdTelemetryInitializer();
-            RequestTelemetry requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
+            RequestTelemetry requestTelemetry = source.Telemetry;
             requestTelemetry.Context.User.AccountId = "1";
             
             // Act
@@ -49,7 +49,7 @@
             // Arrange
             var eventTelemetry = new EventTelemetry("name");
             var source = new TestableAccountIdTelemetryInitializer();
-            RequestTelemetry requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
+            RequestTelemetry requestTelemetry = source.Telemetry;
             requestTelemetry.Context.User.AccountId = "1";
             eventTelemetry.Context.User.AccountId = "2";
 
@@ -153,10 +153,21 @@
         private class TestableAccountIdTelemetryInitializer : AccountIdTelemetryInitializer
         {
             private readonly HttpContext fakeContext = HttpModuleHelper.GetFakeHttpContext();
+            private readonly RequestTelemetry telemetry;
+
+            public TestableAccountIdTelemetryInitializer()
+            {
+                telemetry = fakeContext.SetOperationHolder().Telemetry;
+            }
 
             public HttpContext FakeContext
             {
                 get { return this.fakeContext; }
+            }
+
+            public RequestTelemetry Telemetry
+            {
+                get { return this.telemetry; }
             }
 
             protected override HttpContext ResolvePlatformContext()

--- a/Src/Web/Web.Shared.Net.Tests/AuthenticatedUserIdTelemetryInitializerTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/AuthenticatedUserIdTelemetryInitializerTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace Microsoft.ApplicationInsights.Web
 {
-    using System;
-    using System.Globalization;
     using System.Web;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Web.Helpers;
@@ -33,7 +31,7 @@
             // Arrange
             var eventTelemetry = new EventTelemetry("name");
             var source = new TestableAuthenticatedUserIdTelemetryInitializer();
-            RequestTelemetry requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
+            RequestTelemetry requestTelemetry = source.Telemetry;
             requestTelemetry.Context.User.AuthenticatedUserId = "1";
 
             // Act
@@ -49,7 +47,7 @@
             // Arrange
             var eventTelemetry = new EventTelemetry("name");
             var source = new TestableAuthenticatedUserIdTelemetryInitializer();
-            RequestTelemetry requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
+            RequestTelemetry requestTelemetry = source.Telemetry;
             requestTelemetry.Context.User.AuthenticatedUserId = "1";
             eventTelemetry.Context.User.AuthenticatedUserId = "2";
 
@@ -153,10 +151,21 @@
         private class TestableAuthenticatedUserIdTelemetryInitializer : AuthenticatedUserIdTelemetryInitializer
         {
             private readonly HttpContext fakeContext = HttpModuleHelper.GetFakeHttpContext();
+            private readonly RequestTelemetry telemetry;
+
+            public TestableAuthenticatedUserIdTelemetryInitializer()
+            {
+                telemetry = fakeContext.SetOperationHolder().Telemetry;
+            }
 
             public HttpContext FakeContext
             {
                 get { return this.fakeContext; }
+            }
+
+            public RequestTelemetry Telemetry
+            {
+                get { return this.telemetry; }
             }
 
             protected override HttpContext ResolvePlatformContext()

--- a/Src/Web/Web.Shared.Net.Tests/ClientIpHeaderTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/ClientIpHeaderTelemetryModuleTest.cs
@@ -69,7 +69,7 @@
         public void InitializeSetsLocationIpOfRequestToUserHostAddressIfNoHeadersInRequest()
         {
             var module = new TestableClientIpHeaderTelemetryInitializer();
-            var requestTelemetry = module.PlatformContext.CreateRequestTelemetryPrivate();
+            var requestTelemetry = module.Telemetry;
             
             module.Initialize(new EventTelemetry());
 
@@ -93,7 +93,7 @@
         {
             var dictionary = new Dictionary<string, string> { { "X-Forwarded-For", "1.2.3.4" } };
             var module = new TestableClientIpHeaderTelemetryInitializer(dictionary);
-            var requestTelemetry = module.PlatformContext.CreateRequestTelemetryPrivate();
+            var requestTelemetry = module.Telemetry;
             
             module.Initialize(new TraceTelemetry("trace"));
 
@@ -128,7 +128,7 @@
         {
             var dictionary = new Dictionary<string, string> { { "X-Forwarded-For", "bad" } };
             var module = new TestableClientIpHeaderTelemetryInitializer(dictionary);
-            var telemetry = new RequestTelemetry();
+            var telemetry = module.Telemetry;
 
             module.Initialize(telemetry);
 
@@ -140,6 +140,7 @@
         {
             var dictionary = new Dictionary<string, string> { { "X-Forwarded-For", "1.2.3.4, 2.3.4.5,3.4.5.6" } };
             var module = new TestableClientIpHeaderTelemetryInitializer(dictionary);
+
             var telemetry = new EventTelemetry();
 
             module.Initialize(telemetry);
@@ -152,6 +153,7 @@
         {
             var dictionary = new Dictionary<string, string> { { "X-Forwarded-For", "1.2.3.4, 2.3.4.5" } };
             var module = new TestableClientIpHeaderTelemetryInitializer(dictionary) { UseFirstIp = false };
+
             var telemetry = new ExceptionTelemetry();
 
             module.Initialize(telemetry);
@@ -170,6 +172,7 @@
             var module = new TestableClientIpHeaderTelemetryInitializer(dictionary);
             module.HeaderNames.Clear();
             module.HeaderNames.Add("CustomHeader");
+
             var telemetry = new EventTelemetry();
 
             module.Initialize(telemetry);
@@ -188,6 +191,7 @@
             var module = new TestableClientIpHeaderTelemetryInitializer(dictionary);
             module.HeaderNames.Add("CustomHeader1");
             module.HeaderNames.Add("CustomHeader2");
+
             var telemetry = new PageViewTelemetry();
 
             module.Initialize(telemetry);
@@ -203,7 +207,7 @@
                 { "X-Forwarded-For", "1.2.3.4;2.3.4.5,3.4.5.6" },
             };
             var module = new TestableClientIpHeaderTelemetryInitializer(dictionary) { HeaderValueSeparators = ",;" };
-            var telemetry = new RequestTelemetry();
+            var telemetry = module.Telemetry;
 
             module.Initialize(telemetry);
 
@@ -221,6 +225,7 @@
             var module = new TestableClientIpHeaderTelemetryInitializer(dictionary);
             module.HeaderNames.Add("CustomHeader1");
             module.HeaderNames.Add("CustomHeader2");
+
             var telemetry = new TraceTelemetry("trace");
 
             module.Initialize(telemetry);
@@ -231,15 +236,21 @@
         private class TestableClientIpHeaderTelemetryInitializer : ClientIpHeaderTelemetryInitializer
         {
             private readonly HttpContext platformContext;
+            private readonly RequestTelemetry telemetry;
 
             public TestableClientIpHeaderTelemetryInitializer(IDictionary<string, string> headers = null)
             {
                 this.platformContext = HttpModuleHelper.GetFakeHttpContext(headers);
+                telemetry = PlatformContext.SetOperationHolder().Telemetry;
             }
 
             public HttpContext PlatformContext
             {
                 get { return this.platformContext; }
+            }
+            public RequestTelemetry Telemetry
+            {
+                get { return this.telemetry; }
             }
 
             protected override HttpContext ResolvePlatformContext()

--- a/Src/Web/Web.Shared.Net.Tests/Helpers/HttpContextTestExtensions.cs
+++ b/Src/Web/Web.Shared.Net.Tests/Helpers/HttpContextTestExtensions.cs
@@ -2,19 +2,26 @@
 {
     using System.Web;
     using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Web.Implementation;
 
     internal static class HttpContextTestExtensions
     {
         internal static RequestTelemetry WithAuthCookie(this HttpContext context, string cookieString)
         {
-            var requestTelemetry = new RequestTelemetry();
             context.AddRequestCookie(
                 new HttpCookie(
                     RequestTrackingConstants.WebAuthenticatedUserCookieName,
-                                                    HttpUtility.UrlEncode(cookieString)))
-                   .AddRequestTelemetry(requestTelemetry);
-            return requestTelemetry;
+                                                    HttpUtility.UrlEncode(cookieString)));
+            return context.GetOperation().Telemetry;
+        }
+
+        internal static IOperationHolder<RequestTelemetry> SetOperationHolder(this HttpContext context, RequestTelemetry requestTelemetry = null)
+        {
+            var operationHolder = new TestOperationHolder(requestTelemetry ?? new RequestTelemetry());
+            
+            context.Items.Add(RequestTrackingConstants.RequestTelemetryItemName, operationHolder);
+            return operationHolder;
         }
     }
 }

--- a/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
+++ b/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
@@ -86,11 +86,11 @@
             return httpContext;
         }
 
-        public static HttpContext AddRequestTelemetry(this HttpContext context, RequestTelemetry requestTelemetry)
+        /*public static HttpContext AddRequestTelemetry(this HttpContext context, RequestTelemetry requestTelemetry)
         {
-            context.Items["Microsoft.ApplicationInsights.RequestTelemetry"] = requestTelemetry;
+            context.Items["Microsoft.ApplicationInsights.RequestTelemetry"] = new TestOperationHolder(requestTelemetry);
             return context;
-        }
+        }*/
 
         public static HttpContext AddRequestCookie(this HttpContext context, HttpCookie cookie)
         {

--- a/Src/Web/Web.Shared.Net.Tests/HttpContextExtensionTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/HttpContextExtensionTest.cs
@@ -25,11 +25,9 @@
         [TestMethod]
         public void GetRequestTelemetryReturnsRequestTelemetryFromItems()
         {
-            var expected = new RequestTelemetry();
-
             var context = HttpModuleHelper.GetFakeHttpContext();
-            context.Items.Add(RequestTrackingConstants.RequestTelemetryItemName, expected);
-            
+            var expected = context.SetOperationHolder().Telemetry;
+         
             var actual = context.GetRequestTelemetry();
 
             Assert.AreSame(expected, actual);

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -35,7 +35,7 @@
             var startTime = DateTimeOffset.UtcNow;
 
             var context = HttpModuleHelper.GetFakeHttpContext();
-            var requestTelemetry = context.CreateRequestTelemetryPrivate();
+            var requestTelemetry = context.SetOperationHolder().Telemetry;
             requestTelemetry.Timestamp = startTime;
 
             var module = this.RequestTrackingTelemetryModuleFactory();
@@ -49,7 +49,7 @@
         public void OnBeginRequestSetsTimeIfItWasNotAssignedBefore()
         {
             var context = HttpModuleHelper.GetFakeHttpContext();
-            var requestTelemetry = context.CreateRequestTelemetryPrivate();
+            var requestTelemetry = context.SetOperationHolder().Telemetry;
             requestTelemetry.Timestamp = default(DateTimeOffset);
 
             var module = this.RequestTrackingTelemetryModuleFactory();
@@ -63,7 +63,7 @@
         public void RequestIdIsAvailableAfterOnBegin()
         {
             var context = HttpModuleHelper.GetFakeHttpContext();
-            var requestTelemetry = context.CreateRequestTelemetryPrivate();
+            var requestTelemetry = context.SetOperationHolder().Telemetry;
 
             var module = this.RequestTrackingTelemetryModuleFactory();
 
@@ -102,7 +102,7 @@
         public void OnEndSetsDurationToZeroIfBeginWasNotCalled()
         {
             var context = HttpModuleHelper.GetFakeHttpContext();
-
+            context.SetOperationHolder();
             var module = this.RequestTrackingTelemetryModuleFactory();
             module.Initialize(TelemetryConfiguration.CreateDefault());
             module.OnEndRequest(context);
@@ -114,6 +114,7 @@
         public void OnEndDoesNotOverrideResponseCode()
         {
             var context = HttpModuleHelper.GetFakeHttpContext();
+            context.SetOperationHolder();
             context.Response.StatusCode = 300;
 
             var module = this.RequestTrackingTelemetryModuleFactory();
@@ -199,7 +200,7 @@
             context.Response.StatusCode = 200;
             context.Handler = new System.Web.Handlers.AssemblyResourceLoader();
 
-            var requestTelemetry = context.CreateRequestTelemetryPrivate();
+            var requestTelemetry = context.SetOperationHolder().Telemetry;
             requestTelemetry.Start();
 
             var module = this.RequestTrackingTelemetryModuleFactory();
@@ -217,7 +218,7 @@
             context.Response.StatusCode = 200;
             context.Handler = new FakeHttpHandler();
 
-            var requestTelemetry = context.CreateRequestTelemetryPrivate();
+            var requestTelemetry = context.SetOperationHolder().Telemetry;
             requestTelemetry.Start();
 
             var module = this.RequestTrackingTelemetryModuleFactory();
@@ -234,7 +235,7 @@
             context.Response.StatusCode = 200;
             context.Handler = new FakeHttpHandler();
 
-            var requestTelemetry = context.CreateRequestTelemetryPrivate();
+            var requestTelemetry = context.SetOperationHolder().Telemetry;
             requestTelemetry.Start();
 
             var module = this.RequestTrackingTelemetryModuleFactory();
@@ -252,7 +253,7 @@
             context.Response.StatusCode = 500;
             context.Handler = new System.Web.Handlers.AssemblyResourceLoader();
 
-            var requestTelemetry = context.CreateRequestTelemetryPrivate();
+            var requestTelemetry = context.SetOperationHolder().Telemetry;
             requestTelemetry.Start();
 
             var module = this.RequestTrackingTelemetryModuleFactory();

--- a/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
@@ -99,7 +99,6 @@
                 {
                     { "User-Agent", userAgent }
                 });
-
             source.Filters = this.botSubstrings;
 
             source.Initialize(eventTelemetry);
@@ -111,9 +110,15 @@
         {
             private readonly HttpContext fakeContext;
 
+            public HttpContext FakeContext
+            {
+                get { return this.fakeContext; }
+            }
+
             public TestableSyntheticUserAgentTelemetryInitializer(IDictionary<string, string> headers = null)
             {
                 this.fakeContext = HttpModuleHelper.GetFakeHttpContext(headers);
+                fakeContext.SetOperationHolder();
             }
 
             protected override HttpContext ResolvePlatformContext()

--- a/Src/Web/Web.Shared.Net.Tests/UserTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/UserTelemetryInitializerTest.cs
@@ -23,7 +23,7 @@
         {
             var eventTelemetry = new EventTelemetry("name");
             var source = new TestableUserTelemetryInitializer();
-            var requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
+            var requestTelemetry = source.Telemetry;
 
             requestTelemetry.Context.User.Id = "1";
             source.Initialize(eventTelemetry);
@@ -36,7 +36,7 @@
         {
             var eventTelemetry = new EventTelemetry("name");
             var source = new TestableUserTelemetryInitializer();
-            var requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
+            var requestTelemetry = source.Telemetry;
 
             requestTelemetry.Context.User.Id = "1";
             eventTelemetry.Context.User.Id = "2";
@@ -48,11 +48,9 @@
         [TestMethod]
         public void InitializeReadSessionIdFromSimpleCookie()
         {
-            var requestTelemetry = new RequestTelemetry();
-
             var initializer = new TestableUserTelemetryInitializer();
-            initializer.FakeContext.AddRequestCookie(new HttpCookie("ai_user", "123|" + DateTimeOffset.Now.ToString("O", CultureInfo.InvariantCulture)))
-                .AddRequestTelemetry(requestTelemetry);
+            initializer.FakeContext.AddRequestCookie(new HttpCookie("ai_user", "123|" + DateTimeOffset.Now.ToString("O", CultureInfo.InvariantCulture)));
+            var requestTelemetry = initializer.Telemetry;
 
             var telemetry = new EventTelemetry();
 
@@ -65,11 +63,9 @@
         [TestMethod]
         public void InitializeDoNotReadCookieWithDateOnly()
         {
-            var requestTelemetry = new RequestTelemetry();
-
             var initializer = new TestableUserTelemetryInitializer();
-            initializer.FakeContext.AddRequestCookie(new HttpCookie("ai_user", DateTimeOffset.Now.ToString("O", CultureInfo.InvariantCulture)))
-                .AddRequestTelemetry(requestTelemetry);
+            initializer.FakeContext.AddRequestCookie(new HttpCookie("ai_user", DateTimeOffset.Now.ToString("O", CultureInfo.InvariantCulture)));
+            var requestTelemetry = initializer.Telemetry;
 
             var telemetry = new EventTelemetry();
 
@@ -82,13 +78,12 @@
         [TestMethod]
         public void InitializeReadCookieWithMoreThanTwoParts()
         {
-            var requestTelemetry = new RequestTelemetry();
             var time = DateTimeOffset.Now.ToString("O", CultureInfo.InvariantCulture);
             var cookie = new HttpCookie("ai_user", "1|" + time + "|3");
 
             var initializer = new TestableUserTelemetryInitializer();
-            initializer.FakeContext.AddRequestCookie(cookie)
-                .AddRequestTelemetry(requestTelemetry);
+            initializer.FakeContext.AddRequestCookie(cookie);
+            var requestTelemetry = initializer.Telemetry;
 
             var telemetry = new EventTelemetry();
 
@@ -101,14 +96,12 @@
         [TestMethod]
         public void InitializeDoNotReadCookieWhenTimeIsMalformed()
         {
-            var requestTelemetry = new RequestTelemetry();
             var time = DateTimeOffset.Now.ToString("O", CultureInfo.InvariantCulture);
             var cookie = new HttpCookie("ai_user", "1|NotATime");
 
             var initializer = new TestableUserTelemetryInitializer();
-            initializer.FakeContext.AddRequestCookie(cookie)
-                .AddRequestTelemetry(requestTelemetry);
-
+            initializer.FakeContext.AddRequestCookie(cookie);
+            var requestTelemetry = initializer.Telemetry;
             var telemetry = new EventTelemetry();
 
             initializer.Initialize(telemetry);
@@ -120,11 +113,11 @@
         [TestMethod]
         public void InitializeDoNotReadCookieFromEmptyValue()
         {
-            var requestTelemetry = new RequestTelemetry();
+
 
             var initializer = new TestableUserTelemetryInitializer();
-            initializer.FakeContext.AddRequestCookie(new HttpCookie("ai_user", string.Empty))
-                .AddRequestTelemetry(requestTelemetry);
+            initializer.FakeContext.AddRequestCookie(new HttpCookie("ai_user", string.Empty));
+            var requestTelemetry = initializer.Telemetry;
 
             var telemetry = new EventTelemetry();
 
@@ -137,9 +130,16 @@
         private class TestableUserTelemetryInitializer : UserTelemetryInitializer
         {
             private readonly HttpContext fakeContext = HttpModuleHelper.GetFakeHttpContext();
+            private readonly RequestTelemetry telemetry;
 
             public TestableUserTelemetryInitializer()
             {
+                telemetry = fakeContext.SetOperationHolder().Telemetry;
+            }
+
+            public RequestTelemetry Telemetry
+            {
+                get { return this.telemetry; }
             }
 
             public HttpContext FakeContext

--- a/Src/Web/Web.Shared.Net.Tests/WebTestTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/WebTestTelemetryInitializerTest.cs
@@ -65,7 +65,6 @@
                 {
                     { "synthetictest-runid", "ID" },
                 });
-
             source.Initialize(eventTelemetry);
 
             Assert.IsNull(eventTelemetry.Context.User.Id);
@@ -81,7 +80,6 @@
                 {
                     { "SyntheticTest-Location", "LOCATION" },
                 });
-
             source.Initialize(eventTelemetry);
 
             Assert.IsNull(eventTelemetry.Context.User.Id);
@@ -102,7 +100,6 @@
                     { "SyntheticTest-Location", "LOCATION" },
                     { "synthetictest-runid", "ID" },
                 });
-            
             source.Initialize(eventTelemetry);
 
             Assert.AreEqual("UserId", eventTelemetry.Context.User.Id);
@@ -121,7 +118,6 @@
                     { "SyntheticTest-Location", "LOCATION" },
                     { "synthetictest-runid", "ID" },
                 });
-
             source.Initialize(eventTelemetry);
 
             Assert.AreEqual("SessionId", eventTelemetry.Context.Session.Id);
@@ -137,7 +133,6 @@
                     { "SyntheticTest-Location", "LOCATION" },
                     { "synthetictest-runid", "ID" },
                 });
-
             source.Initialize(eventTelemetry);
 
             Assert.AreEqual("ID", eventTelemetry.Context.Session.Id);
@@ -146,10 +141,14 @@
         private class TestableWebTestTelemetryInitializer : WebTestTelemetryInitializer
         {
             private readonly HttpContext fakeContext;
-
+            public HttpContext FakeContext
+            {
+                get { return this.fakeContext; }
+            }
             public TestableWebTestTelemetryInitializer(IDictionary<string, string> headers = null)
             {
                 this.fakeContext = HttpModuleHelper.GetFakeHttpContext(headers);
+                fakeContext.SetOperationHolder();
             }
 
             protected override HttpContext ResolvePlatformContext()

--- a/Src/Web/Web.Shared.Net.Tests/web.Shared.Net.Tests.projitems
+++ b/Src/Web/Web.Shared.Net.Tests/web.Shared.Net.Tests.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\RequestStatus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\SimpleTelemetryProcessorSpy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\WebTelemetryModuleBaseFake.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\TestOperationHolder.cs" />    
     <Compile Include="$(MSBuildThisFileDirectory)HttpContextExtensionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpRequestExtensionsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\SdkVersionUtilsTest.cs" />

--- a/Src/Web/Web.Shared.Net/ApplicationInsightsHttpModule.cs
+++ b/Src/Web/Web.Shared.Net/ApplicationInsightsHttpModule.cs
@@ -69,6 +69,7 @@
                 {
                     context.BeginRequest += this.OnBeginRequest;
                     context.EndRequest += this.OnEndRequest;
+                    context.PreRequestHandlerExecute += this.OnPreRequestHandlerExecute;
                 }
                 catch (Exception exc)
                 {
@@ -149,6 +150,18 @@
             catch (Exception ex)
             {
                 WebEventSource.Log.HookAddOnSendingHeadersFailedWarning(ex.ToInvariantString());
+            }
+        }
+
+        private void OnPreRequestHandlerExecute(object sender, EventArgs eventArgs)
+        {
+            if (this.isEnabled)
+            {
+                HttpApplication httpApplication = (HttpApplication)sender;
+
+                this.TraceCallback("OnPreRequestHandlerExecute", httpApplication);
+
+                requestModule?.OnPreRequestHandlerExecute(httpApplication.Context);
             }
         }
 

--- a/Src/Web/Web.Shared.Net/HttpContextExtension.cs
+++ b/Src/Web/Web.Shared.Net/HttpContextExtension.cs
@@ -1,4 +1,6 @@
-﻿namespace System.Web
+﻿using Microsoft.ApplicationInsights.Extensibility;
+
+namespace System.Web
 {
     using System.Web;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -21,7 +23,8 @@
                 return null;
             }
 
-            return context.Items[RequestTrackingConstants.RequestTelemetryItemName] as RequestTelemetry;
+            var operation = context.Items[RequestTrackingConstants.RequestTelemetryItemName] as IOperationHolder<RequestTelemetry>;
+            return operation?.Telemetry;
         }
     }
 }


### PR DESCRIPTION
This change improves dependency correlation in AppInsights.Web
1. it aligns AppInsights.Web with [HTTP protocol](https://github.com/lmolkova/correlation/blob/master/http_protocol_proposal_v1.md) that is adopted by System.Net.Http (.NET Core) and currently being implemented in AspNetCore.
2. It uses execution context stored for the operation in Base SDK

This is a **work in progress** and besides feedback and comments you may have for the implementation, we need to have an agreement on following:
1. **Id generation**: it is a part of big feature implemented in .NET: [Activity API](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md). I suggest to change AI base SDK to use Activity where possible (it's available starting from .NET 4.6) and mimic Id generation in older versions. Id becomes hierarchical with guaranteed randomness. Root behavior does not change.
It requires to bring System.Diagnostic.DiagnosticSource to base SDK that may be a problem for users who don't need correlation and use base SDK with powershell. I'll try to address this concern 
2. **Execution context** could be lost between HttpModule.BeginRequest and application code because of ASP.NET native/managed code switches. The solution from ASP.NET team is to use `OnPreRequestHandlerExecute` event to restore from HttpContext.Current any context if it was lost.
However there is no (and should not be) public API to restore CallContext/AsyncLocal set in `StartOperation`. **I suggest add `[InternalsVisisbleTo]` for AppInsgihts.Web to the base SDK lib**. Let me know if you have better suggestions.

Things that are not done yet and will be done
1. Unit/Functional tests for new headers
2. Correlation-Context implementation
3. **AppInsights.Web target and implementation for .NET4.6** ASP.NET classic team will provide their own HttpModule with DiagnosticSource/Activity support and will take care about AsyncLocal flow. AppInsights.Web should use it and do request tracking. The module is being implemented now. 

