### PR TITLE
Upgrade AppInsgihts Core SDK to 2.4.0-beta1-build06467

### DIFF
--- a/Global.props
+++ b/Global.props
@@ -96,7 +96,7 @@
         <NugetVersionFilePath>$(MSBuildThisFileDirectory).nugetVersion</NugetVersionFilePath>
         <BuildNugetVersion Condition="Exists($(NugetVersionFilePath))">$([System.IO.File]::ReadAllText($(NugetVersionFilePath)))</BuildNugetVersion>
 
-        <CoreSdkVersion>2.4.0-beta1-build06239</CoreSdkVersion>
+        <CoreSdkVersion>2.4.0-beta1-build06467</CoreSdkVersion>
 
         <!-- Forces EventRegister target to generate ETW manifest file --> 
         <EtwManifestForceAll>true</EtwManifestForceAll>

--- a/Src/DependencyCollector/Net40.Tests/DependencyCollector.Net40.Tests.csproj
+++ b/Src/DependencyCollector/Net40.Tests/DependencyCollector.Net40.Tests.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/DependencyCollector/Net40.Tests/packages.config
+++ b/Src/DependencyCollector/Net40.Tests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Src/DependencyCollector/Net40/DependencyCollector.Net40.csproj
+++ b/Src/DependencyCollector/Net40/DependencyCollector.Net40.csproj
@@ -27,7 +27,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/DependencyCollector/Net40/packages.config
+++ b/Src/DependencyCollector/Net40/packages.config
@@ -3,7 +3,7 @@
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
+++ b/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/DependencyCollector/Net45.Tests/packages.config
+++ b/Src/DependencyCollector/Net45.Tests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net451" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />

--- a/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
+++ b/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
@@ -28,7 +28,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/DependencyCollector/Net45/packages.config
+++ b/Src/DependencyCollector/Net45/packages.config
@@ -3,6 +3,6 @@
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Src/PerformanceCollector/Net40/Perf.Net40.csproj
+++ b/Src/PerformanceCollector/Net40/Perf.Net40.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/PerformanceCollector/Net40/packages.config
+++ b/Src/PerformanceCollector/Net40/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Src/PerformanceCollector/Net45/Perf.Net45.csproj
+++ b/Src/PerformanceCollector/Net45/Perf.Net45.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/PerformanceCollector/Net45/packages.config
+++ b/Src/PerformanceCollector/Net45/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Src/PerformanceCollector/Unit.Tests/Unit.Tests.csproj
+++ b/Src/PerformanceCollector/Unit.Tests/Unit.Tests.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/PerformanceCollector/Unit.Tests/packages.config
+++ b/Src/PerformanceCollector/Unit.Tests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />

--- a/Src/TestFramework/Net40/TestFramework.Net40.csproj
+++ b/Src/TestFramework/Net40/TestFramework.Net40.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/TestFramework/Net40/packages.config
+++ b/Src/TestFramework/Net40/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Src/TestFramework/Net45/TestFramework.Net45.csproj
+++ b/Src/TestFramework/Net45/TestFramework.Net45.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/TestFramework/Net45/packages.config
+++ b/Src/TestFramework/Net45/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Src/Web/Web.Net40.Tests/Web.Net40.Tests.csproj
+++ b/Src/Web/Web.Net40.Tests/Web.Net40.Tests.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/Web/Web.Net40.Tests/packages.config
+++ b/Src/Web/Web.Net40.Tests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Src/Web/Web.Net40/Web.Net40.csproj
+++ b/Src/Web/Web.Net40/Web.Net40.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/Web/Web.Net40/packages.config
+++ b/Src/Web/Web.Net40/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Src/Web/Web.Net45.Tests/packages.config
+++ b/Src/Web/Web.Net45.Tests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net451" />
   <package id="OpenCover" version="4.6.519" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net451" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />

--- a/Src/Web/Web.Net45/Web.Net45.csproj
+++ b/Src/Web/Web.Net45/Web.Net45.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/Web/Web.Net45/packages.config
+++ b/Src/Web/Web.Net45/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Src/Web/Web.Nuget.Tests/Web.Nuget.Tests.csproj
+++ b/Src/Web/Web.Nuget.Tests/Web.Nuget.Tests.csproj
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">

--- a/Src/Web/Web.Nuget.Tests/packages.config
+++ b/Src/Web/Web.Nuget.Tests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />

--- a/Src/WindowsServer/WindowsServer.Net40.Tests/WindowsServer.Net40.Tests.csproj
+++ b/Src/WindowsServer/WindowsServer.Net40.Tests/WindowsServer.Net40.Tests.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/WindowsServer/WindowsServer.Net40.Tests/packages.config
+++ b/Src/WindowsServer/WindowsServer.Net40.Tests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Src/WindowsServer/WindowsServer.Net40/WindowsServer.Net40.csproj
+++ b/Src/WindowsServer/WindowsServer.Net40/WindowsServer.Net40.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/WindowsServer/WindowsServer.Net40/packages.config
+++ b/Src/WindowsServer/WindowsServer.Net40/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
+++ b/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/WindowsServer/WindowsServer.Net45.Tests/packages.config
+++ b/Src/WindowsServer/WindowsServer.Net45.Tests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />

