### PR TITLE
Run only one fetch app id task at a time for a given instrumenation key.

### DIFF
--- a/Src/Common/CorrelationIdLookupHelper.cs
+++ b/Src/Common/CorrelationIdLookupHelper.cs
@@ -152,8 +152,7 @@
                                 }
                                 finally
                                 {
-                                    int taskId;
-                                    this.fetchTasks.TryRemove(instrumentationKey, out taskId);
+                                    this.fetchTasks.TryRemove(instrumentationKey, out int taskId);
                                 }
                             });
 

--- a/Src/Common/CorrelationIdLookupHelper.cs
+++ b/Src/Common/CorrelationIdLookupHelper.cs
@@ -2,15 +2,16 @@
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using System.Net;
-    using System.Threading.Tasks;
-    using Extensibility;
-    using Extensibility.Implementation.Tracing;
 #if NETCORE
     using System.Net.Http;
 #endif
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// A store for instrumentation App Ids. This makes sure we don't query the public endpoint to find an app Id for the same instrumentation key more than once.
@@ -21,11 +22,6 @@
         /// Max number of app ids to cache.
         /// </summary>
         private const int MAXSIZE = 100;
-
-        // For now we have decided to go with not waiting to retrieve the app Id, instead we just cache it on retrieval.
-        // This means the initial few attempts to get correlation id might fail and the initial telemetry sent might be missing such data.
-        // However, once it is in the cache - subsequent telemetry should contain this data. 
-        private const int GetAppIdTimeout = 0; // milliseconds
 
         private const string CorrelationIdFormat = "cid-v1:{0}";
 
@@ -39,7 +35,7 @@
 
         private ConcurrentDictionary<string, string> knownCorrelationIds = new ConcurrentDictionary<string, string>();
 
-        private ConcurrentDictionary<string, int> FetchTasks = new ConcurrentDictionary<string, int>();
+        private ConcurrentDictionary<string, int> fetchTasks = new ConcurrentDictionary<string, int>();
 
         // Stores failed instrumentation keys along with the time we tried to retrieve them.
         private ConcurrentDictionary<string, FailedResult> failingInstrumenationKeys = new ConcurrentDictionary<string, FailedResult>();
@@ -58,6 +54,25 @@
             }
 
             this.provideAppId = appIdProviderMethod;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CorrelationIdLookupHelper" /> class mostly to be used by the test classes to seed the instrumentation key -> app Id relationship.
+        /// </summary>
+        /// <param name="mapSeed">A dictionary that contains known instrumentation key - app id relationship.</param>
+        public CorrelationIdLookupHelper(Dictionary<string, string> mapSeed)
+        {
+            if (mapSeed == null)
+            {
+                throw new ArgumentNullException(nameof(mapSeed));
+            }
+
+            this.provideAppId = this.FetchAppIdFromService;
+
+            foreach (var entry in mapSeed)
+            {
+                this.knownCorrelationIds[entry.Key] = entry.Value;
+            }
         }
 
         /// <summary>
@@ -122,42 +137,27 @@
                     }
 
                     // We only want one task to be there to fetch the ikey. If initial requests come in a bunch, only one of them gets to take responsibility of creating the fetch task. Rest return.
