### PR TITLE
DependencyCollector for .net core should support netstandard1.3

### DIFF
--- a/Src/Common/CorrelationIdLookupHelper.cs
+++ b/Src/Common/CorrelationIdLookupHelper.cs
@@ -8,7 +8,7 @@
     using System.Threading.Tasks;
     using Extensibility;
     using Extensibility.Implementation.Tracing;
-#if NETCORE
+#if NETSTANDARD
     using System.Net.Http;
 #endif
 
@@ -174,11 +174,11 @@
         {
             try
             {
-#if !NETCORE
+#if !NETSTANDARD
                 SdkInternalOperationsMonitor.Enter();
 #endif
                 Uri appIdEndpoint = this.GetAppIdEndPointUri(instrumentationKey);
-#if !NETCORE
+#if !NETSTANDARD
                 WebRequest request = WebRequest.Create(appIdEndpoint);
                 request.Method = "GET";
 
@@ -196,7 +196,7 @@
             }
             finally
             {
-#if !NETCORE
+#if !NETSTANDARD
                 SdkInternalOperationsMonitor.Exit();
 #endif
             }
@@ -257,7 +257,7 @@
         /// <param name="ex">Exception indicating failure.</param>
         private void RegisterFailure(string instrumentationKey, Exception ex)
         {
-#if !NETCORE
+#if !NETSTANDARD
             var ae = ex as AggregateException;
 
             if (ae != null)
@@ -281,7 +281,7 @@
             {
 #endif
                 this.failingInstrumenationKeys[instrumentationKey] = new FailedResult(DateTime.UtcNow);
-#if !NETCORE
+#if !NETSTANDARD
             }
 #endif
 

--- a/Src/Common/CrossComponentCorrelationEventSource.cs
+++ b/Src/Common/CrossComponentCorrelationEventSource.cs
@@ -1,10 +1,10 @@
 ﻿namespace Microsoft.ApplicationInsights.Common
 {
     using System;
-#if NETCORE || NET45
+#if NETSTANDARD || NET45
     using System.Diagnostics.Tracing;
 #endif
-#if NETCORE
+#if NETSTANDARD
     using System.Reflection;
 #endif
     using Extensibility.Implementation.Tracing;
@@ -83,13 +83,11 @@
             string name;
             try
             {
-#if NETCORE
 #if NETSTANDARD1_3
                 name = "Undefined"; // netstandard1.3 does not have API to retrieve Assembly/AppDomain name
-#else // not NETSTANDARD1_3
+#elif NETSTANDARD1_5
                 name = Assembly.GetEntryAssembly().FullName;
-#endif 
-#else // not NETCORE
+#else // not NETSTANDARD
                 name = AppDomain.CurrentDomain.FriendlyName;
 #endif
             }

--- a/Src/Common/CrossComponentCorrelationEventSource.cs
+++ b/Src/Common/CrossComponentCorrelationEventSource.cs
@@ -84,8 +84,12 @@
             try
             {
 #if NETCORE
+#if NETSTANDARD1_3
+                name = "Undefined"; // netstandard1.3 does not have API to retrieve Assembly/AppDomain name
+#else // not NETSTANDARD1_3
                 name = Assembly.GetEntryAssembly().FullName;
-#else
+#endif 
+#else // not NETCORE
                 name = AppDomain.CurrentDomain.FriendlyName;
 #endif
             }

--- a/Src/Common/CrossComponentCorrelationEventSource.cs
+++ b/Src/Common/CrossComponentCorrelationEventSource.cs
@@ -84,7 +84,13 @@
             try
             {
 #if NETSTANDARD1_3
-                name = "Undefined"; // netstandard1.3 does not have API to retrieve Assembly/AppDomain name
+                // Assembly.GetEntryAssembly() is not available on netstandard1.3, but is available in runtime
+                var getEntryAssemblyMethod =
+                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.NonPublic) ??
+                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.Public);
+
+                var assembly = getEntryAssemblyMethod.Invoke(obj: null, parameters: Array.Empty<object>()) as Assembly;
+                name = assembly.FullName;
 #elif NETSTANDARD1_5
                 name = Assembly.GetEntryAssembly().FullName;
 #else // not NETSTANDARD

--- a/Src/Common/CrossComponentCorrelationEventSource.cs
+++ b/Src/Common/CrossComponentCorrelationEventSource.cs
@@ -86,8 +86,7 @@
 #if NETSTANDARD1_3
                 // Assembly.GetEntryAssembly() is not available on netstandard1.3, but is available in runtime
                 var getEntryAssemblyMethod =
-                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.NonPublic) ??
-                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.Public);
+                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
 
                 var assembly = getEntryAssemblyMethod.Invoke(obj: null, parameters: Array.Empty<object>()) as Assembly;
                 name = assembly.FullName;

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>2.4.0-beta1</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.3;netstandard1.5</TargetFrameworks>
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <DelaySign>true</DelaySign>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.AI.DependencyCollector</AssemblyName>
@@ -17,9 +17,6 @@
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD1_3</DefineConstants>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Copyright>Copyright � Microsoft. All Rights Reserved.</Copyright>
+    <Copyright>Copyright © Microsoft. All Rights Reserved.</Copyright>
     <VersionPrefix>2.4.0-beta1</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard1.5</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
     <DelaySign>true</DelaySign>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.AI.DependencyCollector</AssemblyName>
