### PR TITLE
Separated Aspnet core dependency collector functional test

### DIFF
--- a/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCoreHttpTests.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCoreHttpTests.cs
@@ -1,0 +1,153 @@
+﻿namespace FuncTest
+{
+    using System;    
+    using System.Linq;
+    using AI;
+    using FuncTest.Helpers;
+    using FuncTest.Serialization;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;    
+
+    /// <summary>
+    /// Tests Dependency Collector Functionality for a WebApplication written in Dotnet Core.
+    /// </summary>
+    [TestClass]
+    public class AspNetCoreHttpTests
+    {
+        internal const string AspxCoreAppFolder = ".\\AspxCore";
+        internal static DotNetCoreTestWebApplication AspxCoreTestWebApplication { get; private set; }
+
+        public TestContext TestContext { get; set; }
+
+        [ClassInitialize]
+        public static void MyClassInitialize(TestContext testContext)
+        {
+            AspxCoreTestWebApplication = new DotNetCoreTestWebApplication
+            {
+                AppName = "AspxCore",
+                ExternalCallPath = "external/calls",
+                Port = DeploymentAndValidationTools.AspxCorePort,
+            };
+            DeploymentAndValidationTools.Initialize(new TestWebApplication[] { AspxCoreTestWebApplication }, false);
+        }
+
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {            
+            DeploymentAndValidationTools.CleanUp(new TestWebApplication[] { AspxCoreTestWebApplication }, false);
+        }
+
+        [TestInitialize]
+        public void MyTestInitialize()
+        {
+            DeploymentAndValidationTools.SdkEventListener.Start();
+        }
+
+        [TestCleanup]
+        public void MyTestCleanup()
+        {
+            Assert.IsFalse(DeploymentAndValidationTools.SdkEventListener.FailureDetected, "Failure is detected. Please read test output logs.");
+            DeploymentAndValidationTools.SdkEventListener.Stop();
+        }               
+
+        private static void EnsureDotNetCoreInstalled()
+        {
+            string output = "";
+            string error = "";
+
+            if (!DotNetCoreProcess.HasDotNetExe())
+            {
+                Assert.Inconclusive(".Net Core is not installed");
+            }
+            else
+            {
+                DotNetCoreProcess process = new DotNetCoreProcess("--version")
+                    .RedirectStandardOutputTo((string outputMessage) => output += outputMessage)
+                    .RedirectStandardErrorTo((string errorMessage) => error += errorMessage)
+                    .Run();
+
+                if (process.ExitCode.Value != 0 || !string.IsNullOrEmpty(error))
+                {
+                    Assert.Inconclusive(".Net Core is not installed");
+                }
+                else
+                {
+                    // Look for first dash to get semantic version. (for example: 1.0.0-preview2-003156)
+                    int dashIndex = output.IndexOf('-');
+                    Version version = new Version(dashIndex == -1 ? output : output.Substring(0, dashIndex));
+
+                    Version minVersion = new Version("1.0.0");
+                    if (version < minVersion)
+                    {
+                        Assert.Inconclusive($".Net Core version ({output}) must be greater than or equal to {minVersion}.");
+                    }
+                }
+            }
+        }
+
+        private static IDisposable DotNetCoreTestSetup()
+        {
+            EnsureDotNetCoreInstalled();
+
+            return new ExpectedSDKPrefixChanger("rddd");
+        }
+
+        private const string AspxCoreTestAppFolder = "..\\TestApps\\AspxCore\\";
+
+        #region Tests
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForSyncHttpAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSyncHttpTests(AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, "200", HttpTestConstants.QueryStringOutboundHttp);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForSyncHttpPostCallAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSyncHttpPostTests(AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, "200", HttpTestConstants.QueryStringOutboundHttpPost);
+            }
+        }
+
+        [TestMethod]
+        [Ignore] // Don't run this test until .NET Core writes diagnostic events for failed HTTP requests
+        [TestCategory(TestCategory.NetCore)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForSyncHttpFailedAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which fails.            
+                HttpTestHelper.ExecuteSyncHttpTests(AspxCoreTestWebApplication, false, 1, HttpTestConstants.AccessTimeMaxHttpInitial, "200", HttpTestConstants.QueryStringOutboundHttpFailed);
+            }
+        }
+
+        #endregion        
+
+        private class ExpectedSDKPrefixChanger : IDisposable
+        {
+            private readonly string previousExpectedSDKPrefix;
+
+            public ExpectedSDKPrefixChanger(string expectedSDKPrefix)
+            {
+                previousExpectedSDKPrefix = DeploymentAndValidationTools.ExpectedSDKPrefix;
+                DeploymentAndValidationTools.ExpectedSDKPrefix = expectedSDKPrefix;
+            }
+
+            public void Dispose()
+            {
+                DeploymentAndValidationTools.ExpectedSDKPrefix = previousExpectedSDKPrefix;
+            }
+        }
+    }
+}

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/FuncTest.csproj
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/FuncTest.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\packages\WiX.3.10.1\build\wix.props" Condition="Exists('..\..\..\..\..\packages\WiX.3.10.1\build\wix.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.Common.props'))\Test.Common.props" />
@@ -106,11 +106,14 @@
     <Compile Include="Helpers\Extensions.cs" />
     <Compile Include="Helpers\FakeDataPlatform.cs" />
     <Compile Include="Helpers\HttpListenerObservable.cs" />
+    <Compile Include="Helpers\HttpTestConstants.cs" />
+    <Compile Include="Helpers\HttpTestHelper.cs" />
     <Compile Include="Helpers\ProcessHelper.cs" />
     <Compile Include="Helpers\RequestHelper.cs" />
     <Compile Include="Helpers\TelemetryItemFactory.cs" />
     <Compile Include="Helpers\IISTestWebApplication.cs" />
     <Compile Include="Helpers\TestWebApplication.cs" />