-                    if (this.FetchTasks.TryAdd(instrumentationKey, int.MinValue))
+                    if (this.fetchTasks.TryAdd(instrumentationKey, int.MinValue))
                     {
-                        try
-                        {
-                            // We wait for <getAppIdTimeout> seconds (which is 0 at this point) to retrieve the appId. If retrieved during that time, we return success setting the correlation id.
-                            // If we are still waiting on the result beyond the timeout - for this particular call we return the failure but queue a task continuation for it to be cached for next time.
-                            Task<string> getAppIdTask = this.provideAppId(instrumentationKey.ToLowerInvariant());
-
-                            if (getAppIdTask.Wait(GetAppIdTimeout))
+                        this.provideAppId(instrumentationKey.ToLowerInvariant())
+                            .ContinueWith((appId) =>
                             {
-                                this.GenerateCorrelationIdAndAddToDictionary(instrumentationKey, getAppIdTask.Result);
-                                correlationId = this.knownCorrelationIds[instrumentationKey];
-                                return true;
-                            }
-                            else
-                            {
-                                getAppIdTask.ContinueWith((appId) =>
+                                try
                                 {
-                                    try
-                                    {
-                                        this.GenerateCorrelationIdAndAddToDictionary(instrumentationKey, appId.Result);
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        this.RegisterFailure(instrumentationKey, ex);
-                                    }
-                                });
+                                    this.GenerateCorrelationIdAndAddToDictionary(instrumentationKey, appId.Result);
+                                }
+                                catch (Exception ex)
+                                {
+                                    this.RegisterFailure(instrumentationKey, ex);
+                                }
+                                finally
+                                {
+                                    int taskId;
+                                    this.fetchTasks.TryRemove(instrumentationKey, out taskId);
+                                }
+                            });
 
-                                return false;
-                            }
-                        }
-                        finally
-                        {
-                            int taskId;
-                            this.FetchTasks.TryRemove(instrumentationKey, out taskId);
-                        }
+                        return false;
                     }
                     else
                     {
@@ -174,6 +174,16 @@
                     return false;
                 }
             }
+        }
+
+        /// <summary>
+        /// This method is purely a test helper at this point. It checks whether the task to get app ID is still running.
+        /// </summary>
+        /// <returns>True if fetch task is still in progress, false otherwise.</returns>
+        public bool IsFetchAppInProgress(string ikey)
+        {
+            int value;
+            return this.fetchTasks.TryGetValue(ikey, out value);
         }
 
         private void GenerateCorrelationIdAndAddToDictionary(string ikey, string appId)

--- a/Src/Common/CorrelationIdLookupHelper.cs
+++ b/Src/Common/CorrelationIdLookupHelper.cs
@@ -129,7 +129,6 @@
                             // We wait for <getAppIdTimeout> seconds (which is 0 at this point) to retrieve the appId. If retrieved during that time, we return success setting the correlation id.
                             // If we are still waiting on the result beyond the timeout - for this particular call we return the failure but queue a task continuation for it to be cached for next time.
                             Task<string> getAppIdTask = this.provideAppId(instrumentationKey.ToLowerInvariant());
-                            this.FetchTasks[instrumentationKey] = getAppIdTask.Id;
 
                             if (getAppIdTask.Wait(GetAppIdTimeout))
                             {

--- a/Src/DependencyCollector/Shared.Tests/CorrelationIdLookupHelperTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/CorrelationIdLookupHelperTests.cs
@@ -1,0 +1,48 @@
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Correlation Id Lookup helper tests.
+    /// </summary>
+    [TestClass]
+    public sealed class CorrelationIdLookupHelperTests
+    {
+        /// <summary>
+        /// Makes sure that the first call to get app id returns false, because it hasn't been fetched yet.
+        /// But the second call is able to get it from the dictionary.
+        /// </summary>
+        [TestMethod]
+        public void CorrelationIdLookupHelperReturnsAppIdOnSecondCall()
+        {
+            var correlationIdLookupHelper = new CorrelationIdLookupHelper((ikey) =>
+            {
+                // Pretend App Id is the same as Ikey
+                var tcs = new TaskCompletionSource<string>();
+                tcs.SetResult(ikey);
+                return tcs.Task;
+            });
+
+            string instrumenationKey = Guid.NewGuid().ToString();
+            string cid;
+
+            // First call returns false;
+            Assert.IsFalse(correlationIdLookupHelper.TryGetXComponentCorrelationId(instrumenationKey, out cid));
+
+            // Let's wait for the task to complete. It should be really quick (based on the test setup) but not immediate.
+            while (correlationIdLookupHelper.IsFetchAppInProgress(instrumenationKey))
+            {
+                Thread.Sleep(10); // wait 10 ms.
+            }
+
+            // Once fetch is complete, subsequent calls should return correlation id.
+            Assert.IsTrue(correlationIdLookupHelper.TryGetXComponentCorrelationId(instrumenationKey, out cid));
+        }
+    }
+}

