### PR TITLE
PerformanceCollector.UnitTests: Use AppInsights Base SDK for 4.0 to run 4.0 tests

### DIFF
--- a/Src/PerformanceCollector/Unit.Tests/Test.Common.Sdk.Net40.targets
+++ b/Src/PerformanceCollector/Unit.Tests/Test.Common.Sdk.Net40.targets
@@ -2,6 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<ItemGroup>
+		<Reference Include="Microsoft.ApplicationInsights">
+			<HintPath>$(BinRoot)\$(Configuration)\Src\Web\Web.Net40\Microsoft.ApplicationInsights.dll</HintPath>
+		</Reference>
 		<Reference Include="Microsoft.AI.Web">
 			<HintPath>$(BinRoot)\$(Configuration)\Src\Web\Web.Net40\Microsoft.AI.Web.dll</HintPath>
 		</Reference>

--- a/Src/PerformanceCollector/Unit.Tests/Unit.Tests.csproj
+++ b/Src/PerformanceCollector/Unit.Tests/Unit.Tests.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build07987\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta1-build07987\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Src/PerformanceCollector/Unit.Tests/packages.config
+++ b/Src/PerformanceCollector/Unit.Tests/packages.config
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build07987" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build07987" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
-  <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
+  <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
PerformanceCollector UnitTests target NET 4.5 framework.
project.json has mixed targets  - 4.0 and 4.5, base AppInsights SDK for 4.5 was referenced.

**However they run Web.Net40.Tests.dll.**
It causes TypeLoadException on the Web40 tests, that use new API in AppInsights Base available on 4.0 only.

I have changed base SDK AppInsights.dll to be 4.0 and it did the trick, but something is definitely strange about those tests

I really don't understand why Web tests should run again, but from the PerformanceCollector.UnitTests folder (in build definition all tests run and UnitTests reference Web40.Tests.dll):

```
\Src\PerformanceCollector\**\*tests.dll;
```

**So, may be the correct solution would be not to run Web40 tests again.**

Please advise

