### PR TITLE
Tricks around System.Web.Handlers.TransferRequestHandler for WCF and WebServices

### DIFF
--- a/Src/Web/Web.Nuget/Resources/ApplicationInsights.config.install.xdt
+++ b/Src/Web/Web.Nuget/Resources/ApplicationInsights.config.install.xdt
@@ -24,7 +24,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Src/Web/Web.Shared.Net.Tests/ClientIpHeaderTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/ClientIpHeaderTelemetryModuleTest.cs
@@ -234,7 +234,7 @@
 
             public TestableClientIpHeaderTelemetryInitializer(IDictionary<string, string> headers = null)
             {
-                this.platformContext = HttpModuleHelper.GetFakeHttpContext(headers);
+                this.platformContext = HttpModuleHelper.GetFakeHttpContext(null, headers);
             }
 
             public HttpContext PlatformContext

--- a/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
+++ b/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
@@ -5,13 +5,12 @@
     using System.Globalization;
     using System.IO;
     using System.Net;
+    using System.Reflection;
     using System.Threading;
     using System.Web;
     using System.Web.Hosting;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Web.Implementation;
     using VisualStudio.TestTools.UnitTesting;
 
     internal static class HttpModuleHelper
@@ -60,15 +59,30 @@
             return (HttpApplication)httpApplicationWrapper.Target;
         }
 
-        public static HttpContext GetFakeHttpContext(IDictionary<string, string> headers = null)
+        public static HttpContext GetFakeHttpContext(string url = null, IDictionary<string, string> headers = null)
         {
             Thread.GetDomain().SetData(".appPath", string.Empty);
             Thread.GetDomain().SetData(".appVPath", string.Empty);
 
-            var workerRequest = new SimpleWorkerRequestWithHeaders(UrlPath, UrlQueryString, new StringWriter(CultureInfo.InvariantCulture), headers);
+            var workerRequest = new SimpleWorkerRequestWithHeaders(url ?? UrlPath, UrlQueryString, new StringWriter(CultureInfo.InvariantCulture), headers);
             
             return new HttpContext(workerRequest);
         }
+
+        public static IHttpHandler GetFakeTransferRequestHandler()
+        {
+            var type = Type.GetType("System.Web.Handlers.TransferRequestHandler, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+            var instance = type.Assembly.CreateInstance(
+                type.FullName, 
+                false,
+                BindingFlags.Instance | BindingFlags.Public,
+                null, 
+                null, 
+                null, 
+                null);
+
+            return (IHttpHandler)instance;    
+        }       
 
         public static HttpContext GetFakeHttpContextForFailedRequest()
         {

--- a/Src/Web/Web.Shared.Net.Tests/OperationCorrelationTelemetryInitializerTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/OperationCorrelationTelemetryInitializerTests.cs
@@ -131,7 +131,7 @@
 
             public TestableOperationCorrelationTelemetryInitializer(IDictionary<string, string> headers)
             {
-                 this.fakeContext = HttpModuleHelper.GetFakeHttpContext(headers);
+                 this.fakeContext = HttpModuleHelper.GetFakeHttpContext(null, headers);
             }
 
             public HttpContext FakeContext

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -17,7 +17,6 @@
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using Assert = Xunit.Assert;
-    using System.Reflection;
 
     [TestClass]
     public class RequestTrackingTelemetryModuleTest

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -17,6 +17,7 @@
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using Assert = Xunit.Assert;
+    using System.Reflection;
 
     [TestClass]
     public class RequestTrackingTelemetryModuleTest
@@ -272,6 +273,42 @@
         }
 
         [TestMethod]