--- a/Src/DependencyCollector/Shared.Tests/DependencyCollector.Shared.Tests.projitems
+++ b/Src/DependencyCollector/Shared.Tests/DependencyCollector.Shared.Tests.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Microsoft.ApplicationInsights.DependencyCollector</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CorrelationIdLookupHelperTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HeaderCollectionManipulationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpDependenciesParsingTelemetryInitializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ClientServerDependencyTrackerTests.cs" />

--- a/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
@@ -46,19 +46,12 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
             this.httpProcessingFramework = new FrameworkHttpProcessing(this.configuration, new CacheBasedOperationHolder("testCache", 100 * 1000), /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
-            var correlationIdLookupHelper = new CorrelationIdLookupHelper((string ikey) =>
-            {
-                // Pretend App Id is the same as Ikey
-                var tcs = new TaskCompletionSource<string>();
-                tcs.SetResult(ikey);
-                return tcs.Task;
-            });
-            this.httpProcessingFramework.OverrideCorrelationIdLookupHelper(correlationIdLookupHelper);
+            this.httpProcessingFramework.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string> { { this.configuration.InstrumentationKey, "cid-v1:" + this.configuration.InstrumentationKey } }));
         }
 
         [TestCleanup]
         public void Cleanup()
-        {        
+        {
         }
 #endregion //TestInitiliaze
 

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
@@ -120,7 +120,20 @@
         {
             // Here is a sample App ID, since the test initialize method adds a random ikey and our mock getAppId method pretends that the appId for a given ikey is the same as the ikey.
             // This will not match the current component's App ID. Hence represents an external component.
-            string appId = "0935FC42-FE1A-4C67-975C-0C9D5CBDEE8E";
+            string ikey = "0935FC42-FE1A-4C67-975C-0C9D5CBDEE8E";
+            string appId = ikey + "-appId";
+
+            this.httpProcessingProfiler.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string>
+            {
+                {
+                    ikey,
+                    "cid-v1:" + appId
+                },
+                {
+                    this.configuration.InstrumentationKey,
+                    "cid-v1:" + this.configuration.InstrumentationKey + "-appId"
+                }
+            }));
 
             this.SimulateWebRequestResponseWithAppId(appId);
 
@@ -160,10 +173,7 @@
         [Description("Validates DependencyTelemetry does not send correlation ID if the IKey is from the same component")]
         public void RddTestHttpProcessingProfilerOnEndDoesNotAddAppIdToTargetFieldForInternalComponents()
         {
-            string appId = "b3eb14d6-bb32-4542-9b93-473cd94aaedf";
-
-            // Initialize the test with a given instrumentation key.
-            this.Initialize(appId);
+            string appId = this.configuration.InstrumentationKey + "-appId";
 
             this.SimulateWebRequestResponseWithAppId(appId);
 
@@ -897,21 +907,6 @@
 
         private void SimulateWebRequestResponseWithAppId(string appId)
         {
-            if (appId != this.configuration.InstrumentationKey)
-            {
-                this.httpProcessingProfiler.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string>
-                {
-                    {
-                        appId,
-                        "cid-v1:" + appId
-                    },
-                    {
-                        this.configuration.InstrumentationKey,
-                        "cid-v1:" + this.configuration.InstrumentationKey
-                    }
-                }));
-            }
-
             this.SimulateWebRequestWithGivenRequestContextHeaderValue(this.GetCorrelationIdHeaderValue(appId));
         }
 
