### PR TITLE
Implement request-dependency correlation with Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version 2.4.0-beta1
 - Report status code for the dependencies failed with non-protocol issue like DNS resolution or SSL shakeup problems.
+- Implemented automatic telemetry correlation: all telemetry reported within the scope of the request is correlated to RequestTelemetry reported for the request.
+- Implemented [Correlation HTTP protocol](https://github.com/lmolkova/correlation/blob/master/http_protocol_proposal_v1.md): default headers to pass Operation Root Id and Parent Id were changed. This version is backward compatible with previously supported headers. 
 
 
 ## Version 2.3.0-beta3

--- a/NuGet.config
+++ b/NuGet.config
@@ -18,5 +18,6 @@
   <packageSources>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
     <add key="MyGetApplicationInsights" value="https://www.myget.org/F/applicationinsights/" />
+    <add key="dotnet" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" protocolVersion="3" />    
   </packageSources>
 </configuration>

--- a/Src/Common/AppInsightsActivity.cs
+++ b/Src/Common/AppInsightsActivity.cs
@@ -1,0 +1,145 @@
+﻿namespace Microsoft.ApplicationInsights.Common
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+
+    // this is a temporary solution that mimics System.Diagnostics.Activity and Correlation HTTP protocol:
+    // https://github.com/lmolkova/correlation/blob/master/http_protocol_proposal_v1.md
+    // it is copied from https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+    // and intended to be used on .NET 4.0
+    internal class AppInsightsActivity
+    {
+        private const int RequestIdMaxLength = 1024;
+
+        // Used to generate an ID:
+        // instance unique prefix
+        private static string uniqPrefix;
+
+        // A unique number inside the appdomain, randomized between appdomains. 
+        // Int gives enough randomization and keeps hex-encoded s_currentRootId 8 chars long for most applications
+        private static long currentRootId = (uint)GetRandomNumber();
+
+        public static string GenerateRequestId(string parentId = null)
+        {
+            string ret;
+            if (parentId != null && parentId.Length != 0)
+            {
+                // Start from outside the process (e.g. incoming HTTP)
+                // sanitize external RequestId as it may not be hierarchical. 
+                // we cannot update ParentId, we must let it be logged exactly as it was passed.
+                parentId = parentId[0] == '|' ? parentId : '|' + parentId;
+                if (parentId[parentId.Length - 1] != '.')
+                {
+                    parentId += '.';
+                }
+
+                ret = AppendSuffix(parentId, Interlocked.Increment(ref currentRootId).ToString("x"), '_');
+            }
+            else
+            {
+                // A Root Activity (no parent).  
+                ret = GenerateRootId();
+            }
+
+            // Useful place to place a conditional breakpoint.  
+            return ret;
+        }
+
+        public static string GenerateDependencyId(string parentId)
+        {
+            string ret;
+            if (parentId != null && parentId.Length != 0)
+            {
+                // Start from outside the process (e.g. incoming HTTP)
+                // sanitize external RequestId as it may not be hierarchical. 
+                // we cannot update ParentId, we must let it be logged exactly as it was passed.
+                parentId = parentId[0] == '|' ? parentId : '|' + parentId;
+                if (parentId[parentId.Length - 1] != '.')
+                {
+                    parentId += '.';
+                }
+
+                ret = AppendSuffix(parentId, Interlocked.Increment(ref currentRootId).ToString("x"), '_');
+            }
+            else
+            {
+                // A Root Activity (no parent).  
+                ret = GenerateRootId();
+            }
+
+            // Useful place to place a conditional breakpoint.  
+            return ret;
+        }
+
+        public static string GetRootId(string id)
+        {
+            // id MAY start with '|' and contain '.'. We return substring between them
+            // ParentId MAY NOT have hierarchical structure and we don't know if initially rootId was started with '|',
+            // so we must NOT include first '|' to allow mixed hierarchical and non-hierarchical request id scenarios
+            int rootEnd = id.IndexOf('.');
+            if (rootEnd < 0)
+            {
+                rootEnd = id.Length;
+            }
+
+            int rootStart = id[0] == '|' ? 1 : 0;
+            return id.Substring(rootStart, rootEnd - rootStart);
+        }
+
+        private static string AppendSuffix(string parentId, string suffix, char delimiter)
+        {
+            if (parentId.Length + suffix.Length < RequestIdMaxLength)
+            {
+                return parentId + suffix + delimiter;
+            }
+
+            // Id overflow:
+            // find position in RequestId to trim
+            int trimPosition = RequestIdMaxLength - 9; // overflow suffix + delimiter length is 9
+            while (trimPosition > 1)
+            {
+                if (parentId[trimPosition - 1] == '.' || parentId[trimPosition - 1] == '_')
+                {
+                    break;
+                }
+
+                trimPosition--;
+            }
+
+            // ParentId is not valid Request-Id, let's generate proper one.
+            if (trimPosition == 0)
+            {
+                return GenerateRootId();
+            }
+
+            // generate overflow suffix
+            string overflowSuffix = ((int)GetRandomNumber()).ToString("x8");
+            return parentId.Substring(0, trimPosition) + overflowSuffix + '#';
+        }
+
+        private static string GenerateRootId()
+        {
+            if (uniqPrefix == null)
+            {
+                // Here we make an ID to represent the Process/AppDomain.   Ideally we use process ID but 
+                // it is unclear if we have that ID handy.   Currently we use low bits of high freq tick 
+                // as a unique random number (which is not bad, but loses randomness for startup scenarios).  
+                Interlocked.CompareExchange(ref uniqPrefix, GenerateInstancePrefix(), null);
+            }
+
+            return uniqPrefix + "-" + Interlocked.Increment(ref currentRootId).ToString("x") + '.';
+        }
+
+        private static string GenerateInstancePrefix()
+        {
+            int uniqNum = unchecked((int)Stopwatch.GetTimestamp());
+            return $"|{Environment.MachineName}-{uniqNum:x}";
+        }
+
+        private static ulong GetRandomNumber()
+        {
+            return BitConverter.ToUInt64(Guid.NewGuid().ToByteArray(), 8);
+        }
+    }
+}

--- a/Src/Common/ApplicationInsightsActivity.cs
+++ b/Src/Common/ApplicationInsightsActivity.cs
@@ -12,7 +12,7 @@
     /// Mimics System.Diagnostics.Activity and Correlation HTTP protocol 
     /// and intended to be used on .NET 4.0.
     /// </summary>
-    internal class AppInsightsActivity
+    internal class ApplicationInsightsActivity
     {
         private const int RequestIdMaxLength = 1024;
 

--- a/Src/Common/RequestResponseHeaders.cs
+++ b/Src/Common/RequestResponseHeaders.cs
@@ -21,13 +21,23 @@
         public const string RequestContextTargetKey = "appId"; // Although the name of Source and Target key is the same - appId. Conceptually they are different and hence, we intentionally have two constants here. Makes for better reading of the code.
 
         /// <summary>
-        /// Standard parent Id header.
+        /// Legacy parent Id header.
         /// </summary>
         public const string StandardParentIdHeader = "x-ms-request-id";
 
         /// <summary>
-        /// Standard root id header.
+        /// Legacy root id header.
         /// </summary>
         public const string StandardRootIdHeader = "x-ms-request-root-id";
+
+        /// <summary>
+        /// Standard Request-Id Id header.
+        /// </summary>
+        public const string RequestIdHeader = "Request-Id";
+
+        /// <summary>
+        /// Standard Correlation-Context header.
+        /// </summary>
+        public const string CorrelationContextHeader = "Correlation-Context";
     }
 }

--- a/Src/Common/WebHeaderCollectionExtensions.cs
+++ b/Src/Common/WebHeaderCollectionExtensions.cs
@@ -11,7 +11,7 @@
     /// </summary>
     internal static class WebHeaderCollectionExtensions
     {
-        private const string keyValuePairSeparator = "=";
+        private const string KeyValuePairSeparator = "=";
 
         /// <summary>
         /// For the given header collection, for a given header of name-value type, find the value of a particular key.
@@ -160,7 +160,7 @@
             key = null;
             value = null;
 
-            int indexOfSeparator = pairString.IndexOf(keyValuePairSeparator, StringComparison.Ordinal);
+            int indexOfSeparator = pairString.IndexOf(KeyValuePairSeparator, StringComparison.Ordinal);
 
             // Must be a separator, and cannot be first or last
             if (indexOfSeparator <= 0 || indexOfSeparator == pairString.Length - 1)
@@ -169,7 +169,7 @@
             }
 
             // Must be exactly one separator
-            if (pairString.IndexOf(keyValuePairSeparator, indexOfSeparator + 1, StringComparison.Ordinal) >= 0)
+            if (pairString.IndexOf(KeyValuePairSeparator, indexOfSeparator + 1, StringComparison.Ordinal) >= 0)
             {
                 return false;
             }
@@ -186,7 +186,7 @@
 
         private static string FormatKeyValueHeader(string key, string value)
         {
-            return key.Trim() + keyValuePairSeparator + value.Trim();
+            return key.Trim() + KeyValuePairSeparator + value.Trim();
         }
     }
 }

--- a/Src/Common/WebHeaderCollectionExtensions.cs
+++ b/Src/Common/WebHeaderCollectionExtensions.cs
@@ -1,9 +1,11 @@
 ﻿namespace Microsoft.ApplicationInsights.Common
 {
     using System;
+    using System.Collections.Generic;
     using System.Collections.Specialized;
+    using System.Diagnostics;
     using System.Globalization;
-    using System.Linq;
+    using System.Text;
 
     /// <summary>
     /// WebHeaderCollection extension methods.
@@ -36,12 +38,12 @@
                 var headerValues = requiredHeader.Split(',');
                 foreach (var headerValue in headerValues)
                 {
-                    string keyValueString = headerValue.Trim();
-                    var keyValue = keyValueString.Split('=');
-
-                    if (keyValue.Length == 2 && keyValue[0].Trim() == keyName)
+                    string key, value;
+                    if (headerValue.Contains(keyName) &&
+                        TryParseKeyValueHeader(headerValue, out key, out value) &&
+                        keyName.Equals(key))
                     {
-                        return keyValue[1].Trim();
+                        return value;
                     }
                 }
             }
@@ -50,7 +52,44 @@
         }
 
         /// <summary>