+    <Compile Include="AspNetCoreHttpTests.cs" />
     <Compile Include="IIS\Iis.cs" />
     <Compile Include="IIS\IisApplicationPool.cs" />
     <Compile Include="IIS\IisWebApplication.cs" />

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/EtwEventSessionRdd.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/EtwEventSessionRdd.cs
@@ -1,4 +1,4 @@
-﻿namespace Functional.Helpers
+﻿namespace FuncTest.Helpers
 {
     using System;
     using System.Diagnostics;

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpTestConstants.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpTestConstants.cs
@@ -1,0 +1,107 @@
+﻿using System;
+
+namespace FuncTest.Helpers
+{
+    internal class HttpTestConstants
+    {
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call .
+        /// </summary>
+        internal static string QueryStringOutboundHttp = "?type=http&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call POST.
+        /// </summary>
+        internal static string QueryStringOutboundHttpPost = "?type=httppost&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call POST.
+        /// </summary>
+        internal static string QueryStringOutboundHttpPostFailed = "?type=failedhttppost&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call which fails.
+        /// </summary>
+        internal static string QueryStringOutboundHttpFailed = "?type=failedhttp&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call which fails.
+        /// </summary>
+        internal static string QueryStringOutboundHttpFailedAtDns = "?type=failedhttpinvaliddns&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound Azure sdk Call .
+        /// </summary>
+        internal static string QueryStringOutboundAzureSdk = "?type=azuresdk{0}&count={1}";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228967(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsync1 = "?type=httpasync1&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228967(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsync1Failed = "?type=failedhttpasync1&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url.
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228962(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsync2 = "?type=httpasync2&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228962(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsync2Failed = "?type=failedhttpasync2&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url.
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228968(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsync3 = "?type=httpasync3&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228968(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsync3Failed = "?type=failedhttpasync3&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url.
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228972(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsync4 = "?type=httpasync4&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228972(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsync4Failed = "?type=failedhttpasync4&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url.
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228972(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsyncAwait1 = "?type=httpasyncawait1&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
+        /// <c>http://msdn.microsoft.com/en-us/library/ms228972(v=vs.110).aspx</c>
+        /// </summary>
+        internal static string QueryStringOutboundHttpAsyncAwait1Failed = "?type=failedhttpasyncawait1&count=";
+
+        /// <summary>
+        /// Maximum access time for the initial call - This includes an additional 1-2 delay introduced before the very first call by Profiler V2.
+        /// </summary>        
+        internal static TimeSpan AccessTimeMaxHttpInitial = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Maximum access time for calls after initial - This does not incur perf hit of the very first call.
+        /// </summary>        
+        internal static TimeSpan AccessTimeMaxHttpNormal = TimeSpan.FromSeconds(3);
+    }
+}

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpTestHelper.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpTestHelper.cs
@@ -1,0 +1,280 @@
+﻿using System;
+using System.Linq;
+using AI;
+using FuncTest.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
+
+namespace FuncTest.Helpers
+{
+    internal class HttpTestHelper
+    {
+        /// <summary>
+        /// Resource Name for bing.
+        /// </summary>
+        private static Uri ResourceNameHttpToBing = new Uri("http://www.bing.com");
+
+        /// <summary>
+        /// Resource Name for failed request.
+        /// </summary>
+        private static Uri ResourceNameHttpToFailedRequest = new Uri("http://google.com/404");
+
+        /// <summary>
+        /// Resource Name for failed at DNS request.
+        /// </summary>
+        internal static Uri ResourceNameHttpToFailedAtDnsRequest = new Uri("http://abcdefzzzzeeeeadadad.com");
+
+        /// <summary>
+        /// Helper to execute Async Http tests.
+        /// </summary>
+        /// <param name="testWebApplication">The test application for which tests are to be executed.</param>
+        /// <param name="success">Indicates if the tests should test success or failure case.</param> 
+        /// <param name="count">Number to RDD calls to be made by the test application. </param> 
+        /// <param name="accessTimeMax">Approximate maximum time taken by RDD Call.  </param>
+        /// <param name="url">url</param> 
+        internal static void ExecuteAsyncTests(TestWebApplication testWebApplication, bool success, int count,
+            TimeSpan accessTimeMax, string url, string resultCodeExpected)
+        {
+            var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
+
+            testWebApplication.DoTest(
+                application =>
+                {
+                    var queryString = url;
+                    application.ExecuteAnonymousRequest(queryString + count);
+                    application.ExecuteAnonymousRequest(queryString + count);
+                    application.ExecuteAnonymousRequest(queryString + count);
+
+                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
+                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
+                    var allItems =
+                        DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(
+                            DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
+
+                    var httpItems =
+                        allItems.Where(i => i.data.baseData.type == "Http").ToArray();
+
+                    Assert.AreEqual(
+                        3 * count,
+                        httpItems.Length,
+                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
+
+                    foreach (var httpItem in httpItems)
+                    {
+                        Validate(httpItem, resourceNameExpected, accessTimeMax, success, "GET", resultCodeExpected);
+                    }
+                });
+        }
+
+        /// <summary>
+        /// Helper to execute Sync Http tests
+        /// </summary>
+        /// <param name="testWebApplication">The test application for which tests are to be executed</param>
+        /// <param name="success">indicates if the tests should test success or failure case</param>   
+        /// <param name="count">number to RDD calls to be made by the test application.  </param> 
+        /// <param name="accessTimeMax">approximate maximum time taken by RDD Call.  </param> 
+        public static void ExecuteSyncHttpTests(TestWebApplication testWebApplication, bool success, int count, TimeSpan accessTimeMax,
+            string resultCodeExpected, string queryString)
+        {
+            testWebApplication.DoTest(
+                application =>
+                {                    
+                    var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
+                    application.ExecuteAnonymousRequest(queryString + count);
+
+                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
+                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
+                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
+                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
+
+                    Assert.AreEqual(
+                        count,
+                        httpItems.Length,
+                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
+
+                    foreach (var httpItem in httpItems)
+                    {
+                        Validate(httpItem, resourceNameExpected, accessTimeMax, success, "GET", resultCodeExpected);
+                    }
+                });
+        }
+
+        public static void ExecuteSyncHttpClientTests(TestWebApplication testWebApplication, TimeSpan accessTimeMax, string resultCodeExpected)
+        {
+            testWebApplication.DoTest(
+                application =>
+                {
+                    var queryString = "?type=httpClient&count=1";
+                    var resourceNameExpected = new Uri("http://www.google.com/404");
+                    application.ExecuteAnonymousRequest(queryString);
+
+                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
+                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
+                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
+                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
+
+                    Assert.AreEqual(
+                        1,
+                        httpItems.Length,
+                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
+
+                    foreach (var httpItem in httpItems)
+                    {
+                        // This is a call to google.com/404 which will fail but typically takes longer time. So accesstime can more than normal.
+                        Validate(httpItem, resourceNameExpected, accessTimeMax.Add(TimeSpan.FromSeconds(15)), false, "GET", resultCodeExpected);
+                    }
+                });
+        }
+
+        /// <summary>
+        /// Helper to execute Sync Http tests
+        /// </summary>
+        /// <param name="testWebApplication">The test application for which tests are to be executed</param>
+        /// <param name="success">indicates if the tests should test success or failure case</param>   
+        /// <param name="count">number to RDD calls to be made by the test application.  </param> 
+        /// <param name="accessTimeMax">approximate maximum time taken by RDD Call.  </param> 
+        public static void ExecuteSyncHttpPostTests(TestWebApplication testWebApplication, bool success, int count, TimeSpan accessTimeMax, string resultCodeExpected, string queryString)
+        {
+            testWebApplication.DoTest(
+                application =>
+                {                    
+                    var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
+                    application.ExecuteAnonymousRequest(queryString + count);
+
+                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
+                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
+                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
+                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
+
+                    // Validate the RDD Telemetry properties
+                    Assert.AreEqual(
+                        count,
+                        httpItems.Length,
+                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
+
+                    foreach (var httpItem in httpItems)
+                    {
+                        Validate(httpItem, resourceNameExpected, accessTimeMax, success, "POST", resultCodeExpected);
+                    }
+                });
+        }
+
+        /// <summary>
+        /// Helper to execute Async http test which uses Callbacks.
+        /// </summary>
+        /// <param name="testWebApplication">The test application for which tests are to be executed</param>
+        /// <param name="success">indicates if the tests should test success or failure case</param> 
+        public static void ExecuteAsyncWithCallbackTests(TestWebApplication testWebApplication, bool success, TimeSpan accessTimeMax, string resultCodeExpected, string queryString)
+        {
+            var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
+
+            testWebApplication.DoTest(
+                application =>
+                {
+                application.ExecuteAnonymousRequest(queryString);                        
+
+                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
+                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
+
+                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
+                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
+
+                    // Validate the RDD Telemetry properties
+                    Assert.AreEqual(
+                        1,
+                        httpItems.Length,
+                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
+                    Validate(httpItems[0], resourceNameExpected, accessTimeMax, success, "GET", resultCodeExpected);
+                });
+        }
+
+        /// <summary>
+        /// Helper to execute Async http test which uses async,await pattern (.NET 4.5 or higher only)
+        /// </summary>
+        /// <param name="testWebApplication">The test application for which tests are to be executed</param>
+        /// <param name="success">indicates if the tests should test success or failure case</param> 
+        public static void ExecuteAsyncAwaitTests(TestWebApplication testWebApplication, bool success, TimeSpan accessTimeMax, string resultCodeExpected, string queryString)
+        {
+            var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
+
+            testWebApplication.DoTest(
+                application =>
+                {
+                    application.ExecuteAnonymousRequest(queryString);
+
+                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
+                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
+
+                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
+                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
+
+                    // Validate the RDD Telemetry properties
+                    Assert.AreEqual(
+                        1,
+                        httpItems.Length,
+                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
+                    Validate(httpItems[0], resourceNameExpected, accessTimeMax, success, "GET", resultCodeExpected);
+                });
+        }
+
+        /// <summary>
+        /// Helper to execute Azure SDK tests.
+        /// </summary>
+        /// <param name="testWebApplication">The test application for which tests are to be executed.</param>
+        /// <param name="count">number to RDD calls to be made by the test application.</param> 
+        /// <param name="type"> type of azure call.</param> 
+        /// <param name="expectedUrl">expected url for azure call.</param> 
+        public static void ExecuteAzureSDKTests(TestWebApplication testWebApplication, int count, string type, string expectedUrl, string queryString)
+        {
+            testWebApplication.DoTest(
+                application =>
+                {
+                    application.ExecuteAnonymousRequest(string.Format(CultureInfo.InvariantCulture, queryString, type, count));
+
+                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
+                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured                      
+                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
+                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
+                    int countItem = 0;
+
+                    foreach (var httpItem in httpItems)
+                    {
+                        TimeSpan accessTime = TimeSpan.Parse(httpItem.data.baseData.duration, CultureInfo.InvariantCulture);
+                        Assert.IsTrue(accessTime.TotalMilliseconds >= 0, "Access time should be above zero for azure calls");
+
+                        string actualSdkVersion = httpItem.tags[new ContextTagKeys().InternalSdkVersion];
+                        Assert.IsTrue(actualSdkVersion.Contains(DeploymentAndValidationTools.ExpectedSDKPrefix), "Actual version:" + actualSdkVersion);
+
+                        var url = httpItem.data.baseData.data;
+                        if (url.Contains(expectedUrl))
+                        {
+                            countItem++;
+                        }
+                        else
+                        {
+                            Assert.Fail("ExecuteAzureSDKTests.url not matching for " + url);
+                        }
+                    }
+
+                    Assert.IsTrue(countItem >= count, "Azure " + type + " access captured " + countItem + " is less than " + count);
+                });
+        }
+
+        public static void Validate(TelemetryItem<RemoteDependencyData> itemToValidate,
+            Uri expectedUrl,
+            TimeSpan accessTimeMax,
+            bool successFlagExpected,
+            string verb,
+            string resultCodeExpected)
+        {
+            if ("rddp" == DeploymentAndValidationTools.ExpectedSDKPrefix)
+            {
+                Assert.AreEqual(verb + " " + expectedUrl.AbsolutePath, itemToValidate.data.baseData.name, "For StatusMonitor implementation we expect verb to be collected.");
+                Assert.AreEqual(expectedUrl.Host, itemToValidate.data.baseData.target);
+                Assert.AreEqual(expectedUrl.OriginalString, itemToValidate.data.baseData.data);
+            }
+
+            DeploymentAndValidationTools.Validate(itemToValidate, accessTimeMax, successFlagExpected, resultCodeExpected);
+        }        
+    }
+}

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/HttpTests.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/HttpTests.cs
@@ -1,145 +1,52 @@
 ﻿namespace FuncTest
 {
-    using System;
-    using System.Globalization;
+    using System;    
     using System.Linq;
     using AI;
     using FuncTest.Helpers;
     using FuncTest.Serialization;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using System.Diagnostics;
 
     /// <summary>
-    /// Tests RDD Functionality for a ASP.NET WebApplication in DOTNET 4.5.1, DOTNET 4.6,
-    /// and DOTNET Core.
-    /// ASPX451 refers to the test application throughout the functional test context.
-    /// The same app is used for testing 4.5.1 4.6, and Core scenarios.
+    /// Tests Dependency Collector (HTTP) Functionality for a WebApplication written in classic ASP.NET
     /// </summary>
     [TestClass]
     public class HttpTests
     {
         /// <summary>
-        /// Query string to specify Outbound HTTP Call .
-        /// </summary>
-        private const string QueryStringOutboundHttp = "?type=http&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call POST.
-        /// </summary>
-        private const string QueryStringOutboundHttpPost = "?type=httppost&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call POST.
-        /// </summary>
-        private const string QueryStringOutboundHttpPostFailed = "?type=failedhttppost&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call which fails.
-        /// </summary>
-        private const string QueryStringOutboundHttpFailed = "?type=failedhttp&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call which fails.
-        /// </summary>
-        private const string QueryStringOutboundHttpFailedAtDns = "?type=failedhttpinvaliddns&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound Azure sdk Call .
-        /// </summary>
-        private const string QueryStringOutboundAzureSdk = "?type=azuresdk{0}&count={1}";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228967(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsync1 = "?type=httpasync1&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228967(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsync1Failed = "?type=failedhttpasync1&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url.
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228962(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsync2 = "?type=httpasync2&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228962(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsync2Failed = "?type=failedhttpasync2&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url.
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228968(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsync3 = "?type=httpasync3&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228968(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsync3Failed = "?type=failedhttpasync3&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url.
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228972(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsync4 = "?type=httpasync4&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228972(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsync4Failed = "?type=failedhttpasync4&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url.
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228972(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsyncAwait1 = "?type=httpasyncawait1&count=";
-
-        /// <summary>
-        /// Query string to specify Outbound HTTP Call in async way as described in below url and which fails.
-        /// <c>http://msdn.microsoft.com/en-us/library/ms228972(v=vs.110).aspx</c>
-        /// </summary>
-        private const string QueryStringOutboundHttpAsyncAwait1Failed = "?type=failedhttpasyncawait1&count=";
-
-        /// <summary>
-        /// Resource Name for bing.
-        /// </summary>
-        private Uri ResourceNameHttpToBing = new Uri("http://www.bing.com");
-
-        /// <summary>
-        /// Resource Name for failed request.
-        /// </summary>
-        private Uri ResourceNameHttpToFailedRequest = new Uri("http://google.com/404");
-
-        /// <summary>
-        /// Resource Name for failed at DNS request.
-        /// </summary>
-        private Uri ResourceNameHttpToFailedAtDnsRequest = new Uri("http://abcdefzzzzeeeeadadad.com");
-
-
-        /// <summary>
-        /// Maximum access time for the initial call - This includes an additional 1-2 delay introduced before the very first call by Profiler V2.
+        /// Folder for ASPX 4.5.1 test application deployment.
         /// </summary>        
-        private readonly TimeSpan AccessTimeMaxHttpInitial = TimeSpan.FromSeconds(3);
+        internal const string Aspx451AppFolder = ".\\Aspx451";
 
         /// <summary>
-        /// Maximum access time for calls after initial - This does not incur perf hit of the very first call.
+        /// Folder for ASPX 4.5.1 Win32 mode test application deployment.
         /// </summary>        
-        private readonly TimeSpan AccessTimeMaxHttpNormal = TimeSpan.FromSeconds(3);
+        internal const string Aspx451AppFolderWin32 = ".\\Aspx451Win32";
+
+        internal static IISTestWebApplication Aspx451TestWebApplication { get; private set; }
+
+        internal static IISTestWebApplication Aspx451TestWebApplicationWin32 { get; private set; }
+        
 
         public TestContext TestContext { get; set; }
 
         [ClassInitialize]
         public static void MyClassInitialize(TestContext testContext)
         {
-            DeploymentAndValidationTools.Initialize();
+            Aspx451TestWebApplication = new IISTestWebApplication
+            {
+                AppName = "Aspx451",
+                Port = DeploymentAndValidationTools.Aspx451Port,
+            };
+
+            Aspx451TestWebApplicationWin32 = new IISTestWebApplication
+            {
+                AppName = "Aspx451Win32",
+                Port = DeploymentAndValidationTools.Aspx451PortWin32,
+                EnableWin32Mode = true,
+            };
+
+            DeploymentAndValidationTools.Initialize(new TestWebApplication[] { Aspx451TestWebApplication, Aspx451TestWebApplicationWin32 }, true);
 
             AzureStorageHelper.Initialize();
         }
@@ -147,9 +54,8 @@
         [ClassCleanup]
         public static void MyClassCleanup()
         {
-            AzureStorageHelper.Cleanup();
-
-            DeploymentAndValidationTools.CleanUp();
+            AzureStorageHelper.Cleanup();            
+            DeploymentAndValidationTools.CleanUp(new TestWebApplication[] { Aspx451TestWebApplication, Aspx451TestWebApplicationWin32 }, true);
         }
 
         [TestInitialize]
@@ -164,9 +70,7 @@
             Assert.IsFalse(DeploymentAndValidationTools.SdkEventListener.FailureDetected, "Failure is detected. Please read test output logs.");
             DeploymentAndValidationTools.SdkEventListener.Stop();
         }
-
-        #region 451
-
+        
         private const string Aspx451TestAppFolder = "..\\TestApps\\ASPX451\\App\\";
 
         private static void EnsureNet451Installed()
@@ -177,191 +81,193 @@
             }
         }
 
+        #region Tests
+
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForSyncHttpAspx451()
         {
             EnsureNet451Installed();
 
             // Execute and verify calls which succeeds            
-            this.ExecuteSyncHttpTests(DeploymentAndValidationTools.Aspx451TestWebApplication, true, 1, AccessTimeMaxHttpNormal, "200");
+            HttpTestHelper.ExecuteSyncHttpTests(Aspx451TestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, "200", HttpTestConstants.QueryStringOutboundHttp);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForSyncHttpPostCallAspx451()
         {
             EnsureNet451Installed();
 
             // Execute and verify calls which succeeds            
-            this.ExecuteSyncHttpPostTests(DeploymentAndValidationTools.Aspx451TestWebApplication, true, 1, AccessTimeMaxHttpNormal, "200");
+            HttpTestHelper.ExecuteSyncHttpPostTests(Aspx451TestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, "200", HttpTestConstants.QueryStringOutboundHttpPost);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForSyncHttpFailedAspx451()
         {
             EnsureNet451Installed();
 
             // Execute and verify calls which fails.            
-            this.ExecuteSyncHttpTests(DeploymentAndValidationTools.Aspx451TestWebApplication, false, 1, AccessTimeMaxHttpInitial, "404");
+            HttpTestHelper.ExecuteSyncHttpTests(Aspx451TestWebApplication, false, 1, HttpTestConstants.AccessTimeMaxHttpInitial, "404", HttpTestConstants.QueryStringOutboundHttpFailed);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForAsync1HttpAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAsyncTests(DeploymentAndValidationTools.Aspx451TestWebApplication, true, 1, AccessTimeMaxHttpNormal, QueryStringOutboundHttpAsync1, "200");
+            HttpTestHelper.ExecuteAsyncTests(Aspx451TestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundHttpAsync1, "200");
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForHttpAspx451WithHttpClient()
         {
             EnsureNet451Installed();
 
-            this.ExecuteSyncHttpClientTests(DeploymentAndValidationTools.Aspx451TestWebApplication, AccessTimeMaxHttpNormal, "404");
+            HttpTestHelper.ExecuteSyncHttpClientTests(Aspx451TestWebApplication, HttpTestConstants.AccessTimeMaxHttpNormal, "404");
         }
 
         [TestMethod]
         [Description("Verify RDD is collected for failed Async Http Calls in ASPX 4.5.1 application")]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForFailedAsync1HttpAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAsyncTests(DeploymentAndValidationTools.Aspx451TestWebApplication, false, 1, AccessTimeMaxHttpInitial, QueryStringOutboundHttpAsync1Failed, "404");
+            HttpTestHelper.ExecuteAsyncTests(Aspx451TestWebApplication, false, 1, HttpTestConstants.AccessTimeMaxHttpInitial, HttpTestConstants.QueryStringOutboundHttpAsync1Failed, "404");
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForAsync2HttpAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAsyncTests(DeploymentAndValidationTools.Aspx451TestWebApplication, true, 1, AccessTimeMaxHttpNormal, QueryStringOutboundHttpAsync2, "200");
+            HttpTestHelper.ExecuteAsyncTests(Aspx451TestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundHttpAsync2, "200");
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForFailedAsync2HttpAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAsyncTests(DeploymentAndValidationTools.Aspx451TestWebApplication, false, 1, AccessTimeMaxHttpInitial, QueryStringOutboundHttpAsync2Failed, "404");
+            HttpTestHelper.ExecuteAsyncTests(Aspx451TestWebApplication, false, 1, HttpTestConstants.AccessTimeMaxHttpInitial, HttpTestConstants.QueryStringOutboundHttpAsync2Failed, "404");
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForAsync3HttpAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAsyncTests(DeploymentAndValidationTools.Aspx451TestWebApplication, true, 1, AccessTimeMaxHttpNormal, QueryStringOutboundHttpAsync3, "200");
+            HttpTestHelper.ExecuteAsyncTests(Aspx451TestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundHttpAsync3, "200");
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForFailedAsync3HttpAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAsyncTests(DeploymentAndValidationTools.Aspx451TestWebApplication, false, 1, AccessTimeMaxHttpInitial, QueryStringOutboundHttpAsync3Failed, "404");
+            HttpTestHelper.ExecuteAsyncTests(Aspx451TestWebApplication, false, 1, HttpTestConstants.AccessTimeMaxHttpInitial, HttpTestConstants.QueryStringOutboundHttpAsync3Failed, "404");
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForAsyncWithCallBackHttpAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAsyncWithCallbackTests(DeploymentAndValidationTools.Aspx451TestWebApplication, true, "200");
+            HttpTestHelper.ExecuteAsyncWithCallbackTests(Aspx451TestWebApplication, true, HttpTestConstants.AccessTimeMaxHttpInitial, "200", HttpTestConstants.QueryStringOutboundHttpAsync4);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForAsyncAwaitHttpAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAsyncAwaitTests(DeploymentAndValidationTools.Aspx451TestWebApplication, true, "200");
+            HttpTestHelper.ExecuteAsyncAwaitTests(Aspx451TestWebApplication, true, HttpTestConstants.AccessTimeMaxHttpInitial, "200", HttpTestConstants.QueryStringOutboundHttpAsyncAwait1);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForFailedAsyncAwaitHttpAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAsyncAwaitTests(DeploymentAndValidationTools.Aspx451TestWebApplication, false, "404");
+            HttpTestHelper.ExecuteAsyncAwaitTests(Aspx451TestWebApplication, false, HttpTestConstants.AccessTimeMaxHttpInitial, "404", HttpTestConstants.QueryStringOutboundHttpAsyncAwait1Failed);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForAzureSdkBlobAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAzureSDKTests(DeploymentAndValidationTools.Aspx451TestWebApplication, 1, "blob", "http://127.0.0.1:11000");
+            HttpTestHelper.ExecuteAzureSDKTests(Aspx451TestWebApplication, 1, "blob", "http://127.0.0.1:11000", HttpTestConstants.QueryStringOutboundAzureSdk);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForAzureSdkQueueAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAzureSDKTests(DeploymentAndValidationTools.Aspx451TestWebApplication, 1, "queue", "http://127.0.0.1:11001");
+            HttpTestHelper.ExecuteAzureSDKTests(Aspx451TestWebApplication, 1, "queue", "http://127.0.0.1:11001", HttpTestConstants.QueryStringOutboundAzureSdk);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestRddForAzureSdkTableAspx451()
         {
             EnsureNet451Installed();
 
-            this.ExecuteAzureSDKTests(DeploymentAndValidationTools.Aspx451TestWebApplication, 1, "table", "http://127.0.0.1:11002");
+            HttpTestHelper.ExecuteAzureSDKTests(Aspx451TestWebApplication, 1, "table", "http://127.0.0.1:11002", HttpTestConstants.QueryStringOutboundAzureSdk);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolderWin32)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolderWin32)]
         public void TestRddForWin32ApplicationPool()
         {
             EnsureNet451Installed();
 
-            this.ExecuteSyncHttpTests(DeploymentAndValidationTools.Aspx451TestWebApplicationWin32, true, 1, AccessTimeMaxHttpInitial, "200");
+            HttpTestHelper.ExecuteSyncHttpTests(Aspx451TestWebApplicationWin32, true, 1, HttpTestConstants.AccessTimeMaxHttpInitial, "200", HttpTestConstants.QueryStringOutboundHttp);
         }
 
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
         [Description("Validates that DependencyModule collects telemety for outbound connections to non existent hosts. This request is expected to fail at DNS resolution stage, and hence will not contain http code in result.")]
-        [DeploymentItem(Aspx451TestAppFolder, DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem(Aspx451TestAppFolder, Aspx451AppFolder)]
         public void TestDependencyCollectionForFailedRequestAtDnsResolution()
         {
             EnsureNet451Installed();
 
-            var queryString = QueryStringOutboundHttpFailedAtDns;
-            var resourceNameExpected = ResourceNameHttpToFailedAtDnsRequest;
-            DeploymentAndValidationTools.Aspx451TestWebApplication.ExecuteAnonymousRequest(queryString);
+            var queryString = HttpTestConstants.QueryStringOutboundHttpFailedAtDns;
+            var resourceNameExpected = HttpTestHelper.ResourceNameHttpToFailedAtDnsRequest;
+            Aspx451TestWebApplication.ExecuteAnonymousRequest(queryString);
 
             //// The above request would have trigged RDD module to monitor and create RDD telemetry
             //// Listen in the fake endpoint and see if the RDDTelemtry is captured
@@ -383,366 +289,6 @@
             Assert.IsTrue(actualSdkVersion.Contains(DeploymentAndValidationTools.ExpectedSDKPrefix), "Actual version:" + actualSdkVersion);
         }
 
-        #endregion 451
-
-        #region Core
-
-        private static void EnsureDotNetCoreInstalled()
-        {
-            string output = "";
-            string error = "";
-
-            if (!DotNetCoreProcess.HasDotNetExe())
-            {
-                Assert.Inconclusive(".Net Core is not installed");
-            }
-            else
-            {
-                DotNetCoreProcess process = new DotNetCoreProcess("--version")
-                    .RedirectStandardOutputTo((string outputMessage) => output += outputMessage)
-                    .RedirectStandardErrorTo((string errorMessage) => error += errorMessage)
-                    .Run();
-
-                if (process.ExitCode.Value != 0 || !string.IsNullOrEmpty(error))
-                {
-                    Assert.Inconclusive(".Net Core is not installed");
-                }
-                else
-                {
-                    // Look for first dash to get semantic version. (for example: 1.0.0-preview2-003156)
-                    int dashIndex = output.IndexOf('-');
-                    Version version = new Version(dashIndex == -1 ? output : output.Substring(0, dashIndex));
-
-                    Version minVersion = new Version("1.0.0");
-                    if (version < minVersion)
-                    {
-                        Assert.Inconclusive($".Net Core version ({output}) must be greater than or equal to {minVersion}.");
-                    }
-                }
-            }
-        }
-
-        private static IDisposable DotNetCoreTestSetup()
-        {
-            EnsureDotNetCoreInstalled();
-
-            return new ExpectedSDKPrefixChanger("rddd");
-        }
-
-        private const string AspxCoreTestAppFolder = "..\\TestApps\\AspxCore\\";
-
-        [TestMethod]
-        [TestCategory(TestCategory.NetCore)]
-        [DeploymentItem(AspxCoreTestAppFolder, DeploymentAndValidationTools.AspxCoreAppFolder)]
-        public void TestRddForSyncHttpAspxCore()
-        {
-            using (DotNetCoreTestSetup())
-            {
-                // Execute and verify calls which succeeds            
-                this.ExecuteSyncHttpTests(DeploymentAndValidationTools.AspxCoreTestWebApplication, true, 1, AccessTimeMaxHttpNormal, "200");
-            }
-        }
-
-        [TestMethod]
-        [TestCategory(TestCategory.NetCore)]
-        [DeploymentItem(AspxCoreTestAppFolder, DeploymentAndValidationTools.AspxCoreAppFolder)]
-        public void TestRddForSyncHttpPostCallAspxCore()
-        {
-            using (DotNetCoreTestSetup())
-            {
-                // Execute and verify calls which succeeds            
-                this.ExecuteSyncHttpPostTests(DeploymentAndValidationTools.AspxCoreTestWebApplication, true, 1, AccessTimeMaxHttpNormal, "200");
-            }
-        }
-
-        [TestMethod]
-        [Ignore] // Don't run this test until .NET Core writes diagnostic events for failed HTTP requests
-        [TestCategory(TestCategory.NetCore)]
-        [DeploymentItem(AspxCoreTestAppFolder, DeploymentAndValidationTools.AspxCoreAppFolder)]
-        public void TestRddForSyncHttpFailedAspxCore()
-        {
-            using (DotNetCoreTestSetup())
-            {
-                // Execute and verify calls which fails.            
-                this.ExecuteSyncHttpTests(DeploymentAndValidationTools.AspxCoreTestWebApplication, false, 1, AccessTimeMaxHttpInitial, "200");
-            }
-        }
-
-        #endregion Core
-
-        #region helpers
-
-        /// <summary>
-        /// Helper to execute Async Http tests.
-        /// </summary>
-        /// <param name="testWebApplication">The test application for which tests are to be executed.</param>
-        /// <param name="success">Indicates if the tests should test success or failure case.</param> 
-        /// <param name="count">Number to RDD calls to be made by the test application. </param> 
-        /// <param name="accessTimeMax">Approximate maximum time taken by RDD Call.  </param>
-        /// <param name="url">url</param> 
-        private void ExecuteAsyncTests(TestWebApplication testWebApplication, bool success, int count,
-            TimeSpan accessTimeMax, string url, string resultCodeExpected)
-        {
-            var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
-
-            testWebApplication.DoTest(
-                application =>
-                {
-                    var queryString = url;
-                    application.ExecuteAnonymousRequest(queryString + count);
-                    application.ExecuteAnonymousRequest(queryString + count);
-                    application.ExecuteAnonymousRequest(queryString + count);
-
-                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
-                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
-                    var allItems =
-                        DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(
-                            DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
-
-                    var httpItems =
-                        allItems.Where(i => i.data.baseData.type == "Http").ToArray();
-
-                    Assert.AreEqual(
-                        3 * count,
-                        httpItems.Length,
-                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
-
-                    foreach (var httpItem in httpItems)
-                    {
-                        this.Validate(httpItem, resourceNameExpected, accessTimeMax, success, "GET", resultCodeExpected);
-                    }
-                });
-        }
-
-        /// <summary>
-        /// Helper to execute Sync Http tests
-        /// </summary>
-        /// <param name="testWebApplication">The test application for which tests are to be executed</param>
-        /// <param name="success">indicates if the tests should test success or failure case</param>   
-        /// <param name="count">number to RDD calls to be made by the test application.  </param> 
-        /// <param name="accessTimeMax">approximate maximum time taken by RDD Call.  </param> 
-        private void ExecuteSyncHttpTests(TestWebApplication testWebApplication, bool success, int count, TimeSpan accessTimeMax,
-            string resultCodeExpected)
-        {
-            testWebApplication.DoTest(
-                application =>
-                {
-                    var queryString = success ? QueryStringOutboundHttp : QueryStringOutboundHttpFailed;
-                    var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
-                    application.ExecuteAnonymousRequest(queryString + count);
-
-                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
-                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
-                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
-                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
-
-                    Assert.AreEqual(
-                        count,
-                        httpItems.Length,
-                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
-
-                    foreach (var httpItem in httpItems)
-                    {
-                        this.Validate(httpItem, resourceNameExpected, accessTimeMax, success, "GET", resultCodeExpected);
-                    }
-                });
-        }
-
-        private void ExecuteSyncHttpClientTests(TestWebApplication testWebApplication, TimeSpan accessTimeMax, string resultCodeExpected)
-        {
-            testWebApplication.DoTest(
-                application =>
-                {
-                    var queryString = "?type=httpClient&count=1";
-                    var resourceNameExpected = new Uri("http://www.google.com/404");
-                    application.ExecuteAnonymousRequest(queryString);
-
-                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
-                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
-                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
-                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
-
-                    Assert.AreEqual(
-                        1,
-                        httpItems.Length,
-                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
-
-                    foreach (var httpItem in httpItems)
-                    {
-                        // This is a call to google.com/404 which will fail but typically takes longer time. So accesstime can more than normal.
-                        this.Validate(httpItem, resourceNameExpected, accessTimeMax.Add(TimeSpan.FromSeconds(15)), false, "GET", resultCodeExpected);
-                    }
-                });
-        }
-
-        /// <summary>
-        /// Helper to execute Sync Http tests
-        /// </summary>
-        /// <param name="testWebApplication">The test application for which tests are to be executed</param>
-        /// <param name="success">indicates if the tests should test success or failure case</param>   
-        /// <param name="count">number to RDD calls to be made by the test application.  </param> 
-        /// <param name="accessTimeMax">approximate maximum time taken by RDD Call.  </param> 
-        private void ExecuteSyncHttpPostTests(TestWebApplication testWebApplication, bool success, int count, TimeSpan accessTimeMax, string resultCodeExpected)
-        {
-            testWebApplication.DoTest(
-                application =>
-                {
-                    var queryString = success ? QueryStringOutboundHttpPost : QueryStringOutboundHttpPostFailed;
-                    var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
-                    application.ExecuteAnonymousRequest(queryString + count);
-
-                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
-                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
-                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
-                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
-
-                    // Validate the RDD Telemetry properties
-                    Assert.AreEqual(
-                        count,
-                        httpItems.Length,
-                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
-
-                    foreach (var httpItem in httpItems)
-                    {
-                        this.Validate(httpItem, resourceNameExpected, accessTimeMax, success, "POST", resultCodeExpected);
-                    }
-                });
-        }
-
-        /// <summary>
-        /// Helper to execute Async http test which uses Callbacks.
-        /// </summary>
-        /// <param name="testWebApplication">The test application for which tests are to be executed</param>
-        /// <param name="success">indicates if the tests should test success or failure case</param> 
-        private void ExecuteAsyncWithCallbackTests(TestWebApplication testWebApplication, bool success, string resultCodeExpected)
-        {
-            var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
-
-            testWebApplication.DoTest(
-                application =>
-                {
-                    application.ExecuteAnonymousRequest(success ? QueryStringOutboundHttpAsync4 : QueryStringOutboundHttpAsync4Failed);
-
-                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
-                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
-
-                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
-                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
-
-                    // Validate the RDD Telemetry properties
-                    Assert.AreEqual(
-                        1,
-                        httpItems.Length,
-                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
-                    this.Validate(httpItems[0], resourceNameExpected, AccessTimeMaxHttpInitial, success, "GET", resultCodeExpected);
-                });
-        }
-
-        /// <summary>
-        /// Helper to execute Async http test which uses async,await pattern (.NET 4.5 or higher only)
-        /// </summary>
-        /// <param name="testWebApplication">The test application for which tests are to be executed</param>
-        /// <param name="success">indicates if the tests should test success or failure case</param> 
-        private void ExecuteAsyncAwaitTests(TestWebApplication testWebApplication, bool success, string resultCodeExpected)
-        {
-            var resourceNameExpected = success ? ResourceNameHttpToBing : ResourceNameHttpToFailedRequest;
-
-            testWebApplication.DoTest(
-                application =>
-                {
-                    application.ExecuteAnonymousRequest(success ? QueryStringOutboundHttpAsyncAwait1 : QueryStringOutboundHttpAsyncAwait1Failed);
-
-                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
-                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
-
-                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
-                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
-
-                    // Validate the RDD Telemetry properties
-                    Assert.AreEqual(
-                        1,
-                        httpItems.Length,
-                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
-                    this.Validate(httpItems[0], resourceNameExpected, AccessTimeMaxHttpInitial, success, "GET", resultCodeExpected);
-                });
-        }
-
-        /// <summary>
-        /// Helper to execute Azure SDK tests.
-        /// </summary>
-        /// <param name="testWebApplication">The test application for which tests are to be executed.</param>
-        /// <param name="count">number to RDD calls to be made by the test application.</param> 
-        /// <param name="type"> type of azure call.</param> 
-        /// <param name="expectedUrl">expected url for azure call.</param> 
-        private void ExecuteAzureSDKTests(TestWebApplication testWebApplication, int count, string type, string expectedUrl)
-        {
-            testWebApplication.DoTest(
-                application =>
-                {
-                    application.ExecuteAnonymousRequest(string.Format(CultureInfo.InvariantCulture, QueryStringOutboundAzureSdk, type, count));
-
-                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
-                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured                      
-                    var allItems = DeploymentAndValidationTools.SdkEventListener.ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
-                    var httpItems = allItems.Where(i => i.data.baseData.type == "Http").ToArray();
-                    int countItem = 0;
-
-                    foreach (var httpItem in httpItems)
-                    {
-                        TimeSpan accessTime = TimeSpan.Parse(httpItem.data.baseData.duration, CultureInfo.InvariantCulture);
-                        Assert.IsTrue(accessTime.TotalMilliseconds >= 0, "Access time should be above zero for azure calls");
-
-                        string actualSdkVersion = httpItem.tags[new ContextTagKeys().InternalSdkVersion];
-                        Assert.IsTrue(actualSdkVersion.Contains(DeploymentAndValidationTools.ExpectedSDKPrefix), "Actual version:" + actualSdkVersion);
-
-                        var url = httpItem.data.baseData.data;
-                        if (url.Contains(expectedUrl))
-                        {
-                            countItem++;
-                        }
-                        else
-                        {
-                            Assert.Fail("ExecuteAzureSDKTests.url not matching for " + url);
-                        }
-                    }
-
-                    Assert.IsTrue(countItem >= count, "Azure " + type + " access captured " + countItem + " is less than " + count);
-                });
-        }
-
-        #endregion
-
-        private void Validate(TelemetryItem<RemoteDependencyData> itemToValidate,
-            Uri expectedUrl,
-            TimeSpan accessTimeMax,
-            bool successFlagExpected,
-            string verb,
-            string resultCodeExpected)
-        {
-            if ("rddp" == DeploymentAndValidationTools.ExpectedSDKPrefix)
-            {
-                Assert.AreEqual(verb + " " + expectedUrl.AbsolutePath, itemToValidate.data.baseData.name, "For StatusMonitor implementation we expect verb to be collected.");
-                Assert.AreEqual(expectedUrl.Host, itemToValidate.data.baseData.target);
-                Assert.AreEqual(expectedUrl.OriginalString, itemToValidate.data.baseData.data);
-            }
-
-            DeploymentAndValidationTools.Validate(itemToValidate, accessTimeMax, successFlagExpected, resultCodeExpected);
-        }
-
-        private class ExpectedSDKPrefixChanger : IDisposable
-        {
-            private readonly string previousExpectedSDKPrefix;
-
-            public ExpectedSDKPrefixChanger(string expectedSDKPrefix)
-            {
-                previousExpectedSDKPrefix = DeploymentAndValidationTools.ExpectedSDKPrefix;
-                DeploymentAndValidationTools.ExpectedSDKPrefix = expectedSDKPrefix;
-            }
-
-            public void Dispose()
-            {
-                DeploymentAndValidationTools.ExpectedSDKPrefix = previousExpectedSDKPrefix;
-            }
-        }
+        #endregion 451        
     }
 }

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/SqlTests.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/SqlTests.cs
@@ -10,8 +10,11 @@
 
     using FuncTest.Helpers;
     using FuncTest.Serialization;
-    
 
+
+    /// <summary>
+    /// Tests Dependency Collector (SQL) Functionality for a WebApplication written in classic ASP.NET
+    /// </summary>
     [TestClass]
     public class SqlTests
     {
@@ -50,20 +53,28 @@
         /// </summary>        
         private readonly TimeSpan AccessTimeMaxSqlCallToApmdbNormal = TimeSpan.FromSeconds(5);
 
+        internal const string Aspx451AppFolder = ".\\Aspx451";
+        internal static IISTestWebApplication Aspx451TestWebApplication { get; private set; }
+
         public TestContext TestContext { get; set; }
 
         [ClassInitialize]
         public static void MyClassInitialize(TestContext testContext)
         {
-            DeploymentAndValidationTools.Initialize();
+            Aspx451TestWebApplication = new IISTestWebApplication
+            {
+                AppName = "Aspx451",
+                Port = DeploymentAndValidationTools.Aspx451Port,
+            };
+            DeploymentAndValidationTools.Initialize(new TestWebApplication[] { Aspx451TestWebApplication }, true);
 
-            LocalDb.CreateLocalDb("RDDTestDatabase", DeploymentAndValidationTools.Aspx451TestWebApplication.AppFolder + "\\TestDatabase.sql");
+            LocalDb.CreateLocalDb("RDDTestDatabase", Aspx451TestWebApplication.AppFolder + "\\TestDatabase.sql");
         }
 
         [ClassCleanup]
         public static void MyClassCleanup()
         {
-            DeploymentAndValidationTools.CleanUp();
+            DeploymentAndValidationTools.CleanUp(new TestWebApplication[] { Aspx451TestWebApplication}, true);
         }
 
         [TestInitialize]
@@ -82,7 +93,7 @@
         #region Misc tests
         [TestMethod]
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         public void TestRddForSyncSqlAspx451()
         {
             if (!RegistryCheck.IsNet451Installed)
@@ -90,18 +101,18 @@
                 Assert.Inconclusive(".Net Framework 4.5.1 is not installed");
             }
 
-            this.ExecuteSyncSqlTests(DeploymentAndValidationTools.Aspx451TestWebApplication, 1, 1, AccessTimeMaxSqlCallToApmdbNormal);
+            this.ExecuteSyncSqlTests(Aspx451TestWebApplication, 1, 1, AccessTimeMaxSqlCallToApmdbNormal);
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestStoredProcedureNameIsCollected()
         {
             const string StoredProcedureName = "GetTopTenMessages";
             string queryString = "?type=ExecuteReaderStoredProcedureAsync&count=1&storedProcedureName=" + StoredProcedureName;
 
-            DeploymentAndValidationTools.Aspx451TestWebApplication.DoTest(
+            Aspx451TestWebApplication.DoTest(
                      application =>
                      {
                          application.ExecuteAnonymousRequest(queryString);
@@ -123,7 +134,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteReaderTwiceInSequence()
         {
@@ -131,7 +142,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteReaderTwiceInSequenceFailed()
         {
@@ -139,11 +150,11 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteReaderTwiceWithTasks()
         {
-            DeploymentAndValidationTools.Aspx451TestWebApplication.DoTest(
+            Aspx451TestWebApplication.DoTest(
                      application =>
                      {
                          application.ExecuteAnonymousRequest("?type=TestExecuteReaderTwiceWithTasks&count=1");
@@ -160,7 +171,7 @@
         #region ExecuteReader
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteReaderAsync()
         {
@@ -168,7 +179,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteReaderAsyncFailed()
         {
@@ -176,7 +187,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestBeginExecuteReader()
         {
@@ -184,7 +195,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestBeginExecuteReaderFailed_0Args()
         {
@@ -192,7 +203,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestBeginExecuteReaderFailed_1Arg()
         {
@@ -200,7 +211,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestBeginExecuteReaderFailed_2Arg()
         {
@@ -208,7 +219,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestBeginExecuteReaderFailed_3Arg()
         {
@@ -216,7 +227,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlCommandExecuteReader()
         {
@@ -224,7 +235,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlCommandExecuteReaderFailed_0Args()
         {
@@ -232,7 +243,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlCommandExecuteReaderFailed_1Args()
         {
@@ -242,7 +253,7 @@
 
         #region ExecuteScalar
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteScalarAsync()
         {
@@ -250,7 +261,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteScalarAsyncFailed()
         {
@@ -258,7 +269,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlCommandExecuteScalar()
         {
@@ -266,7 +277,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlCommandExecuteScalarFailed()
         {
@@ -277,7 +288,7 @@
         #region ExecuteNonQuery
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlCommandExecuteNonQuery()
         {
@@ -285,7 +296,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlCommandExecuteNonQueryFailed()
         {
@@ -293,14 +304,14 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteNonQueryAsync()
         {
             this.TestSqlCommandExecute("ExecuteNonQueryAsync", errorNumber: "0", errorMessage: null);
         }
 
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestCategory(TestCategory.Net451)]
         [TestMethod]
         public void TestExecuteNonQueryAsyncFailed()
@@ -308,7 +319,7 @@
             this.TestSqlCommandExecute("ExecuteNonQueryAsync", errorNumber: "208", errorMessage: "Invalid object name 'apm.Database1212121'.");
         }
 
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestCategory(TestCategory.Net451)]
         [TestMethod]
         public void TestBeginExecuteNonQuery_Arg0()
@@ -316,7 +327,7 @@
             this.TestSqlCommandExecute("BeginExecuteNonQuery0", errorNumber: "0", errorMessage: null);
         }
 
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestCategory(TestCategory.Net451)]
         [TestMethod]
         public void TestBeginExecuteNonQuery_Arg2()
@@ -325,7 +336,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestBeginExecuteNonQueryFailed()
         {
@@ -335,7 +346,7 @@
 
         #region ExecuteXmlReader
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteXmlReaderAsync()
         {
@@ -343,7 +354,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestExecuteXmlReaderAsyncFailed()
         {
@@ -351,7 +362,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestBeginExecuteXmlReaderFailed()
         {
@@ -359,7 +370,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlCommandExecuteXmlReader()
         {
@@ -367,7 +378,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlCommandExecuteXmlReaderFailed()
         {
@@ -378,7 +389,7 @@
         #region SqlConnection.Open
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlConnectionOpenSuccess()
         {
@@ -390,7 +401,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlConnectionOpenAccountException()
         {
@@ -402,7 +413,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlConnectionOpenServerException()
         {
@@ -414,7 +425,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlConnectionOpenAsyncSuccess()
         {
@@ -426,7 +437,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlConnectionOpenAsyncAccountException()
         {
@@ -438,7 +449,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlConnectionOpenAsyncServerException()
         {
@@ -450,7 +461,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlConnectionOpenAsyncAwaitSuccess()
         {
@@ -462,7 +473,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlConnectionOpenAsyncAwaitAccountException()
         {
@@ -474,7 +485,7 @@
         }
 
         [TestCategory(TestCategory.Net451)]
-        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", DeploymentAndValidationTools.Aspx451AppFolder)]
+        [DeploymentItem("..\\TestApps\\ASPX451\\App\\", Aspx451AppFolder)]
         [TestMethod]
         public void TestSqlConnectionOpenAsyncAwaitServerException()
         {
@@ -487,9 +498,10 @@
 
         #endregion
 
+        #region PrivateHelpers
         private void TestSqlConnectionExecute(string type, bool success, string exceptionType, bool async)
         {
-            DeploymentAndValidationTools.Aspx451TestWebApplication.DoTest(
+            Aspx451TestWebApplication.DoTest(
                  application =>
                  {
                      string responseForQueryValidation = application.ExecuteAnonymousRequest("?type=" + type + "&success=" + success + "&exceptionType=" + exceptionType);
@@ -526,7 +538,7 @@
 
         private void TestSqlCommandExecute(string type, string errorNumber, string errorMessage, string extraClauseForFailureCase = null)
         {
-            DeploymentAndValidationTools.Aspx451TestWebApplication.DoTest(
+            Aspx451TestWebApplication.DoTest(
                  application =>
                  {
                      bool success = errorNumber == "0";
@@ -682,5 +694,7 @@
 
             DeploymentAndValidationTools.Validate(itemToValidate, accessTimeMax, successFlagExpected);
         }
-    } 
+
+        #endregion
+    }
 }


### PR DESCRIPTION
Dependency collector tests for Aspnet core app and Classic asp.net app split into separate test classes, so that failure to initialize/run one will not affect other.

(At present, lab machines have trouble running asp.net core app - and this is causing all other dependency functional tests to not run/fail.) This PR does not fix the root cause for why asp.net core app fails to run, but this makes the issue self-contained within aspnet core app.