### PR TITLE
Add dependency to DiagnosticSource in nuspecs

### DIFF
--- a/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
+++ b/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -36,8 +36,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25210-01\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/DependencyCollector/Net45.Tests/packages.config
+++ b/Src/DependencyCollector/Net45.Tests/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build08904" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net451" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25210-01" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />

--- a/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
+++ b/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -34,8 +34,7 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25210-01\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/DependencyCollector/Net45/packages.config
+++ b/Src/DependencyCollector/Net45/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build08904" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25210-01" targetFramework="net45" />
 </packages>

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Copyright>Copyright © Microsoft. All Rights Reserved.</Copyright>
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta1-build08904" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0-beta-25130-03" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0-preview1-25210-01" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/Src/DependencyCollector/NuGet/Package.nuspec
+++ b/Src/DependencyCollector/NuGet/Package.nuspec
@@ -23,12 +23,13 @@
       <group targetFramework="net45">
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25210-01" />
       </group>
       <group targetFramework="netcoreapp1.0">
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.Extensions.DiagnosticAdapter" version="1.0.0" />
         <dependency id="NETStandard.Library" version="1.6.1" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.3.0-preview1-24530-04" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25210-01" />
       </group>
     </dependencies>
   </metadata>

--- a/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -36,8 +36,7 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25204-02\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25210-01\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/Web/Web.Net45.Tests/packages.config
+++ b/Src/Web/Web.Net45.Tests/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build08904" targetFramework="net451" />
   <package id="OpenCover" version="4.6.519" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net451" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25204-02" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25210-01" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />

--- a/Src/Web/Web.Net45/Web.Net45.csproj
+++ b/Src/Web/Web.Net45/Web.Net45.csproj
@@ -32,7 +32,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25204-01\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25210-01\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/Web/Web.Net45/packages.config
+++ b/Src/Web/Web.Net45/packages.config
@@ -1,10 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta1-build08904" targetFramework="net45" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0-preview1-10407-02" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25204-01" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25210-01" targetFramework="net45" />
 </packages>
-

--- a/Src/Web/Web.Nuget/Package.nuspec
+++ b/Src/Web/Web.Nuget/Package.nuspec
@@ -25,6 +25,7 @@
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="$version$" />
         <dependency id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0-preview1-10407-02" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25210-01" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This change consolidates different versions of DiagnosticSource referenced and adds dependency to DiagnosticSource in Web and DepenendecyCollector nuspec files