-        /// For the given header collection, sets the header value based on the name value format.
+        /// For the given header collection, for a given header of name-value type, return list of KeyValuePairs.
+        /// </summary>
+        /// <param name="headers">Header collection.</param>
+        /// <param name="headerName">Name of the header in the collection.</param>
+        /// <returns>List of KeyValuePairs in the given header.</returns>
+        public static IDictionary<string, string> GetNameValueCollectionFromHeader(this NameValueCollection headers, string headerName)
+        {
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+
+            var requiredHeader = headers[headerName];
+
+            if (requiredHeader != null)
+            {
+                var values = new Dictionary<string, string>();
+                var headerValues = requiredHeader.Split(',');
+                foreach (var headerValue in headerValues)
+                {
+                    string key, value;
+                    if (TryParseKeyValueHeader(headerValue, out key, out value))
+                    {
+                        if (!values.ContainsKey(key))
+                        {
+                            values.Add(key, value);
+                        }
+                    }
+                }
+
+                return values;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// For the given header collection, adds KeyValuePair to header.
         /// </summary>
         /// <param name="headers">Header collection.</param>
         /// <param name="headerName">Name of the header that is to contain the name-value pair.</param>
@@ -67,13 +106,13 @@
             {
                 throw new ArgumentNullException(nameof(keyName));
             }
-            
+
             var requiredHeader = headers[headerName];
 
             if (!string.IsNullOrEmpty(requiredHeader))
             {
                 bool found = false;
-                var headerValues = requiredHeader.Split(',').Select(s => s.Trim()).ToArray();
+                var headerValues = requiredHeader.Split(',');
                 for (int i = 0; i < headerValues.Length; i++)
                 {
                     string keyValueString = headerValues[i];
@@ -82,23 +121,84 @@
                     if (keyValue.Length == 2 && keyValue[0].Trim() == keyName)
                     {
                         // Overwrite the existing thing
-                        headerValues[i] = string.Format(CultureInfo.InvariantCulture, "{0}={1}", keyName, value);
+                        headerValues[i] = FormatKeyValueHeader(keyName, value);
                         found = true;
                     }
                 }
 
-                headers[headerName] = string.Join(", ", headerValues);
+                headers[headerName] = string.Join(",", headerValues);
 
                 if (!found)
                 {
-                    headers[headerName] += string.Format(CultureInfo.InvariantCulture, ", {0}={1}", keyName, value);
+                    headers[headerName] += string.Format(CultureInfo.InvariantCulture, ",{0}={1}", keyName, value);
                 }
             }
             else
             {
                 // header with headerName does not exist - let's add one.
-                headers[headerName] = string.Format(CultureInfo.InvariantCulture, "{0}={1}", keyName, value);
+                headers[headerName] = FormatKeyValueHeader(keyName, value);
             }
+        }
+
+        /// <summary>
+        /// For the given header collection, sets the header value based on the name value format.
+        /// </summary>
+        /// <param name="headers">Header collection.</param>
+        /// <param name="headerName">Name of the header that is to contain the name-value pair.</param>
+        /// <param name="keyValuePairs">List of KeyValuePairs to format into header.</param>
+        public static void SetHeaderFromNameValueCollection(this NameValueCollection headers, string headerName, IEnumerable<KeyValuePair<string, string>> keyValuePairs)
+        {
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+
+            var requiredHeader = headers[headerName];
+
+            // do not set header if it's present
+            if (string.IsNullOrEmpty(requiredHeader))
+            {
+                StringBuilder headerValue = new StringBuilder();
+                foreach (var pair in keyValuePairs)
+                {
+                    if (headerValue.Length > 0)
+                    {
+                        headerValue.Append(",");
+                    }
+
+                    headerValue.Append(FormatKeyValueHeader(pair.Key, pair.Value));
+                }
+
+                if (headerValue.Length > 0)
+                {
+                    headers[headerName] = headerValue.ToString();
+                }
+            }
+        }
+
+        private static bool TryParseKeyValueHeader(string pairString, out string key, out string value)
+        {
+            Debug.Assert(pairString != null, "pairString is null");
+            var keyValue = pairString.Split('=');
+
+            if (keyValue.Length == 2)
+            {
+                key = keyValue[0].Trim();
+                value = keyValue[1].Trim();
+                if (key.Length > 0 && value.Length > 0)
+                {
+                    return true;
+                }
+            }
+
+            key = null;
+            value = null;
+            return false;
+        }
+
+        private static string FormatKeyValueHeader(string key, string value)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0}={1}", key.Trim(), value.Trim());
         }
     }
 }

--- a/Src/Common/WebHeaderCollectionExtensions.cs
+++ b/Src/Common/WebHeaderCollectionExtensions.cs
@@ -23,11 +23,7 @@
         public static string GetNameValueHeaderValue(this NameValueCollection headers, string headerName, string keyName)
         {
             Debug.Assert(headerName != null, "headerName must not be null");
-
-            if (string.IsNullOrEmpty(keyName))
-            {
-                throw new ArgumentNullException(nameof(keyName));
-            }
+            Debug.Assert(keyName != null, "keyName must not be null");
 
             var requiredHeader = headers[headerName];
 

--- a/Src/DependencyCollector/Net40/DependencyCollector.Net40.csproj
+++ b/Src/DependencyCollector/Net40/DependencyCollector.Net40.csproj
@@ -79,8 +79,8 @@
     <Compile Include="..\..\Web\Web.Net45\Implementation\SdkVersionUtils.cs">
       <Link>SdkVersionUtils.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\AppInsightsActivity.cs">
-      <Link>AppInsightsActivity.cs</Link>
+    <Compile Include="..\..\Common\ApplicationInsightsActivity.cs">
+      <Link>ApplicationInsightsActivity.cs</Link>
     </Compile>       
   </ItemGroup>
   <ItemGroup>

--- a/Src/DependencyCollector/Net40/DependencyCollector.Net40.csproj
+++ b/Src/DependencyCollector/Net40/DependencyCollector.Net40.csproj
@@ -79,6 +79,9 @@
     <Compile Include="..\..\Web\Web.Net45\Implementation\SdkVersionUtils.cs">
       <Link>SdkVersionUtils.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\AppInsightsActivity.cs">
+      <Link>AppInsightsActivity.cs</Link>
+    </Compile>       
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\..\..\packages\Desktop.Analyzers.1.1.0\analyzers\dotnet\cs\Desktop.Analyzers.dll" />

--- a/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
+++ b/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -35,6 +35,10 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Net" />

--- a/Src/DependencyCollector/Net45.Tests/packages.config
+++ b/Src/DependencyCollector/Net45.Tests/packages.config
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build07911" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net451" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />

--- a/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
+++ b/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -33,6 +33,10 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Net" />

--- a/Src/DependencyCollector/Net45/packages.config
+++ b/Src/DependencyCollector/Net45/packages.config
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build07911" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
 </packages>

--- a/Src/DependencyCollector/Shared.Tests/HeaderCollectionManupilationTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/HeaderCollectionManupilationTests.cs
@@ -124,7 +124,7 @@
             WebHeaderCollection headers = new WebHeaderCollection();
 
             // no valid items
-            headers["Correlation-Context"] = "k1, some string";
+            headers["Correlation-Context"] = "k1, some string,k2=v2=v3";
 
             var correlationContext = headers.GetNameValueCollectionFromHeader("Correlation-Context");
             Assert.IsTrue(correlationContext == null || !correlationContext.Any());

--- a/Src/DependencyCollector/Shared.Tests/HeaderCollectionManupilationTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/HeaderCollectionManupilationTests.cs
@@ -1,9 +1,8 @@
 ﻿namespace Microsoft.ApplicationInsights.DependencyCollector
 {
-    using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
-    using System.Text;
     using Common;
     using VisualStudio.TestTools.UnitTesting;
 
@@ -59,13 +58,108 @@
             // Non empty collection - adding new key
             headers.SetNameValueHeaderValue("Request-Context", "roleName", "workerRole");
             Assert.AreEqual(1, headers.Keys.Count);
-            Assert.AreEqual("appId=appIdValue, roleName=workerRole", headers["Request-Context"]);
+            Assert.AreEqual("appId=appIdValue,roleName=workerRole", headers["Request-Context"]);
 
             // overwritting existing key
             headers.SetNameValueHeaderValue("Request-Context", "roleName", "webRole");
             headers.SetNameValueHeaderValue("Request-Context", "appId", "udpatedAppId");
             Assert.AreEqual(1, headers.Keys.Count);
-            Assert.AreEqual("appId=udpatedAppId, roleName=webRole", headers["Request-Context"]);
+            Assert.AreEqual("appId=udpatedAppId,roleName=webRole", headers["Request-Context"]);
+        }
+
+        /// <summary>
+        /// Tests that GetCollectionFromHeaderNoDuplicates gets collection of key-value pairs from existing, non-empty header.
+        /// </summary>
+        [TestMethod]
+        public void GetCollectionFromHeaderNoDuplicates()
+        {
+            WebHeaderCollection headers = new WebHeaderCollection();
+            headers["Correlation-Context"] = "k1=v1, k2=v2, k3 = v3 ";
+
+            var correlationContext = headers.GetNameValueCollectionFromHeader("Correlation-Context");
+            Assert.IsNotNull(correlationContext);
+            var corrContextDict = correlationContext.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Assert.AreEqual(3, corrContextDict.Count);
+            Assert.AreEqual("v1", corrContextDict["k1"]);
+            Assert.AreEqual("v2", corrContextDict["k2"]);
+            Assert.AreEqual("v3", corrContextDict["k3"]);
+        }
+
+        /// <summary>
+        /// Tests that GetCollectionFromHeaderNoDuplicates returns null if header does not exists or is empty.
+        /// </summary>
+        [TestMethod]
+        public void GetCollectionFromEmptyHeader()
+        {
+            WebHeaderCollection headers = new WebHeaderCollection();
+            Assert.IsNull(headers.GetNameValueCollectionFromHeader("Correlation-Context"));
+
+            headers["Correlation-Context"] = "   ";
+            var correlationContext = headers.GetNameValueCollectionFromHeader("Correlation-Context");
+            Assert.IsTrue(correlationContext == null || !correlationContext.Any());
+        }
+
+        /// <summary>
+        /// Tests that GetCollectionFromHeaderNoDuplicates gets collection of key-value pairs from existing, non-empty header with duplicates.
+        /// </summary>
+        [TestMethod]
+        public void GetCollectionFromHeaderWithDuplicates()
+        {
+            WebHeaderCollection headers = new WebHeaderCollection();
+            headers["Correlation-Context"] = "k1=v1, k2=v2, k1 = v3";
+
+            var correlationContext = headers.GetNameValueCollectionFromHeader("Correlation-Context").ToArray();
+            Assert.AreEqual(2, correlationContext.Length);
+            Assert.IsTrue(correlationContext.Contains(new KeyValuePair<string, string>("k1", "v1")));
+            Assert.IsTrue(correlationContext.Contains(new KeyValuePair<string, string>("k2", "v2")));
+        }
+
+        /// <summary>
+        /// Tests that GetCollectionFromHeaderNoDuplicates gets collection of key-value pairs from existing
+        /// non-empty invalid header.
+        /// </summary>
+        [TestMethod]
+        public void GetCollectionFromInvalidHeader()
+        {
+            WebHeaderCollection headers = new WebHeaderCollection();
+
+            // no valid items
+            headers["Correlation-Context"] = "k1, some string";
+
+            var correlationContext = headers.GetNameValueCollectionFromHeader("Correlation-Context");
+            Assert.IsTrue(correlationContext == null || !correlationContext.Any());
+
+            // some valid items
+            headers["Correlation-Context"] = "k1=v1, some string";
+
+            correlationContext = headers.GetNameValueCollectionFromHeader("Correlation-Context");
+            Assert.IsNotNull(correlationContext);
+            Assert.AreEqual(1, correlationContext.Count());
+            Assert.IsTrue(correlationContext.Contains(new KeyValuePair<string, string>("k1", "v1")));
+        }
+
+        [TestMethod]
+        public void SetNameValueHeaderWithEmptyCollectionSetsNothing()
+        {
+            WebHeaderCollection headers = new WebHeaderCollection();
+            headers.SetHeaderFromNameValueCollection("Correlation-Context", new List<KeyValuePair<string, string>>());
+            Assert.IsNull(headers["Correlation-Context"]);
+        }
+
+        [TestMethod]
+        public void SetNameValueHeaderWithNonEmptyCollectionSetsHeader()
+        {
+            WebHeaderCollection headers = new WebHeaderCollection();
+            headers.SetHeaderFromNameValueCollection(
+                "Correlation-Context",
+                new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>("k1 ", "v1"),
+                    new KeyValuePair<string, string>("k2", " v2"),
+                    new KeyValuePair<string, string>("k1", "v3")
+                });
+            Assert.IsNotNull(headers["Correlation-Context"]);
+            Assert.AreEqual("k1=v1,k2=v2,k1=v3", headers["Correlation-Context"]);
         }
     }
 }

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ClientServerDependencyTrackerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ClientServerDependencyTrackerTests.cs
@@ -3,12 +3,18 @@
     using System;
     using System.Collections.Generic;
     using System.Data.SqlClient;
+    using System.Diagnostics;
     using System.Net;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
+#if NET40
+    using Microsoft.ApplicationInsights.Net40;
+#endif
     using Microsoft.ApplicationInsights.Web.TestFramework;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#pragma warning disable 618
 
     /// <summary>
     /// Tests for client server dependency tracker.
@@ -29,6 +35,7 @@
             configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
             configuration.InstrumentationKey = Guid.NewGuid().ToString();
             configuration.TelemetryInitializers.Add(new MockTelemetryInitializer());
