### PR TITLE
Set operationName on context and emit example exception per thread

### DIFF
--- a/Src/WindowsServer/WindowsServer.Shared/FirstChanceExceptionStatisticsTelemetryModule.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/FirstChanceExceptionStatisticsTelemetryModule.cs
@@ -26,6 +26,9 @@
         internal const double CurrentWeight = .7;
         internal const double NewWeight = .3;
         internal const long TicksMovingAverage = 100000000; // 10 seconds
+
+        internal static readonly string OperationNameTag = "ai.operation.name";
+
         internal long MovingAverageTimeout;
         internal double TargetMovingAverage = 5000;
 
@@ -120,7 +123,24 @@
 
         internal bool WasExceptionTracked(Exception exception)
         {
-            bool wasTracked = IsTracked(exception);
+            // some exceptions like MemoryOverflow, ThreadAbort or ExecutionEngine are pre-instantiated 
+            // so the .Data is not writable. Also it can be null in certain cases.
+            if (exception.Data != null && !exception.Data.IsReadOnly)
+            {
+                string trackingId = "MS." + Thread.CurrentThread.ManagedThreadId.ToString(CultureInfo.InvariantCulture);
+
+                if (exception.Data.Contains(trackingId) == true)
+                {
+                    return true;
+                }
+                else
+                {
+                    // mark exception as tracked
+                    exception.Data[trackingId] = null; // The value is unimportant. It's just a sentinel.
+                }
+            }
+
+            return false;
 
             //// This is temporarily being commented out to capture outer exceptions. It will be modified later. 
             ////if (!wasTracked)
@@ -147,26 +167,6 @@
             ////        }
             ////    }
             ////}
-
-            // some exceptions like MemoryOverflow, ThreadAbort or ExecutionEngine are pre-instantiated 
-            // so the .Data is now writable. Also it may be null in certain cases
-            if (exception.Data != null && !exception.Data.IsReadOnly)
-            {
-                // mark exception as tracked
-                exception.Data[Thread.CurrentThread.ManagedThreadId] = null; // The value is unimportant. It's just a sentinel.
-            }
-
-            return wasTracked;
-        }
-
-        private static bool IsTracked(Exception exception)
-        {
-            if (exception.Data != null)
-            {
-                return exception.Data.Contains(Thread.CurrentThread.ManagedThreadId);
-            }
-
-            return false;
         }
 
         /// <summary>
@@ -318,7 +318,7 @@
 
             if (SdkInternalOperationsMonitor.IsEntered())
             {
-                dimensions.Add("operationName", "AI (Internal)");
+                dimensions.Add(OperationNameTag, "AI (Internal)");
             }
             else
             {
@@ -333,7 +333,7 @@
                 {
                     refinedOperationName = this.GetDimCappedString(operationName, this.operationNameValues, OperationNameCacheSize);
 
-                    dimensions.Add("operationName", refinedOperationName);
+                    dimensions.Add(OperationNameTag, refinedOperationName);
                 }
             }
 

--- a/Src/WindowsServer/WindowsServer.Shared/FirstChanceExceptionStatisticsTelemetryModule.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/FirstChanceExceptionStatisticsTelemetryModule.cs
@@ -38,12 +38,6 @@
         private const int UNLOCKED = 0;
 
         /// <summary>
-        /// A key into an <see cref="Exception"/> object's <see cref="Exception.Data"/> dictionary
-        /// used to indicate that the exception is being tracked.
-        /// </summary>
-        private static readonly object ExceptionIsTracked = new object();
-
-        /// <summary>
         /// This object prevents double entry into the exception callback.
         /// </summary>
         [ThreadStatic]
@@ -159,7 +153,7 @@
             if (exception.Data != null && !exception.Data.IsReadOnly)
             {
                 // mark exception as tracked
-                exception.Data[ExceptionIsTracked] = null; // The value is unimportant. It's just a sentinel.
+                exception.Data[Thread.CurrentThread.ManagedThreadId] = null; // The value is unimportant. It's just a sentinel.
             }
 
             return wasTracked;
@@ -169,7 +163,7 @@
         {
             if (exception.Data != null)
             {
-                return exception.Data.Contains(ExceptionIsTracked);
+                return exception.Data.Contains(Thread.CurrentThread.ManagedThreadId);
             }
 
             return false;

--- a/Src/WindowsServer/WindowsServer.Shared/Implementation/MetricManager.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/Implementation/MetricManager.cs
@@ -24,6 +24,7 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Platform;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
@@ -409,9 +410,12 @@
             {
                 foreach (KeyValuePair<string, string> property in metric.Dimensions)
                 {
-                    if (string.Compare(property.Key, "operationName") == 0)
+                    if (string.Compare(property.Key, FirstChanceExceptionStatisticsTelemetryModule.OperationNameTag, StringComparison.Ordinal) == 0)
                     {
-                        telemetry.Context.Operation.Name = property.Value;
+                        if (string.IsNullOrEmpty(property.Value) == false)
+                        {
+                            telemetry.Context.Operation.Name = property.Value;
+                        }
                     }
                     else
                     {

--- a/Src/WindowsServer/WindowsServer.Shared/Implementation/MetricManager.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/Implementation/MetricManager.cs
@@ -409,7 +409,14 @@
             {
                 foreach (KeyValuePair<string, string> property in metric.Dimensions)
                 {
-                    telemetry.Properties.Add(property);
+                    if (string.Compare(property.Key, "operationName") == 0)
+                    {
+                        telemetry.Context.Operation.Name = property.Value;
+                    }
+                    else
+                    {
+                        telemetry.Properties.Add(property);
+                    }
                 }
             }
 


### PR DESCRIPTION
Sets operationName on the context and will emit an example exception for different threads.

Unit tests will be coming.