@@ -957,7 +952,7 @@
             {
                 {
                     instrumentationKey,
-                    "cid-v1:" + instrumentationKey
+                    "cid-v1:" + instrumentationKey + "-appId"
                 }
             });
 

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerHttpProcessingTest.cs
@@ -897,6 +897,21 @@
 
         private void SimulateWebRequestResponseWithAppId(string appId)
         {
+            if (appId != this.configuration.InstrumentationKey)
+            {
+                this.httpProcessingProfiler.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string>
+                {
+                    {
+                        appId,
+                        "cid-v1:" + appId
+                    },
+                    {
+                        this.configuration.InstrumentationKey,
+                        "cid-v1:" + this.configuration.InstrumentationKey
+                    }
+                }));
+            }
+
             this.SimulateWebRequestWithGivenRequestContextHeaderValue(this.GetCorrelationIdHeaderValue(appId));
         }
 
@@ -938,12 +953,12 @@
                 new List<string>(),
                 RandomAppIdEndpoint);
 
-            var correlationIdLookupHelper = new CorrelationIdLookupHelper((string ikey) =>
+            var correlationIdLookupHelper = new CorrelationIdLookupHelper(new Dictionary<string, string>
             {
-                // Pretend App Id is the same as Ikey
-                var tcs = new TaskCompletionSource<string>();
-                tcs.SetResult(ikey);
-                return tcs.Task;
+                {
+                    instrumentationKey,
+                    "cid-v1:" + instrumentationKey
+                }
             });
 
             this.httpProcessingProfiler.OverrideCorrelationIdLookupHelper(correlationIdLookupHelper);

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -29,7 +29,7 @@
         {
             // Pretend App Id is the same as Ikey
             var tcs = new TaskCompletionSource<string>();
-            tcs.SetResult(ikey);
+            tcs.SetResult(ikey + "-appId");
             return tcs.Task;
         });
 
@@ -346,8 +346,9 @@
         [TestMethod]
         public void OnEndAddsSourceFieldForRequestWithCorrelationId()
         {
-            // ARRANGE                       
-            string appId = "b3eb14d6-bb32-4542-9b93-473cd94aaedf";
+            // ARRANGE  
+            string instrumentationKey = "b3eb14d6-bb32-4542-9b93-473cd94aaedf";
+            string appId = instrumentationKey + "-appId";
 
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add(RequestResponseHeaders.RequestContextHeader, this.GetCorrelationIdHeaderValue(appId));
@@ -363,11 +364,11 @@
             {
                 {
                     config.InstrumentationKey,
-                    config.InstrumentationKey
+                    config.InstrumentationKey + "-appId"
                 },
                 {
-                    appId,
-                    appId
+                    instrumentationKey,
+                    appId + "-appId"
                 }
             });
 
@@ -412,7 +413,8 @@
         public void OnEndAddsSourceFieldForRequestWithCorrelationIdAndRoleName()
         {
             // ARRANGE                       
-            string appId = "b3eb14d6-bb32-4542-9b93-473cd94aaedf";
+            string ikey = "b3eb14d6-bb32-4542-9b93-473cd94aaedf";
+            string appId = ikey + "-appId";
             string roleName = "SomeRoleName";
 
             Dictionary<string, string> headers = new Dictionary<string, string>();
@@ -431,10 +433,10 @@
             {
                 {
                     config.InstrumentationKey,
-                    config.InstrumentationKey
+                    config.InstrumentationKey + "-appId"
                 },
                 {
-                    appId,
+                    ikey,
                     appId
                 }
             });


### PR DESCRIPTION
We do this by storing the task id in a concurrent dictionary. If the task is already added, it is not added again, instead we return immediately.

The motivation to do this is to minimize the load when querying for app id. Once app id is retrieved it is stored in a cache and returned from there. But initially when the cache doesn't contain it, user's requests are going to trigger a fetch. User's often have 500 or more requests per second. This change makes sure we do not create 500 or more tasks  (one for each request) in that case. 