+            configuration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
             this.telemetryClient = new TelemetryClient(configuration);
             this.webRequest = WebRequest.Create(new Uri("http://bing.com"));
             this.sqlRequest = new SqlCommand("select * from table;");
@@ -38,6 +45,14 @@
         [TestCleanup]
         public void TestCleanUp()
         {
+#if NET45
+            while (Activity.Current != null)
+            {
+                Activity.Current.Stop();
+            }
+#else
+            CorrelationHelper.CleanOperationContext();
+#endif
             ClientServerDependencyTracker.PretendProfilerIsAttached = false;
         }
 
@@ -49,7 +64,56 @@
         {
             var telemetry = ClientServerDependencyTracker.BeginTracking(this.telemetryClient);
             Assert.AreEqual(telemetry.Timestamp, telemetry.Timestamp);
+
+            Assert.IsNull(telemetry.Context.Operation.ParentId);
+            Assert.IsNotNull(telemetry.Context.Operation.Id);
+            Assert.IsTrue(telemetry.Id.StartsWith('|' + telemetry.Context.Operation.Id));
+            Assert.AreEqual(0, telemetry.Context.Properties.Count);
         }
+
+#if NET45
+        /// <summary>
+        /// Tests if BeginWebTracking() returns operation with associated telemetry item (with operation context).
+        /// </summary>
+        [TestMethod]
+        public void BeginWebTrackingWithParentActivityReturnsOperationItemWithTelemetryItem()
+        {
+            var parentActivity = new Activity("test");
+            parentActivity.SetParentId("|guid.1234_");
+            parentActivity.AddBaggage("k", "v");
+
+            parentActivity.Start();
+
+            var telemetry = ClientServerDependencyTracker.BeginTracking(this.telemetryClient);
+            Assert.AreEqual(parentActivity.Id, telemetry.Context.Operation.ParentId);
+            Assert.AreEqual(parentActivity.RootId, telemetry.Context.Operation.Id);
+
+            var properties = telemetry.Context.Properties;
+            Assert.AreEqual(1, properties.Count);
+            Assert.AreEqual("v", properties["k"]);
+            parentActivity.Stop();
+        }
+#else
+        /// <summary>
+        /// Tests if BeginWebTracking() returns operation with associated telemetry item (with operation context).
+        /// </summary>
+        [TestMethod]
+        public void BeginWebTrackingWithParentCallContextReturnsOperationItemWithTelemetryItem()
+        {
+            var requestTelemetry = new RequestTelemetry { Id = "|guid.1234_" };
+            var correlationContext = new Dictionary<string, string> { ["k"] = "v" };
+            CorrelationHelper.SetOperationContext(requestTelemetry, correlationContext);
+
+            var telemetry = ClientServerDependencyTracker.BeginTracking(this.telemetryClient);
+            Assert.AreEqual("|guid.1234_", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual("guid", telemetry.Context.Operation.Id);
+
+            var properties = telemetry.Context.Properties;
+            Assert.AreEqual(1, properties.Count);
+            Assert.AreEqual("v", properties["k"]);
+            CorrelationHelper.CleanOperationContext();
+        }
+#endif
 
         /// <summary>
         /// Tests if EndTracking() sends telemetry item on success for web and SQL requests.

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
@@ -9,7 +9,6 @@
     using System.Globalization;
     using System.Linq;
     using System.Net;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
 #if !NET40
@@ -22,12 +21,17 @@
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
+#if NET40
+    using Microsoft.ApplicationInsights.Net40;
+#endif
     using Microsoft.ApplicationInsights.TestFramework;
     using Microsoft.ApplicationInsights.Web.TestFramework;
 #if NET40
     using Microsoft.Diagnostics.Tracing;
 #endif
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#pragma warning disable 618
 
     [TestClass]
     public sealed class ProfilerHttpProcessingTest : IDisposable
@@ -54,7 +58,15 @@
 
         [TestCleanup]
         public void Cleanup()
-        {        
+        {
+#if NET45
+            while (Activity.Current != null)
+            {
+                Activity.Current.Stop();
+            }
+#else
+            CorrelationHelper.CleanOperationContext();
+#endif
         }
         #endregion //TestgInitiliaze
 
@@ -184,9 +196,41 @@
             using (var op = client.StartOperation<RequestTelemetry>("request"))
             {
                 this.httpProcessingProfiler.OnBeginForGetResponse(request);
-                Assert.IsNotNull(request.Headers[RequestResponseHeaders.StandardParentIdHeader]);
-                Assert.AreNotEqual(request.Headers[RequestResponseHeaders.StandardParentIdHeader], op.Telemetry.Context.Operation.Id);
+
+                var actualParentIdHeader = request.Headers[RequestResponseHeaders.StandardParentIdHeader];
+                var actualRequestIdHeader = request.Headers[RequestResponseHeaders.RequestIdHeader];
+                Assert.IsNotNull(actualParentIdHeader);
+                Assert.AreNotEqual(actualParentIdHeader, op.Telemetry.Context.Operation.Id);
+
+                Assert.AreEqual(actualParentIdHeader, actualRequestIdHeader);
+#if NET45
+                Assert.IsTrue(actualRequestIdHeader.StartsWith(Activity.Current.Id));
+                Assert.AreNotEqual(Activity.Current.Id, actualRequestIdHeader);
+#else
+                Assert.AreEqual(op.Telemetry.Context.Operation.Id, AppInsightsActivity.GetRootId(request.Headers[RequestResponseHeaders.StandardParentIdHeader]));
+#endif
             }
+        }
+
+        /// <summary>
+        /// Ensures that the parent id header is added when request is sent.
+        /// </summary>
+        [TestMethod]
+        public void RddTestHttpProcessingProfilerOnBeginAddsCorrelationContextHeader()
+        {
+            var request = WebRequest.Create(this.testUrl);
+
+            Assert.IsNull(request.Headers[RequestResponseHeaders.CorrelationContextHeader]);
+#if NET45
+            var activity = new Activity("test").AddBaggage("Key1", "Value1").AddBaggage("Key2", "Value2").Start();
+#else
+            CorrelationHelper.SetOperationContext(new RequestTelemetry(), new Dictionary<string, string> { ["Key1"] = "Value1", ["Key2"] = "Value2" });
+#endif
+            this.httpProcessingProfiler.OnBeginForGetResponse(request);
+
+            var actualCorrelationContextHeader = request.Headers[RequestResponseHeaders.CorrelationContextHeader];
+            Assert.IsNotNull(actualCorrelationContextHeader);
+            Assert.IsTrue(actualCorrelationContextHeader == "Key2=Value2,Key1=Value1" || actualCorrelationContextHeader == "Key1=Value1,Key2=Value2");
         }
 
         /// <summary>

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
@@ -207,7 +207,7 @@
                 Assert.IsTrue(actualRequestIdHeader.StartsWith(Activity.Current.Id));
                 Assert.AreNotEqual(Activity.Current.Id, actualRequestIdHeader);
 #else
-                Assert.AreEqual(op.Telemetry.Context.Operation.Id, AppInsightsActivity.GetRootId(request.Headers[RequestResponseHeaders.StandardParentIdHeader]));
+                Assert.AreEqual(op.Telemetry.Context.Operation.Id, ApplicationInsightsActivity.GetRootId(request.Headers[RequestResponseHeaders.StandardParentIdHeader]));
 #endif
             }
         }

--- a/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
@@ -49,8 +49,8 @@
             // telemetry is initialized by Base SDK OperationCorrealtionTelemetryInitializer
             // however it does not know about Activity on .NET40 and does not know how to properly generate Ids
             // let's fix it
-            telemetry.Id = AppInsightsActivity.GenerateDependencyId(telemetry.Context.Operation.ParentId);
-            telemetry.Context.Operation.Id = AppInsightsActivity.GetRootId(telemetry.Id);
+            telemetry.Id = ApplicationInsightsActivity.GenerateDependencyId(telemetry.Context.Operation.ParentId);
+            telemetry.Context.Operation.Id = ApplicationInsightsActivity.GetRootId(telemetry.Id);
 
 #endif
             PretendProfilerIsAttached = false;

--- a/Src/Web/Web.Net40/Implementation/HttpRequestExtensions.cs
+++ b/Src/Web/Web.Net40/Implementation/HttpRequestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Web.Implementation
 {
     using System;
+    using System.Collections.Specialized;
     using System.Web;
 
     /// <summary>
@@ -68,6 +69,21 @@
             {
                 return httpRequest.Path;
             }
+        }
+
+        public static NameValueCollection UnvalidatedGetHeaders(this HttpRequest httpRequest)
+        {
+            NameValueCollection result;
+            try
+            {
+                result = httpRequest.Headers;
+            }
+            catch (HttpRequestValidationException)
+            {
+                result = httpRequest.Headers;
+            }
+
+            return result;
         }
     }
 }

--- a/Src/Web/Web.Net40/Web.Net40.csproj
+++ b/Src/Web/Web.Net40/Web.Net40.csproj
@@ -73,6 +73,9 @@
     <Compile Include="..\Web.Net45\Implementation\SdkVersionUtils.cs">
       <Link>Implementation\SdkVersionUtils.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\AppInsightsActivity.cs">
+      <Link>AppInsightsActivity.cs</Link>
+    </Compile>    
     <Compile Include="Implementation\HttpRequestExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/Web/Web.Net40/Web.Net40.csproj
+++ b/Src/Web/Web.Net40/Web.Net40.csproj
@@ -73,8 +73,8 @@
     <Compile Include="..\Web.Net45\Implementation\SdkVersionUtils.cs">
       <Link>Implementation\SdkVersionUtils.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\AppInsightsActivity.cs">
-      <Link>AppInsightsActivity.cs</Link>
+    <Compile Include="..\..\Common\ApplicationInsightsActivity.cs">
+      <Link>ApplicationInsightsActivity.cs</Link>
     </Compile>    
     <Compile Include="Implementation\HttpRequestExtensions.cs" />
   </ItemGroup>

--- a/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -35,6 +35,10 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Net" />

--- a/Src/Web/Web.Net45.Tests/packages.config
+++ b/Src/Web/Web.Net45.Tests/packages.config
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build07911" targetFramework="net451" />
   <package id="OpenCover" version="4.6.519" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net451" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />

--- a/Src/Web/Web.Net45/Implementation/HttpRequestExtensions.cs
+++ b/Src/Web/Web.Net45/Implementation/HttpRequestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Web.Implementation
 {
     using System;
+    using System.Collections.Specialized;
     using System.Web;
 
     /// <summary>
@@ -34,6 +35,11 @@
         public static string UnvalidatedGetPath(this HttpRequest httpRequest)
         {
             return httpRequest.Unvalidated.Path;
+        }
+
+        public static NameValueCollection UnvalidatedGetHeaders(this HttpRequest httpRequest)
+        {
+            return httpRequest.Unvalidated.Headers;
         }
     }
 }

--- a/Src/Web/Web.Net45/Web.Net45.csproj
+++ b/Src/Web/Web.Net45/Web.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -28,6 +28,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Net" />

--- a/Src/Web/Web.Net45/packages.config
+++ b/Src/Web/Web.Net45/packages.config
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build07911" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
 </packages>