+        public void NeedProcessRequestReturnsFalseForWCFForTransferHandler()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext("/SeLog.svc/EventData");
+            context.Handler = HttpModuleHelper.GetFakeTransferRequestHandler();
+
+            var module = this.RequestTrackingTelemetryModuleFactory();
+            {
+                Assert.False(module.NeedProcessRequest(context));
+            }
+        }
+
+        [TestMethod]
+        public void NeedProcessRequestReturnsFalseForWebServiceForTransferHandler()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext("/SeLog.asmx/EventData");
+            context.Handler = HttpModuleHelper.GetFakeTransferRequestHandler();
+
+            var module = this.RequestTrackingTelemetryModuleFactory();
+            {
+                Assert.False(module.NeedProcessRequest(context));
+            }
+        }
+
+        [TestMethod]
+        public void NeedProcessRequestReturnsTrueForRegularAppForTransferHandler()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext("/SeLog/EventData");
+            context.Handler = HttpModuleHelper.GetFakeTransferRequestHandler();
+
+            var module = this.RequestTrackingTelemetryModuleFactory();
+            {
+                Assert.True(module.NeedProcessRequest(context));
+            }
+        }
+
+        [TestMethod]
         public void SdkVersionHasCorrectFormat()
         {
             string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(typeof(RequestTrackingTelemetryModule), prefix: "web:");
@@ -296,7 +333,7 @@
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add(RequestResponseHeaders.RequestContextHeader, requestContextContainingCorrelationId);
 
-            var context = HttpModuleHelper.GetFakeHttpContext(headers);
+            var context = HttpModuleHelper.GetFakeHttpContext(null, headers);
 
             var module = this.RequestTrackingTelemetryModuleFactory();
             var config = TelemetryConfiguration.CreateDefault();
@@ -320,7 +357,7 @@
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add(RequestResponseHeaders.RequestContextHeader, this.GetCorrelationIdHeaderValue(appId));
 
-            var context = HttpModuleHelper.GetFakeHttpContext(headers);
+            var context = HttpModuleHelper.GetFakeHttpContext(null, headers);
 
             var module = this.RequestTrackingTelemetryModuleFactory();
             var config = TelemetryConfiguration.CreateDefault();
@@ -344,7 +381,7 @@
             // do not add any sourceikey header.
             Dictionary<string, string> headers = new Dictionary<string, string>();
 
-            var context = HttpModuleHelper.GetFakeHttpContext(headers);
+            var context = HttpModuleHelper.GetFakeHttpContext(null, headers);
 
             var module = this.RequestTrackingTelemetryModuleFactory();
             var config = TelemetryConfiguration.CreateDefault();
@@ -369,7 +406,7 @@
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add(RequestResponseHeaders.RequestContextHeader, appIdInHeader);
 
-            var context = HttpModuleHelper.GetFakeHttpContext(headers);
+            var context = HttpModuleHelper.GetFakeHttpContext(null, headers);
 
             var module = this.RequestTrackingTelemetryModuleFactory();
             var config = TelemetryConfiguration.CreateDefault();

--- a/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
@@ -113,7 +113,7 @@
 
             public TestableSyntheticUserAgentTelemetryInitializer(IDictionary<string, string> headers = null)
             {
-                this.fakeContext = HttpModuleHelper.GetFakeHttpContext(headers);
+                this.fakeContext = HttpModuleHelper.GetFakeHttpContext(null, headers);
             }
 
             protected override HttpContext ResolvePlatformContext()

--- a/Src/Web/Web.Shared.Net.Tests/WebTestTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/WebTestTelemetryInitializerTest.cs
@@ -149,7 +149,7 @@
 
             public TestableWebTestTelemetryInitializer(IDictionary<string, string> headers = null)
             {
-                this.fakeContext = HttpModuleHelper.GetFakeHttpContext(headers);
+                this.fakeContext = HttpModuleHelper.GetFakeHttpContext(null, headers);
             }
 
             protected override HttpContext ResolvePlatformContext()

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx40/ApplicationInsights.config
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx40/ApplicationInsights.config
@@ -18,7 +18,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-      <Add>System.Web.Handlers.TransferRequestHandler</Add>
       <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
       <Add>System.Web.StaticFileHandler</Add>
       <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx45/ApplicationInsights.config
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx45/ApplicationInsights.config
@@ -18,7 +18,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-      <Add>System.Web.Handlers.TransferRequestHandler</Add>
       <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
       <Add>System.Web.StaticFileHandler</Add>
       <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx451/ApplicationInsights.config
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx451/ApplicationInsights.config
@@ -19,7 +19,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/ApplicationInsights.config
@@ -26,7 +26,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/Aspx40/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/Aspx40/ApplicationInsights.config
@@ -28,7 +28,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/ApplicationInsights.config
@@ -25,7 +25,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/Wa40Aspx/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa40Aspx/ApplicationInsights.config
@@ -27,7 +27,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/Wcf40Tests/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/Wcf40Tests/ApplicationInsights.config
@@ -30,7 +30,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/ApplicationInsights.config
@@ -31,7 +31,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/ApplicationInsights.config
@@ -28,7 +28,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>


### PR DESCRIPTION
REST API app can have all requests filtered out #175 