--- a/Src/WindowsServer/WindowsServer.Net45/WindowsServer.Net45.csproj
+++ b/Src/WindowsServer/WindowsServer.Net45/WindowsServer.Net45.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/WindowsServer/WindowsServer.Net45/packages.config
+++ b/Src/WindowsServer/WindowsServer.Net45/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Src/WindowsServer/WindowsServer.Nuget.Tests/WindowsServer.Nuget.Tests.csproj
+++ b/Src/WindowsServer/WindowsServer.Nuget.Tests/WindowsServer.Nuget.Tests.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">

--- a/Src/WindowsServer/WindowsServer.Nuget.Tests/packages.config
+++ b/Src/WindowsServer/WindowsServer.Nuget.Tests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx40/Aspx40.csproj
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx40/Aspx40.csproj
@@ -33,12 +33,12 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx40/packages.config
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx40/packages.config
@@ -11,8 +11,8 @@
   <package id="EntityFramework" version="5.0.0" targetFramework="net40" />
   <package id="jQuery" version="1.8.2" targetFramework="net40" />
   <package id="jQuery.UI.Combined" version="1.8.24" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Membership.OpenAuth" version="1.0.2" targetFramework="net40" />

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
@@ -33,12 +33,12 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx45/packages.config
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx45/packages.config
@@ -6,8 +6,8 @@
   <package id="bootstrap" version="3.0.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.0" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.0.0" targetFramework="net45" />

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx451/Aspx451.csproj
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx451/Aspx451.csproj
@@ -36,12 +36,12 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx451/packages.config
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx451/packages.config
@@ -6,8 +6,8 @@
   <package id="bootstrap" version="3.0.0" targetFramework="net451" />
   <package id="EntityFramework" version="6.1.0" targetFramework="net451" />
   <package id="jQuery" version="1.10.2" targetFramework="net451" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net451" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net451" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.0.0" targetFramework="net451" />

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp40/TestApp40.csproj
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp40/TestApp40.csproj
@@ -42,12 +42,12 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp40/packages.config
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp40/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
@@ -42,11 +42,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/packages.config
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net451" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/FunctionalTests/Functional.csproj
+++ b/Test/Web/FunctionalTests/FunctionalTests/Functional.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))\Global.props" />

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
@@ -40,11 +40,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
@@ -6,8 +6,8 @@
   <package id="bootstrap" version="3.0.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.0" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.0.0" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/Aspx40/Aspx40.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Aspx40/Aspx40.csproj
@@ -44,11 +44,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/Web/FunctionalTests/TestApps/Aspx40/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Aspx40/packages.config
@@ -11,8 +11,8 @@
   <package id="EntityFramework" version="5.0.0" targetFramework="net40" />
   <package id="jQuery" version="1.8.2" targetFramework="net40" />
   <package id="jQuery.UI.Combined" version="1.8.24" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Membership.OpenAuth" version="1.0.2" targetFramework="net40" />

--- a/Test/Web/FunctionalTests/TestApps/ConsoleAppFW40/ConsoleAppFW40.csproj
+++ b/Test/Web/FunctionalTests/TestApps/ConsoleAppFW40/ConsoleAppFW40.csproj
@@ -35,11 +35,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Test/Web/FunctionalTests/TestApps/ConsoleAppFW40/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/ConsoleAppFW40/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
@@ -52,11 +52,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/packages.config
@@ -11,8 +11,8 @@
   <package id="jQuery.UI.Combined" version="1.8.24" targetFramework="net40" />
   <package id="jQuery.Validation" version="1.10.0" targetFramework="net40" />
   <package id="knockoutjs" version="2.2.0" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />

--- a/Test/Web/FunctionalTests/TestApps/Wa40Aspx/Wa40Aspx.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wa40Aspx/Wa40Aspx.csproj
@@ -50,11 +50,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/Web/FunctionalTests/TestApps/Wa40Aspx/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa40Aspx/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Test/Web/FunctionalTests/TestApps/Wcf40Tests/Wcf40Tests.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wcf40Tests/Wcf40Tests.csproj
@@ -51,11 +51,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net40\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/Web/FunctionalTests/TestApps/Wcf40Tests/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Wcf40Tests/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
@@ -53,11 +53,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net451" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
@@ -53,11 +53,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06239\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0-beta1-build06467\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06239\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build06467\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06239" targetFramework="net451" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06239" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build06467" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta1-build06467" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />


### PR DESCRIPTION
Previous Core SDK had a bug https://github.com/Microsoft/ApplicationInsights-dotnet/pull/489 that prevented nuget to be installed