--- a/Src/Web/Web.Shared.Net.Tests/AccountIdTelemetryInitializerTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/AccountIdTelemetryInitializerTests.cs
@@ -12,6 +12,12 @@
     [TestClass]
     public class AccountIdTelemetryInitializerTests
     {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Common.ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void InitializeDoesNotThrowWhenHttpContextIsNull()
         {

--- a/Src/Web/Web.Shared.Net.Tests/ApplicationInsightsHttpModuleTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/ApplicationInsightsHttpModuleTests.cs
@@ -36,6 +36,7 @@
         {
             ((IHttpModule)this.module.Target).Dispose();
             ((IHttpModule)this.module2.Target).Dispose();
+            Common.ActivityHelpers.StopRequestActivity();
         }
 
         [TestMethod]

--- a/Src/Web/Web.Shared.Net.Tests/AuthenticatedUserIdTelemetryInitializerTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/AuthenticatedUserIdTelemetryInitializerTests.cs
@@ -12,6 +12,12 @@
     [TestClass]
     public class AuthenticatedUserIdTelemetryInitializerTests
     {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Common.ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void InitializeDoesNotThrowWhenHttpContextIsNull()
         {

--- a/Src/Web/Web.Shared.Net.Tests/ClientIpHeaderTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/ClientIpHeaderTelemetryModuleTest.cs
@@ -18,6 +18,12 @@
             Trace.WriteLine(Assembly.GetExecutingAssembly().FullName);
         }
 
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Common.ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void ConstructorSetsDefaultClientIpHeader()
         {

--- a/Src/Web/Web.Shared.Net.Tests/ExceptionTrackingTelemetryModuleTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/ExceptionTrackingTelemetryModuleTests.cs
@@ -31,6 +31,12 @@
             };
         }
 
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Common.ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void OnErrorTracksExceptionsThatArePresentInHttpContext()
         {

--- a/Src/Web/Web.Shared.Net.Tests/HttpContextExtensionTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/HttpContextExtensionTest.cs
@@ -10,6 +10,12 @@
     [TestClass]
     public class HttpContextExtensionTest
     {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Common.ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void GetRequestTelemetryReturnsNullForNullContext()
         {

--- a/Src/Web/Web.Shared.Net.Tests/OperationCorrelationTelemetryInitializerTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/OperationCorrelationTelemetryInitializerTests.cs
@@ -1,17 +1,22 @@
 ﻿namespace Microsoft.ApplicationInsights.Web
 {
-    using System;
     using System.Collections.Generic;
-    using System.Web;    
-    using Common;
+    using System.Web;
+    using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Web.Helpers;
     using Microsoft.ApplicationInsights.Web.Implementation;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;    
-    
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class OperationCorrelationTelemetryInitializerTests
     {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void InitializeDoesNotThrowWhenHttpContextIsNull()
         {
@@ -20,118 +25,84 @@
         }
 
         [TestMethod]
-        public void InitializeSetsParentIdForTelemetryUsingIdFromRequestTelemetry()
+        public void DefaultHeadersOperationCorrelationTelemetryInitializerAreSet()
         {
-            var exceptionTelemetry = new ExceptionTelemetry();
-            var source = new TestableOperationCorrelationTelemetryInitializer(null);
-            var requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
-
-            source.Initialize(exceptionTelemetry);
-
-            Assert.AreEqual(requestTelemetry.Id, exceptionTelemetry.Context.Operation.ParentId);
+            var initializer = new OperationCorrelationTelemetryInitializer();
+            Assert.AreEqual(RequestResponseHeaders.StandardParentIdHeader, initializer.ParentOperationIdHeaderName);
+            Assert.AreEqual(RequestResponseHeaders.StandardRootIdHeader, initializer.RootOperationIdHeaderName);
         }
 
         [TestMethod]
-        public void InitializeDoesNotOverrideCustomerParentOperationId()
+        public void CustomHeadersOperationCorrelationTelemetryInitializerAreSetProperly()
         {
-            var source = new TestableOperationCorrelationTelemetryInitializer(null);
+            var initializer = new OperationCorrelationTelemetryInitializer();
+            initializer.ParentOperationIdHeaderName = "myParentHeader";
+            initializer.RootOperationIdHeaderName = "myRootHeader";
 
-            var customerTelemetry = new TraceTelemetry("Text");
-            customerTelemetry.Context.Operation.ParentId = "CustomId";
+            Assert.AreEqual("myParentHeader", ActivityHelpers.ParentOperationIdHeaderName);
+            Assert.AreEqual("myRootHeader", ActivityHelpers.RootOperationIdHeaderName);
 
-            source.Initialize(customerTelemetry);
-
-            Assert.AreEqual("CustomId", customerTelemetry.Context.Operation.ParentId);
+            Assert.AreEqual("myParentHeader", initializer.ParentOperationIdHeaderName);
+            Assert.AreEqual("myRootHeader", initializer.RootOperationIdHeaderName);
         }
 
         [TestMethod]
-        public void InitializeSetsRootOperationIdForTelemetryUsingIdFromRequestTelemetry()
+        public void OperationContextIsSetForNonRequestTelemetry()
         {
-            var exceptionTelemetry = new ExceptionTelemetry();
-            var source = new TestableOperationCorrelationTelemetryInitializer(null);
-            var requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
-            requestTelemetry.Context.Operation.Id = "RootId";
+            var source = new TestableOperationCorrelationTelemetryInitializer(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "|guid.1",
+                ["Correlation-Context"] = "k1=v1,k2=v2,k1=v3"
+            });
 
+            // simulate OnBegin behavior:
+            // create telemetry and start activity for children
+            var requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
+            ActivityHelpers.StartActivity(source.FakeContext);
+            
+            // lost Acitivity / call context
+            ActivityHelpers.StopRequestActivity();
+
+            var exceptionTelemetry = new ExceptionTelemetry();
             source.Initialize(exceptionTelemetry);
 
             Assert.AreEqual(requestTelemetry.Context.Operation.Id, exceptionTelemetry.Context.Operation.Id);
+            Assert.AreEqual(requestTelemetry.Id, exceptionTelemetry.Context.Operation.ParentId);
+
+            Assert.AreEqual(2, exceptionTelemetry.Context.Properties.Count);
+            Assert.AreEqual("v1", exceptionTelemetry.Context.Properties["k1"]);
+            Assert.AreEqual("v2", exceptionTelemetry.Context.Properties["k2"]);
         }
 
         [TestMethod]
-        public void InitializeDoesNotOverrideCustomerRootOperationId()
+        public void OperationContextIsNotUpdatedIfOperationIdIsSet()
         {
-            var source = new TestableOperationCorrelationTelemetryInitializer(null);
-            var requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
-            requestTelemetry.Context.Operation.Id = "RootId";
+            var source = new TestableOperationCorrelationTelemetryInitializer(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "|guid.1",
+                ["Correaltion-Context"] = "k1=v1"
+            });
 
-            var customerTelemetry = new TraceTelemetry("Text");
-            customerTelemetry.Context.Operation.Id = "CustomId";
+            // create telemetry and immediately clean call context/activity
+            source.FakeContext.CreateRequestTelemetryPrivate();
+            ActivityHelpers.StopRequestActivity();
 
-            source.Initialize(customerTelemetry);
+            var exceptionTelemetry = new ExceptionTelemetry();
+            exceptionTelemetry.Context.Operation.Id = "guid";
+            source.Initialize(exceptionTelemetry);
 
-            Assert.AreEqual("CustomId", customerTelemetry.Context.Operation.Id);
-        }
+            Assert.IsNull(exceptionTelemetry.Context.Operation.ParentId);
 
-        [TestMethod]
-        public void InitializeSetsRequestTelemetryRootOperaitonIdToOepraitonId()
-        {
-            var source = new TestableOperationCorrelationTelemetryInitializer(null);
-            var requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
-
-            var customerTelemetry = new TraceTelemetry("Text");
-
-            source.Initialize(customerTelemetry);
-
-            Assert.AreEqual(requestTelemetry.Id, requestTelemetry.Context.Operation.Id);
-        }
-
-        [TestMethod]
-        public void InitializeReadsParentIdFromCustomHeader()
-        {
-            var source = new TestableOperationCorrelationTelemetryInitializer(new Dictionary<string, string>() { { "headerName", "ParentId" } });
-            source.ParentOperationIdHeaderName = "headerName";
-
-            var customerTelemetry = new TraceTelemetry("Text");
-
-            source.Initialize(customerTelemetry);
-
-            var requestTelemetry = source.FakeContext.ReadOrCreateRequestTelemetryPrivate();
-            Assert.AreEqual("ParentId", requestTelemetry.Context.Operation.ParentId);
-        }
-
-        [TestMethod]
-        public void InitializeReadsRootIdFromCustomHeader()
-        {
-            var source = new TestableOperationCorrelationTelemetryInitializer(new Dictionary<string, string>() { { "headerName", "RootId" } });
-            source.RootOperationIdHeaderName = "headerName";
-
-            var customerTelemetry = new TraceTelemetry("Text");
-
-            source.Initialize(customerTelemetry);
-            Assert.AreEqual("RootId", customerTelemetry.Context.Operation.Id);
-
-            var requestTelemetry = source.FakeContext.ReadOrCreateRequestTelemetryPrivate();
-            Assert.AreEqual("RootId", requestTelemetry.Context.Operation.Id);
-        }
-
-        [TestMethod]
-        public void InitializeDoNotMakeRequestAParentOfItself()
-        {
-            var source = new TestableOperationCorrelationTelemetryInitializer(null);
-            var requestTelemetry = source.FakeContext.ReadOrCreateRequestTelemetryPrivate();
-
-            source.Initialize(requestTelemetry);
-            Assert.AreEqual(null, requestTelemetry.Context.Operation.ParentId);
-            Assert.AreEqual(requestTelemetry.Id, requestTelemetry.Context.Operation.Id);
+            Assert.AreEqual(0, exceptionTelemetry.Context.Properties.Count);
         }
 
         private class TestableOperationCorrelationTelemetryInitializer : OperationCorrelationTelemetryInitializer
         {
             private readonly HttpContext fakeContext;
 
-            public TestableOperationCorrelationTelemetryInitializer(IDictionary<string, string> headers)
+            public TestableOperationCorrelationTelemetryInitializer(IDictionary<string, string> headers = null)
             {
-                 this.fakeContext = HttpModuleHelper.GetFakeHttpContext(headers);
+                this.fakeContext = HttpModuleHelper.GetFakeHttpContext(headers);
             }
 
             public HttpContext FakeContext

--- a/Src/Web/Web.Shared.Net.Tests/OperationCorrelationTelemetryInitializerTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/OperationCorrelationTelemetryInitializerTests.cs
@@ -58,7 +58,6 @@
             // simulate OnBegin behavior:
             // create telemetry and start activity for children
             var requestTelemetry = source.FakeContext.CreateRequestTelemetryPrivate();
-            ActivityHelpers.StartActivity(source.FakeContext);
             
             // lost Acitivity / call context
             ActivityHelpers.StopRequestActivity();

--- a/Src/Web/Web.Shared.Net.Tests/OperationNameTelemetryInitializerTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/OperationNameTelemetryInitializerTests.cs
@@ -10,6 +10,12 @@
     [TestClass]
     public class OperationNameTelemetryInitializerTests
     {
+        [TestCleanup]
+        public void Cleanup()
+        {
+           Common.ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void InitializeDoesNotThrowWhenHttpContextIsNull()
         {

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -2,12 +2,14 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Globalization;
     using System.Threading.Tasks;
     using System.Web;
 
-    using Common;
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.TestFramework;
@@ -29,6 +31,12 @@
             return tcs.Task;
         });
 
+        [TestCleanup]
+        public void Cleanup()
+        {
+            ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void OnBeginRequestDoesNotSetTimeIfItWasAssignedBefore()
         {
@@ -38,9 +46,7 @@
             var requestTelemetry = context.CreateRequestTelemetryPrivate();
             requestTelemetry.Timestamp = startTime;
 
-            var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
-            module.OnBeginRequest(context);
+            this.RequestTrackingTelemetryModuleFactory().OnBeginRequest(context);
 
             Assert.Equal(startTime, requestTelemetry.Timestamp);
         }
@@ -52,9 +58,7 @@
             var requestTelemetry = context.CreateRequestTelemetryPrivate();
             requestTelemetry.Timestamp = default(DateTimeOffset);
 
-            var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
-            module.OnBeginRequest(context);
+            this.RequestTrackingTelemetryModuleFactory().OnBeginRequest(context);
 
             Assert.NotEqual(default(DateTimeOffset), requestTelemetry.Timestamp);
         }
@@ -65,10 +69,7 @@
             var context = HttpModuleHelper.GetFakeHttpContext();
             var requestTelemetry = context.CreateRequestTelemetryPrivate();
 
-            var module = this.RequestTrackingTelemetryModuleFactory();
-
-            module.Initialize(TelemetryConfiguration.CreateDefault());
-            module.OnBeginRequest(context);
+            this.RequestTrackingTelemetryModuleFactory().OnBeginRequest(context);
 
             Assert.True(!string.IsNullOrEmpty(requestTelemetry.Id));
         }
@@ -77,9 +78,8 @@
         public void OnEndSetsDurationToPositiveValue()
         {
             var context = HttpModuleHelper.GetFakeHttpContext();
-            
+
             var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
             module.OnBeginRequest(context);
             module.OnEndRequest(context);
 
@@ -91,9 +91,7 @@
         {
             var context = HttpModuleHelper.GetFakeHttpContext();
 
-            var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
-            module.OnEndRequest(context);
+            this.RequestTrackingTelemetryModuleFactory().OnEndRequest(context);
 
             Assert.NotNull(context.GetRequestTelemetry());
         }
@@ -102,10 +100,7 @@
         public void OnEndSetsDurationToZeroIfBeginWasNotCalled()
         {
             var context = HttpModuleHelper.GetFakeHttpContext();
-
-            var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
-            module.OnEndRequest(context);
+            this.RequestTrackingTelemetryModuleFactory().OnEndRequest(context);
 
             Assert.Equal(0, context.GetRequestTelemetry().Duration.Ticks);
         }
@@ -114,11 +109,10 @@
         public void OnEndDoesNotOverrideResponseCode()
         {
             var context = HttpModuleHelper.GetFakeHttpContext();
+            context.CreateRequestTelemetryPrivate();
             context.Response.StatusCode = 300;
 
             var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
-
             module.OnBeginRequest(context);
             var requestTelemetry = context.GetRequestTelemetry();
             requestTelemetry.ResponseCode = "Test";
@@ -136,6 +130,7 @@
             var module = this.RequestTrackingTelemetryModuleFactory();
             module.Initialize(TelemetryConfiguration.CreateDefault());
             module.OnBeginRequest(context);
+
             var requestTelemetry = context.GetRequestTelemetry();
             requestTelemetry.Url = new Uri("http://test/");
 
@@ -151,7 +146,6 @@
             context.Response.StatusCode = 401;
 
             var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
             module.OnBeginRequest(context);
             module.OnEndRequest(context);
 
@@ -206,7 +200,6 @@
             var context = HttpModuleHelper.GetFakeHttpContext();
 
             var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
             module.OnBeginRequest(context);
             module.OnEndRequest(context);
 
@@ -226,8 +219,7 @@
                 TelemetryChannel = stubTelemetryChannel
             };
 
-            var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(configuration);
+            var module = this.RequestTrackingTelemetryModuleFactory(configuration);
             module.OnBeginRequest(context);
             module.OnEndRequest(context);
 
@@ -246,8 +238,6 @@
 
             var module = this.RequestTrackingTelemetryModuleFactory();
             module.Handlers.Add("System.Web.Handlers.AssemblyResourceLoader");
-            var configuration = TelemetryConfiguration.CreateDefault();
-            module.Initialize(configuration);
 
             Assert.False(module.NeedProcessRequest(context));
         }
@@ -263,8 +253,6 @@
             requestTelemetry.Start();
 
             var module = this.RequestTrackingTelemetryModuleFactory();
-            var configuration = TelemetryConfiguration.CreateDefault();
-            module.Initialize(configuration);
 
             Assert.True(module.NeedProcessRequest(context));
         }
@@ -281,8 +269,6 @@
 
             var module = this.RequestTrackingTelemetryModuleFactory();
             module.Handlers.Add("Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModuleTest+FakeHttpHandler");
-            var configuration = TelemetryConfiguration.CreateDefault();
-            module.Initialize(configuration);
 
             Assert.False(module.NeedProcessRequest(context));
         }
@@ -298,8 +284,6 @@
             requestTelemetry.Start();
 
             var module = this.RequestTrackingTelemetryModuleFactory();
-            var configuration = TelemetryConfiguration.CreateDefault();
-            module.Initialize(configuration);
 
             Assert.True(module.NeedProcessRequest(context));
         }
@@ -321,7 +305,6 @@
             var context = HttpModuleHelper.GetFakeHttpContext();
 
             var module = this.RequestTrackingTelemetryModuleFactory();
-            module.Initialize(TelemetryConfiguration.CreateDefault());
             module.OnBeginRequest(context);
             module.OnEndRequest(context);
 
@@ -340,12 +323,10 @@
 
             var context = HttpModuleHelper.GetFakeHttpContext(headers);
 
-            var module = this.RequestTrackingTelemetryModuleFactory();
-            var config = TelemetryConfiguration.CreateDefault();
-            config.InstrumentationKey = ikey;
+            var config = this.CreateDefaultConfig(context, instrumentationKey: ikey);
+            var module = this.RequestTrackingTelemetryModuleFactory(config);
 
             // ACT
-            module.Initialize(config);
             module.OnBeginRequest(context);
             module.OnEndRequest(context);
 
@@ -414,10 +395,6 @@
             var context = HttpModuleHelper.GetFakeHttpContext(headers);
 
             var module = this.RequestTrackingTelemetryModuleFactory();
-            var config = TelemetryConfiguration.CreateDefault();
-            config.InstrumentationKey = Guid.NewGuid().ToString();
-
-            module.Initialize(config);
             module.OnBeginRequest(context);
             context.GetRequestTelemetry().Source = appIdInSourceField;
 
@@ -428,11 +405,374 @@
             Assert.Equal(appIdInSourceField, context.GetRequestTelemetry().Source);
         }
 
-        private RequestTrackingTelemetryModule RequestTrackingTelemetryModuleFactory()
+        [TestMethod]
+        public void OnBeginSetsOperationContextWithStandardHeaders()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "|guid1.1",
+                ["Correlation-Context"] = "k=v"
+            });
+
+            var module = this.RequestTrackingTelemetryModuleFactory();
+            module.OnBeginRequest(context);
+            var requestTelemetry = context.GetRequestTelemetry();
+
+            // initialize telemetry
+            module.OnEndRequest(context);
+
+            Assert.Equal("guid1", requestTelemetry.Context.Operation.Id);
+            Assert.Equal("|guid1.1", requestTelemetry.Context.Operation.ParentId);
+
+            Assert.True(requestTelemetry.Id.StartsWith("|guid1.1."));
+            Assert.NotEqual("|guid1.1", requestTelemetry.Id);
+            Assert.Equal("guid1", this.GetActivityRootId(requestTelemetry.Id));
+            Assert.Equal("v", requestTelemetry.Properties["k"]);
+        }
+
+        [TestMethod]
+        public void OnBeginSetsOperationContextWithStandardHeadersWithNonHierarchialId()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "guid1",
+                ["Correlation-Context"] = "k=v"
+            });
+
+            var module = this.RequestTrackingTelemetryModuleFactory();
+            module.OnBeginRequest(context);
+            var requestTelemetry = context.GetRequestTelemetry();
+            module.OnEndRequest(context);
+
+            Assert.Equal("guid1", requestTelemetry.Context.Operation.Id);
+            Assert.Equal("guid1", requestTelemetry.Context.Operation.ParentId);
+
+            Assert.True(requestTelemetry.Id.StartsWith("|guid1."));
+            Assert.NotEqual("|guid1.1.", requestTelemetry.Id);
+            Assert.Equal("guid1", this.GetActivityRootId(requestTelemetry.Id));
+
+            // will initialize telemetry
+            module.OnEndRequest(context);
+            Assert.Equal("v", requestTelemetry.Properties["k"]);
+        }
+
+        [TestMethod]
+        public void OnBeginSetsOperationContextWithoutHeaders()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext();
+
+            var module = this.RequestTrackingTelemetryModuleFactory(this.CreateDefaultConfig(context));
+            module.OnBeginRequest(context);
+            var requestTelemetry = context.GetRequestTelemetry();
+            module.OnEndRequest(context);
+
+            var operationId = requestTelemetry.Context.Operation.Id;
+            Assert.NotNull(operationId);
+            Assert.Null(requestTelemetry.Context.Operation.ParentId);
+            Assert.True(requestTelemetry.Id.StartsWith('|' + operationId + '.'));
+            Assert.NotEqual(operationId, requestTelemetry.Id);
+        }
+
+        [TestMethod]
+        public void InitializeFromStandardHeadersAlwaysWinsCustomHeaders()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "standard-id",
+                ["x-ms-request-id"] = "legacy-id",
+                ["x-ms-request-rooit-id"] = "legacy-root-id"
+            });
+
+            var config = this.CreateDefaultConfig(context);
+            var module = this.RequestTrackingTelemetryModuleFactory(config);
+            module.OnBeginRequest(context);
+
+            var requestTelemetry = context.GetRequestTelemetry();
+
+            // initialize telemetry
+            module.OnEndRequest(context);
+            Assert.Equal("standard-id", requestTelemetry.Context.Operation.ParentId);
+            Assert.Equal("standard-id", requestTelemetry.Context.Operation.Id);
+            Assert.Equal("standard-id", this.GetActivityRootId(requestTelemetry.Id));
+            Assert.NotEqual(requestTelemetry.Context.Operation.Id, requestTelemetry.Id);
+        }
+
+        [TestMethod]
+        public void OnBeginSetsOperationContextWithLegacyHeaders()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["x-ms-request-id"] = "guid1",
+                ["x-ms-request-root-id"] = "guid2"
+            });
+
+            var module = this.RequestTrackingTelemetryModuleFactory();
+            module.OnBeginRequest(context);
+            var requestTelemetry = context.GetRequestTelemetry();
+            module.OnEndRequest(context);
+
+            Assert.Equal("guid2", requestTelemetry.Context.Operation.Id);
+            Assert.Equal("guid1", requestTelemetry.Context.Operation.ParentId);
+
+            Assert.True(requestTelemetry.Id.StartsWith("|guid2."));
+        }
+
+        // skip, Activity not yet validates correlation context
+        [Ignore]
+        [TestMethod]
+        public void InitializeWithInvalidCorrelationContext()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "|guid.",
+                ["Correlation-Context"] = $"123,k1=v1,k12345678910111213=v2,k3={Guid.NewGuid()}{Guid.NewGuid()}" // key length must be less than 16, value length < 42
+            });
+
+            var module = this.RequestTrackingTelemetryModuleFactory();
+            module.OnBeginRequest(context);
+            var requestTelemetry = context.GetRequestTelemetry();
+
+            // initialize telemetry
+            module.OnEndRequest(context);
+
+            Assert.Equal("v1", requestTelemetry.Context.Properties["k1"]);
+        }
+
+        [TestMethod]
+        public void InitializeWithInvalidRequestId()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string> { ["Request-Id"] = string.Empty });
+
+            var module = this.RequestTrackingTelemetryModuleFactory(this.CreateDefaultConfig(context));
+            module.OnBeginRequest(context);
+            var requestTelemetry = context.GetRequestTelemetry();
+            module.OnEndRequest(context);
+
+            Assert.Null(requestTelemetry.Context.Operation.ParentId);
+            Assert.NotNull(requestTelemetry.Context.Operation.Id);
+            Assert.Equal(requestTelemetry.Context.Operation.Id, this.GetActivityRootId(requestTelemetry.Id));
+        }
+
+        [TestMethod]
+        public void InitializeFromStandardHeaderWithHierarchicalIdAndCorrelationContextId()
+        {
+            // accoring to the spec: https://github.com/lmolkova/correlation/blob/master/http_protocol_proposal_v1.md
+            // service that receives non-hierarchical id, gets Id from the Correlation-Context and creates requestId from it
+            // so below example is not valid according to the spec
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "|guid1.",
+                ["Correlation-Context"] = "Id=guid2"
+            });
+
+            var module = this.RequestTrackingTelemetryModuleFactory(this.CreateDefaultConfig(context));
+            module.OnBeginRequest(context);
+            var requestTelemetry = context.GetRequestTelemetry();
+
+            // initialize telemetry
+            module.OnEndRequest(context);
+
+            Assert.Equal("|guid1.", requestTelemetry.Context.Operation.ParentId);
+            Assert.Equal("guid1", requestTelemetry.Context.Operation.Id);
+            Assert.Equal("guid1", this.GetActivityRootId(requestTelemetry.Id));
+
+            Assert.Equal("guid2", requestTelemetry.Context.Properties["Id"]);
+        }
+
+        [TestMethod]
+        public void InitializeFromStandardHeaderWithNonHierarchicalIdAndCorrelationContextId()
+        {
+            // accoring to the spec: https://github.com/lmolkova/correlation/blob/master/http_protocol_proposal_v1.md
+            // service that receives non-hierarchical id, gets Id from the Correlation-Context and creates requestId from it
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "guid1",
+                ["Correlation-Context"] = "Id=guid2"
+            });
+
+            var module = this.RequestTrackingTelemetryModuleFactory(this.CreateDefaultConfig(context));
+            module.OnBeginRequest(context);
+            var requestTelemetry = context.GetRequestTelemetry();
+
+            // initialize telemetry
+            module.OnEndRequest(context);
+            Assert.Equal("guid1", requestTelemetry.Context.Operation.ParentId);
+            Assert.Equal("guid2", requestTelemetry.Context.Operation.Id);
+            Assert.Equal("guid2", this.GetActivityRootId(requestTelemetry.Id));
+            Assert.NotEqual("guid2", requestTelemetry.Id);
+
+            Assert.Equal("guid2", requestTelemetry.Context.Properties["Id"]);
+        }
+
+        [TestMethod]
+        public void OnBeginReadsParentIdFromCustomHeader()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["headerName"] = "ParentId"
+            });
+
+            var config = this.CreateDefaultConfig(context, parentIdHeaderName: "headerName");
+            this.RequestTrackingTelemetryModuleFactory(config).OnBeginRequest(context);
+
+            var requestTelemetry = context.GetRequestTelemetry();
+
+            Assert.Equal("ParentId", requestTelemetry.Context.Operation.ParentId);
+        }
+
+        [TestMethod]
+        public void OnBeginReadsRootIdFromCustomHeader()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["headerName"] = "RootId"
+            });
+
+            var config = this.CreateDefaultConfig(context, rootIdHeaderName: "headerName");
+            var module = this.RequestTrackingTelemetryModuleFactory(config);
+            module.OnBeginRequest(context);
+            var requestTelemetry = context.GetRequestTelemetry();
+
+            module.OnEndRequest(context);
+            Assert.Equal("RootId", requestTelemetry.Context.Operation.Id);
+
+            Assert.Equal("RootId", requestTelemetry.Context.Operation.Id);
+            Assert.NotEqual("RootId", requestTelemetry.Id);
+            Assert.Equal("RootId", this.GetActivityRootId(requestTelemetry.Id));
+        }
+
+        [TestMethod]
+        public void OnBeginTelemetryCreatedWithinRequestScopeIsRequestChild()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "|guid1.1",
+                ["Correlation-Context"] = "k=v"
+            });
+
+            var config = this.CreateDefaultConfig(context);
+            var module = this.RequestTrackingTelemetryModuleFactory(config);
+            module.OnBeginRequest(context);
+
+            var requestTelemetry = context.GetRequestTelemetry();
+            var telemetryClient = new TelemetryClient(config);
+            var exceptionTelemetry = new ExceptionTelemetry();
+            telemetryClient.Initialize(exceptionTelemetry);
+
+            module.OnEndRequest(context);
+
+            Assert.Equal("guid1", exceptionTelemetry.Context.Operation.Id);
+            Assert.Equal(requestTelemetry.Id, exceptionTelemetry.Context.Operation.ParentId);
+            Assert.Equal("v", exceptionTelemetry.Context.Properties["k"]);
+        }
+
+        [TestMethod]
+        public void OnPreHandlerTelemetryCreatedWithinRequestScopeIsRequestChild()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "|guid1.1",
+                ["Correlation-Context"] = "k=v"
+            });
+
+            var config = this.CreateDefaultConfig(context);
+            var module = this.RequestTrackingTelemetryModuleFactory(config);
+
+            module.OnBeginRequest(context);
+
+            // simulate losing call context by cleaning up activity
+            ActivityHelpers.StopRequestActivity();
+
+            // CallContext was lost after OnBegin, so OnPreRequestHandlerExecute will set it
+            module.OnPreRequestHandlerExecute(context);
+
+            // if OnPreRequestHandlerExecute set a CallContext, child telemetry will be properly filled
+            var telemetryClient = new TelemetryClient(config);
+
+            var trace = new TraceTelemetry();
+            telemetryClient.TrackTrace(trace);
+            var requestTelemetry = context.GetRequestTelemetry();
+
+            Assert.Equal(requestTelemetry.Context.Operation.Id, trace.Context.Operation.Id);
+#if NET40
+            Assert.Equal(requestTelemetry.Id, trace.Context.Operation.ParentId);
+#else
+            // we created Activity for request and assigned Id for the request like guid1.1.12345
+            // then we created Activity for request children and assigned it Id like guid1.1.12345_1
+            // then we lost it and restored (started a new child activity), so the Id is guid1.1.123_1.abc
+            // so the request is grand parent to the trace
+            Assert.True(trace.Context.Operation.ParentId.StartsWith(requestTelemetry.Id));
+            Assert.Equal(Activity.Current.ParentId, trace.Context.Operation.ParentId);
+#endif
+            Assert.Equal("v", trace.Context.Properties["k"]);
+        }
+
+        [TestMethod]
+        public void TelemetryCreatedWithinRequestScopeIsRequestChildWhenActivityIsLost()
+        {
+            var context = HttpModuleHelper.GetFakeHttpContext(new Dictionary<string, string>
+            {
+                ["Request-Id"] = "|guid1.1",
+                ["Correlation-Context"] = "k=v"
+            });
+
+            var config = this.CreateDefaultConfig(context);
+            var module = this.RequestTrackingTelemetryModuleFactory(config);
+
+            module.OnBeginRequest(context);
+
+            // simulate losing call context by cleaning up activity
+            ActivityHelpers.StopRequestActivity();
+
+            var telemetryClient = new TelemetryClient(config);
+
+            var trace = new TraceTelemetry();
+            telemetryClient.TrackTrace(trace);
+            var requestTelemetry = context.GetRequestTelemetry();
+
+            Assert.Equal(requestTelemetry.Context.Operation.Id, trace.Context.Operation.Id);
+#if NET40
+            Assert.Equal(requestTelemetry.Id, trace.Context.Operation.ParentId);
+#else
+            // we created Activity for request and assigned Id for the request like guid1.1.12345
+            // then we created Activity for request children and assigned it Id like guid1.1.12345_1
+            // then we lost it and restored (started a new child activity), so the Id is guid1.1.123_1.abc
+            // so the request is grand parent to the trace
+            Assert.True(trace.Context.Operation.ParentId.StartsWith(requestTelemetry.Id));
+#endif
+            Assert.Equal("v", trace.Context.Properties["k"]);
+        }
+
+        private TelemetryConfiguration CreateDefaultConfig(HttpContext fakeContext, string rootIdHeaderName = null, string parentIdHeaderName = null, string instrumentationKey = null)
+        {
+            var config = TelemetryConfiguration.CreateDefault();
+            var telemetryInitializer = new TestableOperationCorrelationTelemetryInitializer(fakeContext);
+
+            if (rootIdHeaderName != null)
+            {
+                telemetryInitializer.RootOperationIdHeaderName = rootIdHeaderName;
+            }
+
+            if (parentIdHeaderName != null)
+            {
+                telemetryInitializer.ParentOperationIdHeaderName = parentIdHeaderName;
+            }
+
+            config.TelemetryInitializers.Add(telemetryInitializer);
+            config.InstrumentationKey = instrumentationKey ?? Guid.NewGuid().ToString();
+            return config;
+        }
+
+        private string GetActivityRootId(string telemetryId)
+        {
+            return telemetryId.Substring(1, telemetryId.IndexOf('.') - 1);
+        }
+
+        private RequestTrackingTelemetryModule RequestTrackingTelemetryModuleFactory(TelemetryConfiguration config = null)
         {
             var module = new RequestTrackingTelemetryModule();
             module.OverrideCorrelationIdLookupHelper(this.correlationIdLookupHelper);
-
+            module.Initialize(config ?? this.CreateDefaultConfig(HttpModuleHelper.GetFakeHttpContext()));
             return module;
         }
 