@@ -16,6 +17,9 @@
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <DefineConstants>$(DefineConstants);NETSTANDARD1_3</DefineConstants>    
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,7 +34,4 @@
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/Src/DependencyCollector/NuGet/Package.nuspec
+++ b/Src/DependencyCollector/NuGet/Package.nuspec
@@ -53,5 +53,11 @@
     <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.3\Microsoft.AI.DependencyCollector.dll" target="lib\netstandard1.3" />
     <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.3\Microsoft.AI.DependencyCollector.pdb" target="lib\netstandard1.3" />
     <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.3\Microsoft.AI.DependencyCollector.xml" target="lib\netstandard1.3" />
+
+    <!-- For .NET Standard 1.5 projects -->
+    <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.5\Microsoft.AI.DependencyCollector.dll" target="lib\netstandard1.5" />
+    <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.5\Microsoft.AI.DependencyCollector.pdb" target="lib\netstandard1.5" />
+    <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.5\Microsoft.AI.DependencyCollector.xml" target="lib\netstandard1.5" />
+
   </files>
 </package>

--- a/Src/DependencyCollector/NuGet/Package.nuspec
+++ b/Src/DependencyCollector/NuGet/Package.nuspec
@@ -25,7 +25,7 @@
         <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" />
         <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25210-01" />
       </group>
-      <group targetFramework="netstandard1.6">
+      <group targetFramework="netstandard1.3">
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.Extensions.DiagnosticAdapter" version="1.1.0" />
         <dependency id="Microsoft.Extensions.PlatformAbstractions" version="1.1.0" />
@@ -49,9 +49,9 @@
     <file src="$configuration$\Src\DependencyCollector\Net45\Microsoft.AI.DependencyCollector.pdb" target="lib\net45" />
     <file src="$configuration$\Src\DependencyCollector\Net45\Microsoft.AI.DependencyCollector.xml" target="lib\net45" />
 
-    <!-- For .NET Standard 1.6 projects -->
-    <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.6\Microsoft.AI.DependencyCollector.dll" target="lib\netstandard1.6" />
-    <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.6\Microsoft.AI.DependencyCollector.pdb" target="lib\netstandard1.6" />
-    <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.6\Microsoft.AI.DependencyCollector.xml" target="lib\netstandard1.6" />
+    <!-- For .NET Standard 1.3 projects -->
+    <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.3\Microsoft.AI.DependencyCollector.dll" target="lib\netstandard1.3" />
+    <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.3\Microsoft.AI.DependencyCollector.pdb" target="lib\netstandard1.3" />
+    <file src="$configuration$\Src\DependencyCollector\NetCore\netstandard1.3\Microsoft.AI.DependencyCollector.xml" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -6,7 +6,7 @@
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-#if !NETCORE
+#if !NETSTANDARD
     using Microsoft.Diagnostics.Instrumentation.Extensions.Intercept;
 #else
     using Microsoft.Extensions.PlatformAbstractions;
