### PR TITLE
Fix NullReferenceException if there was no current activity

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
@@ -217,9 +217,10 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         if (webRequest.Headers[RequestResponseHeaders.CorrelationContextHeader] == null)
                         {
 #if NET45
-                            if (Activity.Current.Baggage.Any())
+                            var currentActivity = Activity.Current;
+                            if (currentActivity != null && currentActivity.Baggage.Any())
                             {
-                                webRequest.Headers.SetHeaderFromNameValueCollection(RequestResponseHeaders.CorrelationContextHeader, Activity.Current.Baggage);
+                                webRequest.Headers.SetHeaderFromNameValueCollection(RequestResponseHeaders.CorrelationContextHeader, currentActivity.Baggage);
                             }
 #else
 #pragma warning disable 618


### PR DESCRIPTION
The outgoing request is tracked outside of parent incoming request, so the Activity.Current could be null.
Unit tests cannot discover the problem, since all exceptions are swallowed.

```
System.NullReferenceException:
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.HttpProcessing.OnBegin (Microsoft.AI.DependencyCollector, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.HttpDiagnosticSourceListener.OnNext (Microsoft.AI.DependencyCollector, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at System.Diagnostics.DiagnosticListener.Write (System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.HttpHandlerDiagnosticListener+HttpWebRequestArrayList.Add (Microsoft.AI.DependencyCollector, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at System.Net.Connection.StartRequest (System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Net.Connection.SubmitRequest (System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Net.ServicePoint.SubmitRequest (System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Net.HttpWebRequest.SubmitRequest (System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Net.HttpWebRequest.GetRequestStream (System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Net.HttpWebRequest.GetRequestStream (System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse.QuickPulseServiceClient.SendRequest (Microsoft.AI.PerfCounterCollector, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse.QuickPulseCollectionStateManager.UpdateState (Microsoft.AI.PerfCounterCollector, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule.StateThreadWorker (Microsoft.AI.PerfCounterCollector, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
   at System.Threading.ExecutionContext.RunInternal (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Threading.ExecutionContext.Run (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Threading.ExecutionContext.Run (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Threading.ThreadHelper.ThreadStart (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
```