@@ -455,6 +795,26 @@
 
             public void ProcessRequest(System.Web.HttpContext context)
             {
+            }
+        }
+
+        private class TestableOperationCorrelationTelemetryInitializer : OperationCorrelationTelemetryInitializer
+        {
+            private readonly HttpContext fakeContext;
+
+            public TestableOperationCorrelationTelemetryInitializer(HttpContext fakeContext)
+            {
+                this.fakeContext = fakeContext;
+            }
+
+            public HttpContext FakeContext
+            {
+                get { return this.fakeContext; }
+            }
+
+            protected override HttpContext ResolvePlatformContext()
+            {
+                return this.fakeContext;
             }
         }
     }

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -697,12 +697,12 @@
 #if NET40
             Assert.Equal(requestTelemetry.Id, trace.Context.Operation.ParentId);
 #else
-            // we created Activity for request and assigned Id for the request like guid1.1.12345
-            // then we created Activity for request children and assigned it Id like guid1.1.12345_1
-            // then we lost it and restored (started a new child activity), so the Id is guid1.1.123_1.abc
+            // we created Activity for request and assigned Id for the request like guid1.1.12345_
+            // then we lost it and restored (started a new child activity), so the Id is guid1.1.12345_abc_
             // so the request is grand parent to the trace
+            Assert.Equal(Activity.Current.ParentId, requestTelemetry.Id);
             Assert.True(trace.Context.Operation.ParentId.StartsWith(requestTelemetry.Id));