@@ -19,14 +19,14 @@
     {
         private readonly object lockObject = new object();
 
-#if !NET40 && !NETCORE
+#if !NET40 && !NETSTANDARD
         // Net40 does not support framework event source
         private HttpDiagnosticSourceListener httpDiagnosticSourceListener;
         private FrameworkHttpEventListener httpEventListener;
         private FrameworkSqlEventListener sqlEventListener;
 #endif
 
-#if !NETCORE
+#if !NETSTANDARD
         private ProfilerSqlCommandProcessing sqlCommandProcessing;
         private ProfilerSqlConnectionProcessing sqlConnectionProcessing;
         private ProfilerHttpProcessing httpProcessing;        
@@ -108,7 +108,7 @@
                         {                            
                             this.telemetryConfiguration = configuration;
 
-#if !NETCORE
+#if !NETSTANDARD
                             // Net40 only supports runtime instrumentation
                             // Net45 supports either but not both to avoid duplication
                             this.InitializeForRuntimeInstrumentationOrFramework();
@@ -119,7 +119,7 @@
                         catch (Exception exc)
                         {
                             string clrVersion;
-#if NETCORE
+#if NETSTANDARD
                             clrVersion = PlatformServices.Default.Application.RuntimeFramework.FullName;
 #else
                             clrVersion = Environment.Version.ToString();
@@ -133,7 +133,7 @@
             }
         }
 
-#if !NETCORE
+#if !NETSTANDARD
         internal virtual void InitializeForRuntimeProfiler()
         {
             // initialize instrumentation extension
@@ -173,7 +173,7 @@
             {
                 if (disposing)
                 {
-#if !NET40 && !NETCORE
+#if !NET40 && !NETSTANDARD
                     // Net40 does not support framework event source and diagnostic source
                     if (this.httpDiagnosticSourceListener != null)
                     {
@@ -196,7 +196,7 @@
             }
         }
 
-#if !NETCORE
+#if !NETSTANDARD
         /// <summary>
         /// Initialize for framework event source (not supported for Net40).
         /// </summary>

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -269,8 +269,7 @@
 #if NETSTANDARD1_3
                 // Assembly.GetEntryAssembly() is not available on netstandard1.3, but is available in runtime
                 var getEntryAssemblyMethod =
-                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.NonPublic) ??
-                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.Public);
+                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
 
                 var assembly = getEntryAssemblyMethod.Invoke(obj: null, parameters: Array.Empty<object>()) as Assembly;
                 name = assembly.FullName;

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -267,7 +267,13 @@
             try
             {
 #if NETSTANDARD1_3
-                name = "Undefined"; // netstandard1.3 does not have API to retrieve Assembly/AppDomain name
+                // Assembly.GetEntryAssembly() is not available on netstandard1.3, but is available in runtime
+                var getEntryAssemblyMethod =
+                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.NonPublic) ??
+                    typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.Public);
+
+                var assembly = getEntryAssemblyMethod.Invoke(obj: null, parameters: Array.Empty<object>()) as Assembly;
+                name = assembly.FullName;
 #elif NETSTANDARD1_5
                 name = Assembly.GetEntryAssembly().FullName;
 #else // not NETSTANDARD

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -1,11 +1,11 @@
 ﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
-#if NETCORE || NET45
+#if NETSTANDARD || NET45
     using System.Diagnostics.Tracing;
 #endif
     using System.Globalization;
-#if NETCORE
+#if NETSTANDARD
     using System.Reflection;
 #endif
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
@@ -266,13 +266,11 @@
             string name;
             try
             {
-#if NETCORE
 #if NETSTANDARD1_3
                 name = "Undefined"; // netstandard1.3 does not have API to retrieve Assembly/AppDomain name
-#else // not NETSTANDARD1_3
+#elif NETSTANDARD1_5
                 name = Assembly.GetEntryAssembly().FullName;
-#endif 
-#else // not NETCORE
+#else // not NETSTANDARD
                 name = AppDomain.CurrentDomain.FriendlyName;
 #endif
             }

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -267,8 +267,12 @@
             try
             {
 #if NETCORE
+#if NETSTANDARD1_3
+                name = "Undefined"; // netstandard1.3 does not have API to retrieve Assembly/AppDomain name
+#else // not NETSTANDARD1_3
                 name = Assembly.GetEntryAssembly().FullName;
-#else
+#endif 
+#else // not NETCORE
                 name = AppDomain.CurrentDomain.FriendlyName;
 #endif
             }

--- a/Src/Web/Web.Net45/Implementation/SdkVersionUtils.cs
+++ b/Src/Web/Web.Net45/Implementation/SdkVersionUtils.cs
@@ -4,7 +4,7 @@
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
-#if NETCORE
+#if NETSTANDARD
     using System.Collections.Generic;
 #endif
 
@@ -15,8 +15,8 @@
             // Since dependencySource is no longer set, sdk version is prepended with information which can identify whether RDD was collected by profiler/framework
             // For directly using TrackDependency(), version will be simply what is set by core
             Type sdkVersionUtilsType = typeof(SdkVersionUtils);
-            
-#if NETCORE
+
+#if NETSTANDARD
             IEnumerable<Attribute> assemblyCustomAttributes = sdkVersionUtilsType.GetTypeInfo().Assembly.GetCustomAttributes();
 #else
             object[] assemblyCustomAttributes = sdkVersionUtilsType.Assembly.GetCustomAttributes(false);


### PR DESCRIPTION
DependencyCollector for .NET Core will be used by AI AspNetCore SDK.
Core SDK will target netstandard1.3 (since AspNetCore itself targets this).

In order to collect dependencies from Http client on netstandard 1.3, DependencyCollector target should be aligned with Core SDK