-            Assert.Equal(Activity.Current.ParentId, trace.Context.Operation.ParentId);
+            Assert.Equal(Activity.Current.Id, trace.Context.Operation.ParentId);
 #endif
             Assert.Equal("v", trace.Context.Properties["k"]);
         }

--- a/Src/Web/Web.Shared.Net.Tests/SessionTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/SessionTelemetryInitializerTest.cs
@@ -11,6 +11,12 @@
     [TestClass]
     public class SessionTelemetryInitializerTest
     {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Common.ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void InitializeDoesNotThrowWhenHttpContextIsNull()
         {

--- a/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
@@ -10,7 +10,13 @@
     [TestClass]
     public class SyntheticUserAgentTelemetryInitializerTest
     {
-        private string botSubstrings = "search|spider|crawl|Bot|Monitor|AlwaysOn";          
+        private string botSubstrings = "search|spider|crawl|Bot|Monitor|AlwaysOn";
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Common.ActivityHelpers.StopRequestActivity();
+        }
 
         [TestMethod]
         public void SyntheticSourceIsNotSetIfUserProvidedValue()

--- a/Src/Web/Web.Shared.Net.Tests/UserTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/UserTelemetryInitializerTest.cs
@@ -11,6 +11,12 @@
     [TestClass]
     public class UserTelemetryInitializerTest
     {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Common.ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void InitializeDoesNotThrowWhenHttpContextIsNull()
         {

--- a/Src/Web/Web.Shared.Net.Tests/WebTestTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/WebTestTelemetryInitializerTest.cs
@@ -9,6 +9,12 @@
     [TestClass]
     public class WebTestTelemetryInitializerTests
     {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Common.ActivityHelpers.StopRequestActivity();
+        }
+
         [TestMethod]
         public void SyntheticSourceIsNotSetIfUserProvidedValue()
         {

--- a/Src/Web/Web.Shared.Net/ApplicationInsightsHttpModule.cs
+++ b/Src/Web/Web.Shared.Net/ApplicationInsightsHttpModule.cs
@@ -69,6 +69,7 @@
                 {
                     context.BeginRequest += this.OnBeginRequest;
                     context.EndRequest += this.OnEndRequest;
+                    context.PreRequestHandlerExecute += this.OnPreRequestHandlerExecute;
                 }
                 catch (Exception exc)
                 {
@@ -149,6 +150,18 @@
             catch (Exception ex)
             {
                 WebEventSource.Log.HookAddOnSendingHeadersFailedWarning(ex.ToInvariantString());
+            }
+        }
+
+        private void OnPreRequestHandlerExecute(object sender, EventArgs eventArgs)
+        {
+            if (this.isEnabled)
+            {
+                HttpApplication httpApplication = (HttpApplication)sender;
+
+                this.TraceCallback("OnPreRequestHandlerExecute", httpApplication);
+
+                this.requestModule?.OnPreRequestHandlerExecute(httpApplication.Context);
             }
         }
 

--- a/Src/Web/Web.Shared.Net/Implementation/ActivityHelpers.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/ActivityHelpers.cs
@@ -1,5 +1,6 @@
 namespace Microsoft.ApplicationInsights.Common
 {
+    using System;
     using System.Collections.Generic;
 #if NET45
     using System.Diagnostics;
@@ -129,18 +130,18 @@ namespace Microsoft.ApplicationInsights.Common
             requestTelemetry.Context.Operation.ParentId = parentId;
             if (rootId != null)
             {
-                requestTelemetry.Id = AppInsightsActivity.GenerateRequestId(rootId);
+                requestTelemetry.Id = ApplicationInsightsActivity.GenerateRequestId(rootId);
             }
             else if (parentId != null)
             {
-                requestTelemetry.Id = AppInsightsActivity.GenerateRequestId(parentId);
+                requestTelemetry.Id = ApplicationInsightsActivity.GenerateRequestId(parentId);
             }
             else
             {
-                requestTelemetry.Id = AppInsightsActivity.GenerateRequestId();
+                requestTelemetry.Id = ApplicationInsightsActivity.GenerateRequestId();
             }
 
-            requestTelemetry.Context.Operation.Id = AppInsightsActivity.GetRootId(requestTelemetry.Id);
+            requestTelemetry.Context.Operation.Id = ApplicationInsightsActivity.GetRootId(requestTelemetry.Id);
             if (correlationContext != null)
             {
                 foreach (var item in correlationContext)
@@ -193,7 +194,7 @@ namespace Microsoft.ApplicationInsights.Common
             if (!string.IsNullOrEmpty(parentId))
             {
                 correlationContext =
-                    request.Headers.GetNameValueCollectionFromHeader(RequestResponseHeaders.CorrelationContextHeader);
+                    request.UnvalidatedGetHeaders().GetNameValueCollectionFromHeader(RequestResponseHeaders.CorrelationContextHeader);
 
                 bool isHierarchicalId = IsHierarchicalRequestId(parentId);
 

--- a/Src/Web/Web.Shared.Net/Implementation/ActivityHelpers.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/ActivityHelpers.cs
@@ -1,0 +1,289 @@
+namespace Microsoft.ApplicationInsights.Common
+{
+    using System.Collections.Generic;
+#if NET45
+    using System.Diagnostics;
+#endif
+    using System.Web;
+
+    using Microsoft.ApplicationInsights.DataContracts;
+#if NET40
+    using Microsoft.ApplicationInsights.Net40;
+#endif
+    using Microsoft.ApplicationInsights.Web.Implementation;
+
+    internal class ActivityHelpers
+    {
+        internal const string ChildActivityItemName = "Microsoft.AppInsights.Web.Child";
+        internal const string CorrelationContextItemName = "Microsoft.AppInsights.Web.CorrelationContext";
+
+        internal static string RootOperationIdHeaderName { get; set; }
+
+        internal static string ParentOperationIdHeaderName { get; set; }
+
+#if NET45
+        /// <summary>
+        /// Parses incoming request headers: initializes Operation Context and stores it in Activity.
+        /// </summary>
+        /// <param name="context">HttpContext instance.</param>
+        /// <returns>RequestTelemetry with OperationContext parsed from the request.</returns>
+        internal static RequestTelemetry ParseRequest(HttpContext context)
+        {
+            RequestTelemetry requestTelemetry = new RequestTelemetry();
+            var request = context.Request;
+            IDictionary<string, string> correlationContext;
+            string rootId, parentId;
+            if (!TryParseStandardHeaders(request, out rootId, out parentId, out correlationContext))
+            {
+                TryParseCustomHeaders(request, out rootId, out parentId);
+            }
+
+            var requestActivity = new Activity("Microsoft.AppInsights.Web.Request");
+
+            var effectiveParent = rootId ?? parentId;
+            if (effectiveParent != null)
+            {
+                requestActivity.SetParentId(effectiveParent);
+            }
+
+            if (correlationContext != null)
+            {
+                foreach (var item in correlationContext)
+                {
+                    requestActivity.AddBaggage(item.Key, item.Value);
+                    if (!requestTelemetry.Context.Properties.ContainsKey(item.Key))
+                    {
+                        requestTelemetry.Context.Properties.Add(item.Key, item.Value);
+                    }
+                }
+            }
+
+            requestActivity.Start();
+
+            // Initialize requestTelemetry Context immediately: 
+            // even though it will be initialized with Base OperationCorrelationTelemetryInitializer,
+            // activity may be lost in native/managed thread hops.
+            requestTelemetry.Context.Operation.ParentId = parentId;
+            requestTelemetry.Context.Operation.Id = requestActivity.RootId;
+            requestTelemetry.Id = requestActivity.Id;
+
+            return requestTelemetry;
+        }
+
+        /// <summary>
+        /// Starts Activity that provides Operation Context for any telemetry tracked within the scope of current request.
+        /// </summary>
+        /// <param name="context">HttpContext instance.</param>
+        internal static void StartActivity(HttpContext context)
+        {
+            // start an Activity to initialize any telemetry that will be tracked within this request scope
+            // save it in the HttpContext, so we will be able to restore it if it will be lost in managed/native thread hops
+            var childActivity = new Activity(ChildActivityItemName).Start();
+            context.Items[ChildActivityItemName] = childActivity;
+        }
+
+        /// <summary>
+        /// Restores Activity if it was lost.
+        /// </summary>
+        /// <param name="context">HttpContext instance.</param>
+        internal static void RestoreActivityIfLost(HttpContext context)
+        {
+            if (Activity.Current == null)
+            {
+                var lostActivity = context.Items[ChildActivityItemName] as Activity;
+                if (lostActivity != null)
+                {
+                    var restoredActivity = new Activity(lostActivity.OperationName);
+                    restoredActivity.SetParentId(lostActivity.Id);
+                    restoredActivity.SetStartTime(lostActivity.StartTimeUtc);
+                    foreach (var item in lostActivity.Baggage)
+                    {
+                        restoredActivity.AddBaggage(item.Key, item.Value);
+                    }
+
+                    restoredActivity.Start();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Stops activity for child telemetry.
+        /// </summary>
+        internal static void StopActivity()
+        {
+            Activity current = Activity.Current;
+            while (current != null)
+            {
+                if (current.OperationName == ChildActivityItemName)
+                {
+                    current.Stop();
+                    return;
+                }
+
+                current = current.Parent;
+            }
+        }
+
+        /// <summary>
+        /// Stops root, top-most activity, created for current request.
+        /// </summary>
+        internal static void StopRequestActivity()
+        {
+            Activity current = Activity.Current;
+            while (Activity.Current != null)
+            {
+                Activity.Current.Stop();
+            }
+        }
+#else
+#pragma warning disable 618
+        /// <summary>
+        /// Parses incoming request headers; initializes Operation Context and stores it in CallContext.
+        /// </summary>
+        /// <param name="context">HttpContext instance.</param>
+        /// <returns>RequestTelemetry with OperationContext parsed from the request.</returns>
+        internal static RequestTelemetry ParseRequest(HttpContext context)
+        {
+            RequestTelemetry requestTelemetry = new RequestTelemetry();
+            var request = context.Request;
+
+            IDictionary<string, string> correlationContext;
+            string rootId, parentId;
+            if (!TryParseStandardHeaders(request, out rootId, out parentId, out correlationContext))
+            {
+                TryParseCustomHeaders(request, out rootId, out parentId);
+            }
+
+            requestTelemetry.Context.Operation.ParentId = parentId;
+            if (rootId != null)
+            {
+                requestTelemetry.Id = AppInsightsActivity.GenerateRequestId(rootId);
+            }
+            else if (parentId != null)
+            {
+                requestTelemetry.Id = AppInsightsActivity.GenerateRequestId(parentId);
+            }
+            else
+            {
+                requestTelemetry.Id = AppInsightsActivity.GenerateRequestId();
+            }
+
+            requestTelemetry.Context.Operation.Id = AppInsightsActivity.GetRootId(requestTelemetry.Id);
+            if (correlationContext != null)
+            {
+                foreach (var item in correlationContext)
+                {
+                    if (!requestTelemetry.Context.Properties.ContainsKey(item.Key))
+                    {
+                        requestTelemetry.Context.Properties.Add(item.Key, item.Value);
+                    }
+                }
+            }
+
+            context.Items[CorrelationContextItemName] = correlationContext;
+            return requestTelemetry;
+        }
+
+        /// <summary>
+        /// Sets CallContext that provides Operation Context for any telemetry tracked within the scope of current request.
+        /// </summary>
+        /// <param name="context">HttpContext instance.</param>
+        internal static void StartActivity(HttpContext context)
+        {
+            // start an Activity to initialize any telemetry that will be tracked within this request scope
+            // save it in the HttpContext, so we will be able to restore it if it will be lost in managed/native thread hops
+            var requestTelemetry = context.GetRequestTelemetry();
+            var correlationContext = context.Items[CorrelationContextItemName] as IDictionary<string, string>;
+            if (requestTelemetry != null)
+            {
+                CorrelationHelper.SetOperationContext(requestTelemetry, correlationContext);
+            }
+        }
+
+        /// <summary>
+        /// Restores CallContext if it was lost.
+        /// </summary>
+        /// <param name="context">HttpContext instance.</param>
+        internal static void RestoreActivityIfLost(HttpContext context)
+        {
+            var requestTelemetry = context.GetRequestTelemetry();
+            var correlationContext = context.Items[CorrelationContextItemName] as IDictionary<string, string>;
+
+            CorrelationHelper.SetOperationContext(requestTelemetry, correlationContext);
+        }
+
+        /// <summary>
+        /// Cleans up CallContext.
+        /// </summary>
+        internal static void StopActivity()
+        {
+            CorrelationHelper.CleanOperationContext();
+        }
+
+        /// <summary>
+        /// Cleans up CallContext.
+        /// </summary>
+        internal static void StopRequestActivity()
+        {
+            // it just allows to have the same API for Activity/CallContext
+            CorrelationHelper.CleanOperationContext();
+        }
+#pragma warning restore 618
+#endif
+
+        private static bool TryParseStandardHeaders(HttpRequest request, out string rootId, out string parentId, out IDictionary<string, string> correlationContext)
+        {
+            rootId = null;
+            correlationContext = null;
+            parentId = request.UnvalidatedGetHeader(RequestResponseHeaders.RequestIdHeader);
+
+            // don't bother parsing correlation-context if there was no RequestId
+            if (!string.IsNullOrEmpty(parentId))
+            {
+                correlationContext =
+                    request.Headers.GetNameValueCollectionFromHeader(RequestResponseHeaders.CorrelationContextHeader);
+
+                bool isHierarchicalId = IsHierarchicalRequestId(parentId);
+
+                if (correlationContext != null)
+                {
+                    foreach (var item in correlationContext)
+                    {
+                        if (!isHierarchicalId && item.Key == "Id")
+                        {
+                            rootId = item.Value;
+                        }
+                    }
+                }
+
+                return true;
+            }
+
+            parentId = null;
+            return false;
+        }
+
+        private static bool IsHierarchicalRequestId(string requestId)
+        {
+            return !string.IsNullOrEmpty(requestId) && requestId[0] == '|';
+        }
+
+        private static bool TryParseCustomHeaders(HttpRequest request, out string rootId, out string parentId)
+        {
+            parentId = request.UnvalidatedGetHeader(ParentOperationIdHeaderName);
+            rootId = request.UnvalidatedGetHeader(RootOperationIdHeaderName);
+
+            if (rootId?.Length == 0)
+            {
+                rootId = null;
+            }
+
+            if (parentId?.Length == 0)
+            {
+                parentId = null;
+            }
+
+            return rootId != null || parentId != null;
+        }
+    }
+}

--- a/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
@@ -1,7 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Web.Implementation
 {
     using System;
-    using System.Globalization;
     using System.Linq;
     using System.Web;
     using Microsoft.ApplicationInsights.Common;
@@ -17,8 +16,7 @@
                 throw new ArgumentException("platformContext");
             }
 
-            var result = new RequestTelemetry();
-            result.GenerateOperationId();
+            var result = ActivityHelpers.ParseRequest(platformContext);
 
             platformContext.Items.Add(RequestTrackingConstants.RequestTelemetryItemName, result);
             WebEventSource.Log.WebTelemetryModuleRequestTelemetryCreated();

--- a/Src/Web/Web.Shared.Net/OperationCorrelationTelemetryInitializer.cs
+++ b/Src/Web/Web.Shared.Net/OperationCorrelationTelemetryInitializer.cs
@@ -1,10 +1,14 @@
 ﻿namespace Microsoft.ApplicationInsights.Web
 {
+#if NET40
+    using System.Collections.Generic;
+#else
+    using System.Diagnostics;
+#endif
     using System.Web;
     using Common;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Web.Implementation;
 
     /// <summary>
@@ -17,19 +21,27 @@
         /// </summary>
         public OperationCorrelationTelemetryInitializer()
         {
-            this.ParentOperationIdHeaderName = RequestResponseHeaders.StandardParentIdHeader;
-            this.RootOperationIdHeaderName = RequestResponseHeaders.StandardRootIdHeader;
+            ActivityHelpers.ParentOperationIdHeaderName = RequestResponseHeaders.StandardParentIdHeader;
+            ActivityHelpers.RootOperationIdHeaderName = RequestResponseHeaders.StandardRootIdHeader;
         }
 
         /// <summary>
         /// Gets or sets the name of the header to get parent operation Id from.
         /// </summary>
-        public string ParentOperationIdHeaderName { get; set; }
+        public string ParentOperationIdHeaderName
+        {
+            get { return ActivityHelpers.ParentOperationIdHeaderName; }
+            set { ActivityHelpers.ParentOperationIdHeaderName = value; }
+        }
 
         /// <summary>
         /// Gets or sets the name of the header to get root operation Id from.
         /// </summary>
-        public string RootOperationIdHeaderName { get; set; }
+        public string RootOperationIdHeaderName
+        {
+            get { return ActivityHelpers.RootOperationIdHeaderName; }
+            set { ActivityHelpers.RootOperationIdHeaderName = value; }
+        }
 
         /// <summary>
         /// Implements initialization logic.
@@ -42,50 +54,59 @@
             RequestTelemetry requestTelemetry,
             ITelemetry telemetry)
         {
-            OperationContext parentContext = requestTelemetry.Context.Operation;
-            HttpRequest currentRequest = platformContext.Request;
-
-            // Make sure that RequestTelemetry is initialized.
-            if (string.IsNullOrEmpty(parentContext.ParentId))
-            {
-                if (!string.IsNullOrWhiteSpace(this.ParentOperationIdHeaderName))
-                {
-                    var parentId = currentRequest.UnvalidatedGetHeader(this.ParentOperationIdHeaderName);
-                    if (!string.IsNullOrEmpty(parentId))
-                    {
-                        parentContext.ParentId = parentId;
-                    }
-                }
-            }
-
-            if (string.IsNullOrEmpty(parentContext.Id))
-            {
-                if (!string.IsNullOrWhiteSpace(this.RootOperationIdHeaderName))
-                {
-                    var rootId = currentRequest.UnvalidatedGetHeader(this.RootOperationIdHeaderName);
-                    if (!string.IsNullOrEmpty(rootId))
-                    {
-                        parentContext.Id = rootId;
-                    }
-                }
-
-                if (string.IsNullOrEmpty(parentContext.Id))
-                {
-                    parentContext.Id = requestTelemetry.Id;
-                }
-            }
-
+            // Telemetry is initialized by Base SDK OperationCorrelationTelemetryInitializer from the call context /Current Activity
+            // However we still may lose CorrelationContext/AsyncLocal due to IIS managed/native thread hops. 
+            // We protect from it with PreRequestHandlerExecute event, that happens right before the handler
+            // However some telemetry may be reported between BeginRequest and PreRequestHandlerExecute in the HttpModule pipeline
+            // So this telemetry initializer works when:
+            //   - telemetry was tracked before PreRequestHandlerExecute
+            //   - AND execution context was lost in the HttpModule pipeline: base SDK OperationCorrelationTelemetryInitializer had nothing to initialize telemetry with
+            //   - AND Telemetry was tracked from the thread that has HttpContext.Current (synchronously in HttpModule)
+            //
+            // In other cases, telemetry is not guaranteed to be properly initialized:
+            // - if tracked in custom HttpModule
+            // - AND in async method or after async method was invoked
+            // - AND when the execution context is lost
             if (telemetry != requestTelemetry)
             {
+                if (!string.IsNullOrEmpty(telemetry.Context.Operation.Id))
+                {
+                    // telemetry is already initialized
+                    return;
+                }
+
+                telemetry.Context.Operation.Id = requestTelemetry.Context.Operation.Id;
                 if (string.IsNullOrEmpty(telemetry.Context.Operation.ParentId))
                 {
                     telemetry.Context.Operation.ParentId = requestTelemetry.Id;
                 }
-
-                if (string.IsNullOrEmpty(telemetry.Context.Operation.Id))
+#if NET45
+                var activity = platformContext.Items[ActivityHelpers.ChildActivityItemName] as Activity;
+                if (activity == null)
                 {
-                    telemetry.Context.Operation.Id = parentContext.Id;
+                    return;
                 }
+
+                foreach (var item in activity.Baggage)
+                {
+                    if (!telemetry.Context.Properties.ContainsKey(item.Key))
+                    {
+                        telemetry.Context.Properties.Add(item);
+                    }
+                }
+#else
+                var correlationContext = platformContext.Items[ActivityHelpers.CorrelationContextItemName] as IDictionary<string, string>;
+                if (correlationContext != null)
+                {
+                    foreach (var item in correlationContext)
+                    {
+                        if (!telemetry.Context.Properties.ContainsKey(item.Key))
+                        {
+                            telemetry.Context.Properties.Add(item);
+                        }
+                    }
+                }
+#endif
             }
         }
     }

--- a/Src/Web/Web.Shared.Net/OperationCorrelationTelemetryInitializer.cs
+++ b/Src/Web/Web.Shared.Net/OperationCorrelationTelemetryInitializer.cs
@@ -30,8 +30,18 @@
         /// </summary>
         public string ParentOperationIdHeaderName
         {
-            get { return ActivityHelpers.ParentOperationIdHeaderName; }
-            set { ActivityHelpers.ParentOperationIdHeaderName = value; }
+            get
+            {
+                return ActivityHelpers.ParentOperationIdHeaderName;
+            }
+
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    ActivityHelpers.ParentOperationIdHeaderName = value;
+                }
+            }
         }
 
         /// <summary>
@@ -39,8 +49,18 @@
         /// </summary>
         public string RootOperationIdHeaderName
         {
-            get { return ActivityHelpers.RootOperationIdHeaderName; }
-            set { ActivityHelpers.RootOperationIdHeaderName = value; }
+            get
+            {
+                return ActivityHelpers.RootOperationIdHeaderName;
+            }
+
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    ActivityHelpers.RootOperationIdHeaderName = value;
+                }
+            }
         }
 
         /// <summary>

--- a/Src/Web/Web.Shared.Net/OperationCorrelationTelemetryInitializer.cs
+++ b/Src/Web/Web.Shared.Net/OperationCorrelationTelemetryInitializer.cs
@@ -101,7 +101,7 @@
                     telemetry.Context.Operation.ParentId = requestTelemetry.Id;
                 }
 #if NET45
-                var activity = platformContext.Items[ActivityHelpers.ChildActivityItemName] as Activity;
+                var activity = platformContext.Items[ActivityHelpers.RequestActivityItemName] as Activity;
                 if (activity == null)
                 {
                     return;

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -79,12 +79,7 @@
                 return;
             }
 
-            var telemetry = context.GetRequestTelemetry();
-            if (telemetry == null)
-            {
-                telemetry = context.CreateRequestTelemetryPrivate();
-                ActivityHelpers.StartActivity(context);
-            }
+            var telemetry = context.ReadOrCreateRequestTelemetryPrivate();
 
             // NB! Whatever is saved in RequestTelemetry on Begin is not guaranteed to be sent because Begin may not be called; Keep it in context
             // In WCF there will be 2 Begins and 1 End. We need time from the first one
@@ -133,7 +128,7 @@
 
             // we store Activity/Call context to initialize child telemtery within the scope of this request,
             // so it's time to stop it
-            ActivityHelpers.StopActivity();
+            ActivityHelpers.StopRequestActivity();
             var requestTelemetry = context.ReadOrCreateRequestTelemetryPrivate();
             requestTelemetry.Stop();
 
@@ -200,7 +195,6 @@
             }
 
             this.telemetryClient.TrackRequest(requestTelemetry);
-            ActivityHelpers.StopRequestActivity();
         }
 
         /// <summary>

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -167,7 +167,7 @@
 
                 try
                 {
-                    sourceAppId = context.Request.Headers.GetNameValueHeaderValue(RequestResponseHeaders.RequestContextHeader, RequestResponseHeaders.RequestContextSourceKey);
+                    sourceAppId = context.Request.UnvalidatedGetHeaders().GetNameValueHeaderValue(RequestResponseHeaders.RequestContextHeader, RequestResponseHeaders.RequestContextSourceKey);
                 }
                 catch (Exception ex)
                 {

--- a/Src/Web/Web.Shared.Net/Web.Shared.Net.projitems
+++ b/Src/Web/Web.Shared.Net/Web.Shared.Net.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AuthenticatedUserIdTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpContextBaseExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpContextExtension.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ActivityHelpers.cs" />    
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpRequestExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\RequestTrackingConstants.cs" />

--- a/Test/Web/FunctionalTests/FunctionalTests/WebAppFW45Tests.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/WebAppFW45Tests.cs
@@ -381,11 +381,17 @@
             Assert.AreEqual(this.Config.IKey, items[requestItemIndex].iKey, "IKey is not the same as in config file");
             Assert.AreEqual(this.Config.IKey, items[exceptionItemIndex].iKey, "IKey is not the same as in config file");
 
-            // Check that request id is set in exception operation Id
+            // Check that request id is set in exception operation parentId
             Assert.AreEqual(
-                ((TelemetryItem<RequestData>)items[requestItemIndex]).data.baseData.id, 
-                items[exceptionItemIndex].tags[new ContextTagKeys().OperationId], 
-                "Operation Id is not same as Request id");    
+                ((TelemetryItem<RequestData>)items[requestItemIndex]).data.baseData.id,
+                items[exceptionItemIndex].tags[new ContextTagKeys().OperationParentId],
+                "Exception ParentId is not same as Request id");
+
+            // Check that request and exception have the same operation id
+            Assert.AreEqual(
+                items[requestItemIndex].tags[new ContextTagKeys().OperationId],
+                items[exceptionItemIndex].tags[new ContextTagKeys().OperationId],
+                "Exception Operation Id is not same as Request Operation Id");
         }
 
         /// <summary>


### PR DESCRIPTION
This change implements telemetry correlation
1. Supports [HTTP protocol](https://github.com/lmolkova/correlation/blob/master/http_protocol_proposal_v1.md)
2. Uses [Activity](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md) to store and pass correlation Ids and context

--------
Depends on https://github.com/Microsoft/ApplicationInsights-dotnet/pull/505. Do not merge until base changes are approved