### PR TITLE
Track dependency instrumented with HttpDesktop DiagnosticSource in Response event (#509)

### DIFF
--- a/Src/DependencyCollector/Net46.Tests/DependencyTrackingTelemetryModuleTestNet46.cs
+++ b/Src/DependencyCollector/Net46.Tests/DependencyTrackingTelemetryModuleTestNet46.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+    using System.IO;
     using System.Net;
 
     using Microsoft.ApplicationInsights.Channel;
@@ -54,9 +55,13 @@
                 module.ProfileQueryEndpoint = FakeProfileApiEndpoint;
                 module.Initialize(config);
 
-                var url = new Uri("http://bing.com");
+                var url = new Uri("https://www.bing.com/");
                 HttpWebRequest request = WebRequest.CreateHttp(url);
-                request.GetResponse();
+                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                using (var reader = new StreamReader(response.GetResponseStream()))
+                {
+                    reader.ReadToEnd();
+                }
 
                 Assert.IsNotNull(sentTelemetry);
                 var item = (DependencyTelemetry)sentTelemetry;
@@ -118,11 +123,16 @@
                 module.ProfileQueryEndpoint = FakeProfileApiEndpoint;
                 module.Initialize(config);
 
-                var url = new Uri("http://bing.com");
+                var url = new Uri("https://www.bing.com/");
                 HttpWebRequest request = WebRequest.CreateHttp(url);
 
                 var parent = new Activity("parent").AddBaggage("k", "v").SetParentId("|guid.").Start();
-                request.GetResponse();
+                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                using (var reader = new StreamReader(response.GetResponseStream()))
+                {
+                    reader.ReadToEnd();
+                }
+
                 parent.Stop();
 
                 Assert.IsNotNull(sentTelemetry);

--- a/Src/DependencyCollector/Net46.Tests/DependencyTrackingTelemetryModuleTestNet46.cs
+++ b/Src/DependencyCollector/Net46.Tests/DependencyTrackingTelemetryModuleTestNet46.cs
@@ -55,6 +55,12 @@
             DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
         }
 
+        [TestCleanup]
+        public void Cleanup()
+        {
+            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
+        }
+
         [TestMethod]
         [Timeout(5000)]
         public void TestDependencyCollectionDiagnosticSourceNoParentActivity()
@@ -64,6 +70,7 @@
                 module.EnableDiagnosticSourceInstrumentation = true;
                 module.ProfileQueryEndpoint = FakeProfileApiEndpoint;
                 module.Initialize(this.config);
+                Assert.IsTrue(DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated);
 
                 var url = new Uri("https://www.bing.com/");
                 HttpWebRequest request = WebRequest.CreateHttp(url);
@@ -107,6 +114,7 @@
             {
                 module.ProfileQueryEndpoint = FakeProfileApiEndpoint;
                 module.Initialize(this.config);
+                Assert.IsFalse(DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated);
 
                 var url = new Uri("https://www.bing.com/");
                 HttpWebRequest request = WebRequest.CreateHttp(url);

--- a/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
+++ b/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="..\Shared.Tests\Implementation\DependencyCollectorDiagnosticListenerTests.Netstandard20.cs" Link="DependencyCollectorDiagnosticListenerTests.Netstandard20.cs" />
     <Compile Include="..\Shared.Tests\Implementation\EnumerableAssert.cs" Link="EnumerableAssert.cs" />
     <Compile Include="..\Shared.Tests\Implementation\MockCorrelationIdLookupHelper.cs" Link="MockCorrelationIdLookupHelper.cs" />
+    <Compile Include="..\..\TestFramework\Shared\SdkVersionHelper.cs" Link="SdkVersionHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Copyright>Copyright © Microsoft. All Rights Reserved.</Copyright>
@@ -29,6 +29,7 @@
     <Compile Include="..\Shared\Implementation\HttpCoreDiagnosticSourceListener.cs" Link="HttpCoreDiagnosticSourceListener.cs" />
     <Compile Include="..\Shared\Implementation\HttpHeadersUtilities.cs" Link="HttpHeadersUtilities.cs" />
     <Compile Include="..\Shared\Implementation\PropertyFetcher.cs" Link="PropertyFetcher.cs" />
+    <Compile Include="..\Shared\Implementation\RDDSource.cs" Link="RDDSource.cs" />
     <Compile Include="..\Shared\Implementation\HttpParsers\AzureBlobHttpParser.cs" Link="AzureBlobHttpParser.cs" />
     <Compile Include="..\Shared\Implementation\HttpParsers\AzureIotHubHttpParser.cs" Link="AzureIotHubHttpParser.cs" />
     <Compile Include="..\Shared\Implementation\HttpParsers\AzureQueueHttpParser.cs" Link="AzureQueueHttpParser.cs" />

--- a/Src/DependencyCollector/Shared.Tests/DependencyCollector.Shared.Tests.projitems
+++ b/Src/DependencyCollector/Shared.Tests/DependencyCollector.Shared.Tests.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HttpDependenciesParsingTelemetryInitializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ClientServerDependencyTrackerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\DependencyTargetNameHelperTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\DesktopDiagnosticSourceHttpProcessingTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureBlobHttpParserTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureServiceBusHttpParserTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\DocumentDbHttpParserTests.cs" />

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
@@ -12,6 +12,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.TestFramework;
 #if !NETCORE
     using Microsoft.ApplicationInsights.Web.TestFramework;
 #endif
@@ -203,6 +205,10 @@ namespace Microsoft.ApplicationInsights.DependencyCollector
             Assert.AreEqual(RequestUrl, telemetry.Target);
             Assert.AreEqual(HttpOkResultCode, telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success);
+
+            string expectedVersion =
+                SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), prefix: "rdddsc:");
+            Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
         }
 
         /// <summary>

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
@@ -11,6 +11,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.TestFramework;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     /// <summary>
@@ -72,6 +74,10 @@ namespace Microsoft.ApplicationInsights.DependencyCollector
             Assert.AreEqual(activity.ParentId, telemetry.Context.Operation.ParentId);
             Assert.AreEqual(activity.Id, telemetry.Id);
             Assert.AreEqual("v", telemetry.Context.Properties["k"]);
+
+            string expectedVersion =
+                SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), prefix: "rdddsc:");
+            Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
         }
 
         /// <summary>

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
@@ -1,0 +1,306 @@
+﻿#if NET45
+namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.TestFramework;
+    using Microsoft.ApplicationInsights.Web.TestFramework;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class DesktopDiagnosticSourceHttpProcessingTests
+    {
+        #region Fields
+        private const string RandomAppIdEndpoint = "http://app.id.endpoint"; // appIdEndpoint - this really won't be used for tests because of the app id provider override.
+        private const int TimeAccuracyMilliseconds = 50;
+        private Uri testUrl = new Uri("http://www.microsoft.com/");
+        private int sleepTimeMsecBetweenBeginAndEnd = 100;
+        private TelemetryConfiguration configuration;
+        private List<ITelemetry> sendItems;
+        private DesktopDiagnosticSourceHttpProcessing httpProcessingFramework;
+        #endregion //Fields
+
+        #region TestInitialize
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this.configuration = new TelemetryConfiguration();
+            this.sendItems = new List<ITelemetry>();
+            this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
+            this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
+            this.httpProcessingFramework = new DesktopDiagnosticSourceHttpProcessing(this.configuration, new ObjectInstanceBasedOperationHolder(), /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
+            var correlationIdLookupHelper = new CorrelationIdLookupHelper((string ikey) =>
+            {
+                // Pretend App Id is the same as Ikey
+                var tcs = new TaskCompletionSource<string>();
+                tcs.SetResult(ikey);
+                return tcs.Task;
+            });
+            this.httpProcessingFramework.OverrideCorrelationIdLookupHelper(correlationIdLookupHelper);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+        }
+        #endregion //TestInitiliaze
+
+        /// <summary>
+        /// Validates that OnRequestSend and OnResponseReceive sends valid telemetry.
+        /// </summary>
+        [TestMethod]
+        public void RddTestHttpProcessingFrameworkUpdateTelemetryName()
+        {
+            var stopwatch = Stopwatch.StartNew();
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
+            this.httpProcessingFramework.OnRequestSend(request);
+            Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
+            Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
+            var response = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK);
+            stopwatch.Stop();
+            this.httpProcessingFramework.OnResponseReceive(request, response);
+
+            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
+            ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "200");
+        }
+
+        /// <summary>
+        /// Validates that even if multiple events have fired, as long as there is only
+        /// one HttpWebRequest, only one event should be written, during the first call
+        /// to OnResponseReceive.
+        /// </summary>
+        [TestMethod]
+        public void RddTestHttpProcessingFrameworkNoDuplication()
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
+            var redirectResponse = TestUtils.GenerateHttpWebResponse(HttpStatusCode.Redirect);
+            var successResponse = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK);
+
+            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnRequestSend(request);  
+            Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
+            Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
+            this.httpProcessingFramework.OnResponseReceive(request, redirectResponse);
+            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
+
+            this.httpProcessingFramework.OnResponseReceive(request, redirectResponse);
+            this.httpProcessingFramework.OnResponseReceive(request, successResponse);
+            stopwatch.Stop();
+
+            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
+            ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "302");
+        }
+
+        /// <summary>
+        /// Validates if DependencyTelemetry sent contains the cross component correlation ID.
+        /// </summary>
+        [TestMethod]
+        [Description("Validates if DependencyTelemetry sent contains the cross component correlation ID.")]
+        public void RddTestHttpProcessingFrameworkOnEndAddsAppIdToTargetField()
+        {
+            // Here is a sample App ID, since the test initialize method adds a random ikey and our mock getAppId method pretends that the appId for a given ikey is the same as the ikey.
+            // This will not match the current component's App ID. Hence represents an external component.
+            string appId = "0935FC42-FE1A-4C67-975C-0C9D5CBDEE8E";
+
+            var request = WebRequest.Create(this.testUrl);
+
+            Dictionary<string, string> headers = new Dictionary<string, string>
+            {
+                { RequestResponseHeaders.RequestContextHeader, this.GetCorrelationIdHeaderValue(appId) }
+            };
+
+            var response = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK, headers);
+
+            this.httpProcessingFramework.OnRequestSend(request);
+            this.httpProcessingFramework.OnResponseReceive(request, response);
+            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
+            Assert.AreEqual(this.testUrl.Host + " | " + this.GetCorrelationIdValue(appId), ((DependencyTelemetry)this.sendItems[0]).Target);
+        }
+
+        /// <summary>
+        /// Ensures that the source request header is added when request is sent.
+        /// </summary>
+        [TestMethod]
+        [Description("Ensures that the source request header is added when request is sent.")]
+        public void RddTestHttpProcessingFrameworkOnBeginAddsSourceHeader()
+        {
+            var request = WebRequest.Create(this.testUrl);
+
+            Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
+
+            this.httpProcessingFramework.OnRequestSend(request);
+            Assert.IsNotNull(request.Headers.GetNameValueHeaderValue(RequestResponseHeaders.RequestContextHeader, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+        }
+
+        /// <summary>
+        /// Ensures that the parent id header is added when request is sent.
+        /// </summary>
+        [TestMethod]
+        public void RddTestHttpProcessingFrameworkOnBeginAddsParentIdHeader()
+        {
+            var request = WebRequest.Create(this.testUrl);
+
+            Assert.IsNull(request.Headers[RequestResponseHeaders.StandardParentIdHeader]);
+
+            var client = new TelemetryClient(this.configuration);
+            using (var op = client.StartOperation<RequestTelemetry>("request"))
+            {
+                this.httpProcessingFramework.OnRequestSend(request);
+
+                var actualParentIdHeader = request.Headers[RequestResponseHeaders.StandardParentIdHeader];
+                var actualRequestIdHeader = request.Headers[RequestResponseHeaders.RequestIdHeader];
+                Assert.IsNotNull(actualParentIdHeader);
+                Assert.AreNotEqual(actualParentIdHeader, op.Telemetry.Context.Operation.Id);
+
+                Assert.AreEqual(actualParentIdHeader, actualRequestIdHeader);
+#if NET45
+                Assert.IsTrue(actualRequestIdHeader.StartsWith(Activity.Current.Id, StringComparison.Ordinal));
+                Assert.AreNotEqual(Activity.Current.Id, actualRequestIdHeader);
+#else
+                Assert.AreEqual(op.Telemetry.Context.Operation.Id, ApplicationInsightsActivity.GetRootId(request.Headers[RequestResponseHeaders.StandardParentIdHeader]));
+#endif
+                // This code should go away when Activity is fixed: https://github.com/dotnet/corefx/issues/18418
+                // check that Ids are not generated by Activity
+                // so they look like OperationTelemetry.Id
+                var operationId = op.Telemetry.Context.Operation.Id;
+
+                // length is like default RequestTelemetry.Id length
+                Assert.AreEqual(new DependencyTelemetry().Id.Length, operationId.Length);
+
+                // operationId is ulong base64 encoded
+                byte[] data = Convert.FromBase64String(operationId);
+                Assert.AreEqual(8, data.Length);
+                BitConverter.ToUInt64(data, 0);
+
+                // does not look like root Id generated by Activity
+                Assert.AreEqual(1, operationId.Split('-').Length);
+
+                //// end of workaround test
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the source request header is not added, as per the config, when request is sent.
+        /// </summary>
+        [TestMethod]
+        [Description("Ensures that the source request header is not added when the config commands as such")]
+        public void RddTestHttpProcessingFrameworkOnBeginSkipsAddingSourceHeaderPerConfig()
+        {
+            string hostnamepart = "partofhostname";
+            string url = string.Format(CultureInfo.InvariantCulture, "http://hostnamestart{0}hostnameend.com/path/to/something?param=1", hostnamepart);
+            var request = WebRequest.Create(new Uri(url));
+
+            Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
+            Assert.AreEqual(0, request.Headers.Keys.Cast<string>().Where((x) => { return x.StartsWith("x-ms-", StringComparison.OrdinalIgnoreCase); }).Count());
+
+            var localHttpProcessingFramework = new DesktopDiagnosticSourceHttpProcessing(
+                this.configuration, 
+                new ObjectInstanceBasedOperationHolder(),  
+                false, 
+                new List<string>(),
+                RandomAppIdEndpoint);
+
+            localHttpProcessingFramework.OnRequestSend(request);
+            Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
+            Assert.AreEqual(0, request.Headers.Keys.Cast<string>().Count(x => x.StartsWith("x-ms-", StringComparison.OrdinalIgnoreCase)));
+
+            ICollection<string> exclusionList = new SanitizedHostList() { "randomstringtoexclude", hostnamepart };
+            localHttpProcessingFramework = new DesktopDiagnosticSourceHttpProcessing(
+                this.configuration,
+                new ObjectInstanceBasedOperationHolder(),
+                true, 
+                exclusionList,
+                RandomAppIdEndpoint);
+            localHttpProcessingFramework.OnRequestSend(request);
+            Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
+            Assert.AreEqual(0, request.Headers.Keys.Cast<string>().Count(x => x.StartsWith("x-ms-", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        /// <summary>
+        /// Ensures that the source request header is not overwritten if already provided by the user.
+        /// </summary>
+        [TestMethod]
+        [Description("Ensures that the source request header is not overwritten if already provided by the user.")]
+        public void RddTestHttpProcessingFrameworkOnBeginDoesNotOverwriteExistingSource()
+        {
+            string sampleHeaderValueWithAppId = RequestResponseHeaders.RequestContextCorrelationSourceKey + "=HelloWorld";
+            var request = WebRequest.Create(this.testUrl);
+
+            request.Headers.Add(RequestResponseHeaders.RequestContextHeader, sampleHeaderValueWithAppId);
+
+            this.httpProcessingFramework.OnRequestSend(request);
+            var actualHeaderValue = request.Headers[RequestResponseHeaders.RequestContextHeader];
+
+            Assert.IsNotNull(actualHeaderValue);
+            Assert.AreEqual(sampleHeaderValueWithAppId, actualHeaderValue);
+
+            string sampleHeaderValueWithoutAppId = "helloWorld";
+            request = WebRequest.Create(this.testUrl);
+
+            request.Headers.Add(RequestResponseHeaders.RequestContextHeader, sampleHeaderValueWithoutAppId);
+
+            this.httpProcessingFramework.OnRequestSend(request);
+            actualHeaderValue = request.Headers[RequestResponseHeaders.RequestContextHeader];
+
+            Assert.IsNotNull(actualHeaderValue);
+            Assert.AreNotEqual(sampleHeaderValueWithAppId, actualHeaderValue);
+        }
+
+        private static void ValidateTelemetryPacketForOnRequestSend(DependencyTelemetry remoteDependencyTelemetryActual, Uri url, string kind, bool? success, double valueMin, string statusCode)
+        {
+            Assert.AreEqual("GET " + url.AbsolutePath, remoteDependencyTelemetryActual.Name, true, "Resource name in the sent telemetry is wrong");
+            string expectedVersion =
+                SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), prefix: "rddfd:");
+            ValidateTelemetryPacket(remoteDependencyTelemetryActual, url, kind, success, valueMin, statusCode, expectedVersion);
+        }
+
+        private static void ValidateTelemetryPacket(DependencyTelemetry remoteDependencyTelemetryActual, Uri url, string kind, bool? success, double valueMin, string statusCode, string expectedVersion)
+        {
+            Assert.AreEqual(url.Host, remoteDependencyTelemetryActual.Target, true, "Resource target in the sent telemetry is wrong");
+            Assert.AreEqual(url.OriginalString, remoteDependencyTelemetryActual.Data, true, "Resource data in the sent telemetry is wrong");
+            Assert.AreEqual(kind.ToString(), remoteDependencyTelemetryActual.Type, "DependencyKind in the sent telemetry is wrong");
+            Assert.AreEqual(success, remoteDependencyTelemetryActual.Success, "Success in the sent telemetry is wrong");
+            Assert.AreEqual(statusCode, remoteDependencyTelemetryActual.ResultCode, "ResultCode in the sent telemetry is wrong");
+
+            var valueMinRelaxed = valueMin - TimeAccuracyMilliseconds;
+            Assert.IsTrue(
+                remoteDependencyTelemetryActual.Duration >= TimeSpan.FromMilliseconds(valueMinRelaxed),
+                string.Format(CultureInfo.InvariantCulture, "Value (dependency duration = {0}) in the sent telemetry should be equal or more than the time duration between start and end", remoteDependencyTelemetryActual.Duration));
+
+            var valueMax = valueMin + TimeAccuracyMilliseconds;
+            Assert.IsTrue(
+                remoteDependencyTelemetryActual.Duration <= TimeSpan.FromMilliseconds(valueMax),
+                string.Format(CultureInfo.InvariantCulture, "Value (dependency duration = {0}) in the sent telemetry should not be signigficantly bigger then the time duration between start and end", remoteDependencyTelemetryActual.Duration));
+
+            Assert.AreEqual(expectedVersion, remoteDependencyTelemetryActual.Context.GetInternalContext().SdkVersion);
+        }
+
+        private string GetCorrelationIdValue(string appId)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "cid-v1:{0}", appId);
+        }
+
+        private string GetCorrelationIdHeaderValue(string appId)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0}=cid-v1:{1}", RequestResponseHeaders.RequestContextCorrelationTargetKey, appId);
+        }
+    }
+}
+#endif

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         {
             Assert.AreEqual("GET " + url.AbsolutePath, remoteDependencyTelemetryActual.Name, true, "Resource name in the sent telemetry is wrong");
             string expectedVersion =
-                SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), prefix: "rddfd:");
+                SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), prefix: "rdddsd:");
             ValidateTelemetryPacket(remoteDependencyTelemetryActual, url, kind, success, valueMin, statusCode, expectedVersion);
         }
 

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
@@ -42,19 +42,14 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
             this.httpDesktopProcessingFramework = new DesktopDiagnosticSourceHttpProcessing(this.configuration, new ObjectInstanceBasedOperationHolder(), /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
-            var correlationIdLookupHelper = new CorrelationIdLookupHelper((string ikey) =>
-            {
-                // Pretend App Id is the same as Ikey
-                var tcs = new TaskCompletionSource<string>();
-                tcs.SetResult(ikey);
-                return tcs.Task;
-            });
-            this.httpDesktopProcessingFramework.OverrideCorrelationIdLookupHelper(correlationIdLookupHelper);
+            this.httpDesktopProcessingFramework.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string> { { this.configuration.InstrumentationKey, "cid-v1:" + this.configuration.InstrumentationKey } }));
+            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
         }
 
         [TestCleanup]
         public void Cleanup()
         {
+            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
         }
         #endregion //TestInitiliaze
 

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
@@ -64,14 +64,15 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         [TestMethod]
         public void RddTestHttpProcessingFrameworkUpdateTelemetryName()
         {
-            var stopwatch = Stopwatch.StartNew();
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
+
+            var stopwatch = Stopwatch.StartNew();
             this.httpProcessingFramework.OnRequestSend(request);
             Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
             Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
             var response = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK);
-            stopwatch.Stop();
             this.httpProcessingFramework.OnResponseReceive(request, response);
+            stopwatch.Stop();
 
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "200");
@@ -85,11 +86,11 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         [TestMethod]
         public void RddTestHttpProcessingFrameworkNoDuplication()
         {
-            Stopwatch stopwatch = Stopwatch.StartNew();
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
             var redirectResponse = TestUtils.GenerateHttpWebResponse(HttpStatusCode.Redirect);
             var successResponse = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK);
 
+            Stopwatch stopwatch = Stopwatch.StartNew();
             this.httpProcessingFramework.OnRequestSend(request);  
             this.httpProcessingFramework.OnRequestSend(request);  
             this.httpProcessingFramework.OnRequestSend(request);  
@@ -98,11 +99,11 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
             Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
             this.httpProcessingFramework.OnResponseReceive(request, redirectResponse);
+            stopwatch.Stop();
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
 
             this.httpProcessingFramework.OnResponseReceive(request, redirectResponse);
             this.httpProcessingFramework.OnResponseReceive(request, successResponse);
-            stopwatch.Stop();
 
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "302");

--- a/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
@@ -47,11 +47,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
             this.httpProcessingFramework = new FrameworkHttpProcessing(this.configuration, new CacheBasedOperationHolder("testCache", 100 * 1000), /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
             this.httpProcessingFramework.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string> { { this.configuration.InstrumentationKey, "cid-v1:" + this.configuration.InstrumentationKey } }));
+            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
         }
 
         [TestCleanup]
         public void Cleanup()
         {
+            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
         }
 #endregion //TestInitiliaze
 
@@ -164,7 +166,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
             var id1 = ClientServerDependencyTracker.GetIdForRequestObject(request);
             var id2 = 200;
-            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnBeginHttpCallback(id1, this.testUrl.ToString());  
             Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
             Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
 
@@ -180,7 +182,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
             var id = ClientServerDependencyTracker.GetIdForRequestObject(request);
-            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnBeginHttpCallback(id, this.testUrl.ToString());  
             this.httpProcessingFramework.OnEndHttpCallback(id, null, false, statusCode);
 
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
@@ -196,13 +198,26 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
             var id = ClientServerDependencyTracker.GetIdForRequestObject(request);
-            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnBeginHttpCallback(id, this.testUrl.ToString());  
             this.httpProcessingFramework.OnEndHttpCallback(id, null, false, statusCode);
 
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             var actual = this.sendItems[0] as DependencyTelemetry;
 
             Assert.IsTrue(actual.Success.Value);
+        }
+
+        [TestMethod]
+        public void FrameworkHttpProcessingIsDisabledWhenHttpDesktopDiagSourceIsEnabled()
+        {
+            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = true;
+
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
+            var id = ClientServerDependencyTracker.GetIdForRequestObject(request);
+            this.httpProcessingFramework.OnBeginHttpCallback(id, this.testUrl.ToString());
+            this.httpProcessingFramework.OnEndHttpCallback(id, null, false, 200);
+
+            Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be sent");
         }
 
         [TestMethod]
@@ -224,229 +239,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         {
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrlNonStandardPort);
             var id = ClientServerDependencyTracker.GetIdForRequestObject(request);
-            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnBeginHttpCallback(id, this.testUrlNonStandardPort.ToString());  
             this.httpProcessingFramework.OnEndHttpCallback(id, null, false, 500);
 
             Assert.AreEqual(1, this.sendItems.Count, "Exactly one telemetry item should be sent");
             DependencyTelemetry receivedItem = (DependencyTelemetry)this.sendItems[0];
             string expectedTarget = this.testUrlNonStandardPort.Host + ":" + this.testUrlNonStandardPort.Port;
             Assert.AreEqual(expectedTarget, receivedItem.Target, "HttpProcessingFramework returned incorrect target for non standard port.");
-        }
-
-        /// <summary>
-        /// Validates that even if OnBeginHttpCallback is called after OnRequestSend, the
-        /// packet should match what's written during OnRequestSend.
-        /// </summary>
-        [TestMethod]
-        public void RddTestHttpProcessingFrameworkUpdateTelemetryName()
-        {
-            Stopwatch stopwatch = Stopwatch.StartNew();
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
-            var id = ClientServerDependencyTracker.GetIdForRequestObject(request);
-            this.httpProcessingFramework.OnRequestSend(request);  
-            this.httpProcessingFramework.OnBeginHttpCallback(id, this.testUrl.OriginalString);
-            Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
-            Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
-            this.httpProcessingFramework.OnEndHttpCallback(id, true, false, 200);
-            stopwatch.Stop();
-
-            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
-            ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "200");
-        }
-
-        /// <summary>
-        /// Validates that even if multiple events have fired, as long as there is only
-        /// one HttpWebRequest, only one event should be written, during the first call
-        /// to OnEndHttpCallback.
-        /// </summary>
-        [TestMethod]
-        public void RddTestHttpProcessingFrameworkNoDuplication()
-        {
-            Stopwatch stopwatch = Stopwatch.StartNew();
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
-            var id = ClientServerDependencyTracker.GetIdForRequestObject(request);
-            var returnObject = TestUtils.GenerateHttpWebResponse(HttpStatusCode.BadRequest);
-
-            this.httpProcessingFramework.OnRequestSend(request);  
-            this.httpProcessingFramework.OnRequestSend(request);  
-            this.httpProcessingFramework.OnBeginHttpCallback(id, this.testUrl.OriginalString);
-            this.httpProcessingFramework.OnRequestSend(request);  
-            this.httpProcessingFramework.OnRequestSend(request);  
-            this.httpProcessingFramework.OnBeginHttpCallback(id, this.testUrl.OriginalString);
-            this.httpProcessingFramework.OnBeginHttpCallback(id, this.testUrl.OriginalString);
-            this.httpProcessingFramework.OnRequestSend(request);  
-            Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
-            Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
-            this.httpProcessingFramework.OnResponseReceive(request, returnObject);
-            this.httpProcessingFramework.OnEndHttpCallback(id, false, false, 409);
-            this.httpProcessingFramework.OnEndHttpCallback(id, true, false, 304);
-            this.httpProcessingFramework.OnResponseReceive(request, returnObject);
-            this.httpProcessingFramework.OnEndHttpCallback(id, true, false, 200);
-            this.httpProcessingFramework.OnResponseReceive(request, returnObject);
-            this.httpProcessingFramework.OnEndHttpCallback(id, false, false, 400);
-            stopwatch.Stop();
-
-            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
-            ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, false, stopwatch.Elapsed.TotalMilliseconds, "409");
-        }
-
-        /// <summary>
-        /// Validates if DependencyTelemetry sent contains the cross component correlation ID.
-        /// </summary>
-        [TestMethod]
-        [Description("Validates if DependencyTelemetry sent contains the cross component correlation ID.")]
-        public void RddTestHttpProcessingFrameworkOnEndAddsAppIdToTargetField()
-        {
-            // Here is a sample App ID, since the test initialize method adds a random ikey and our mock getAppId method pretends that the appId for a given ikey is the same as the ikey.
-            // This will not match the current component's App ID. Hence represents an external component.
-            string appId = "0935FC42-FE1A-4C67-975C-0C9D5CBDEE8E";
-
-            this.SimulateWebRequestResponseWithAppId(appId);
-
-            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
-            Assert.AreEqual(this.testUrl.Host + " | " + this.GetCorrelationIdValue(appId), ((DependencyTelemetry)this.sendItems[0]).Target);
-        }
-
-        /// <summary>
-        /// Ensures that the source request header is added when request is sent.
-        /// </summary>
-        [TestMethod]
-        [Description("Ensures that the source request header is added when request is sent.")]
-        public void RddTestHttpProcessingFrameworkOnBeginAddsSourceHeader()
-        {
-            var request = WebRequest.Create(this.testUrl);
-
-            Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
-
-            this.httpProcessingFramework.OnRequestSend(request);
-            Assert.IsNotNull(request.Headers.GetNameValueHeaderValue(RequestResponseHeaders.RequestContextHeader, RequestResponseHeaders.RequestContextCorrelationSourceKey));
-        }
-
-        /// <summary>
-        /// Ensures that the parent id header is added when request is sent.
-        /// </summary>
-        [TestMethod]
-        public void RddTestHttpProcessingFrameworkOnBeginAddsParentIdHeader()
-        {
-            var request = WebRequest.Create(this.testUrl);
-
-            Assert.IsNull(request.Headers[RequestResponseHeaders.StandardParentIdHeader]);
-
-            var client = new TelemetryClient(this.configuration);
-            using (var op = client.StartOperation<RequestTelemetry>("request"))
-            {
-                this.httpProcessingFramework.OnRequestSend(request);
-
-                var actualParentIdHeader = request.Headers[RequestResponseHeaders.StandardParentIdHeader];
-                var actualRequestIdHeader = request.Headers[RequestResponseHeaders.RequestIdHeader];
-                Assert.IsNotNull(actualParentIdHeader);
-                Assert.AreNotEqual(actualParentIdHeader, op.Telemetry.Context.Operation.Id);
-
-                Assert.AreEqual(actualParentIdHeader, actualRequestIdHeader);
-#if NET45
-                Assert.IsTrue(actualRequestIdHeader.StartsWith(Activity.Current.Id, StringComparison.Ordinal));
-                Assert.AreNotEqual(Activity.Current.Id, actualRequestIdHeader);
-#else
-                Assert.AreEqual(op.Telemetry.Context.Operation.Id, ApplicationInsightsActivity.GetRootId(request.Headers[RequestResponseHeaders.StandardParentIdHeader]));
-#endif
-                // This code should go away when Activity is fixed: https://github.com/dotnet/corefx/issues/18418
-                // check that Ids are not generated by Activity
-                // so they look like OperationTelemetry.Id
-                var operationId = op.Telemetry.Context.Operation.Id;
-
-                // length is like default RequestTelemetry.Id length
-                Assert.AreEqual(new DependencyTelemetry().Id.Length, operationId.Length);
-
-                // operationId is ulong base64 encoded
-                byte[] data = Convert.FromBase64String(operationId);
-                Assert.AreEqual(8, data.Length);
-                BitConverter.ToUInt64(data, 0);
-
-                // does not look like root Id generated by Activity
-                Assert.AreEqual(1, operationId.Split('-').Length);
-
-                //// end of workaround test
-            }
-        }
-
-        /// <summary>
-        /// Ensures that the source request header is not added, as per the config, when request is sent.
-        /// </summary>
-        [TestMethod]
-        [Description("Ensures that the source request header is not added when the config commands as such")]
-        public void RddTestHttpProcessingFrameworkOnBeginSkipsAddingSourceHeaderPerConfig()
-        {
-            string hostnamepart = "partofhostname";
-            string url = string.Format(CultureInfo.InvariantCulture, "http://hostnamestart{0}hostnameend.com/path/to/something?param=1", hostnamepart);
-            var request = WebRequest.Create(new Uri(url));
-
-            Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
-            Assert.AreEqual(0, request.Headers.Keys.Cast<string>().Where((x) => { return x.StartsWith("x-ms-", StringComparison.OrdinalIgnoreCase); }).Count());
-
-            var httpProcessingFramework = new FrameworkHttpProcessing(this.configuration, new CacheBasedOperationHolder("tempCache1", 100 * 1000), /*setCorrelationHeaders*/ false, new List<string>(), RandomAppIdEndpoint);
-            httpProcessingFramework.OnRequestSend(request);
-            Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
-            Assert.AreEqual(0, request.Headers.Keys.Cast<string>().Where((x) => { return x.StartsWith("x-ms-", StringComparison.OrdinalIgnoreCase); }).Count());
-
-            ICollection<string> exclusionList = new SanitizedHostList() { "randomstringtoexclude", hostnamepart };
-            httpProcessingFramework = new FrameworkHttpProcessing(this.configuration, new CacheBasedOperationHolder("tempCache2", 100 * 1000), /*setCorrelationHeaders*/ true, exclusionList, RandomAppIdEndpoint);
-            httpProcessingFramework.OnRequestSend(request);
-            Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
-            Assert.AreEqual(0, request.Headers.Keys.Cast<string>().Where((x) => { return x.StartsWith("x-ms-", StringComparison.OrdinalIgnoreCase); }).Count());
-        }
-
-        /// <summary>
-        /// Ensures that the source request header is not overwritten if already provided by the user.
-        /// </summary>
-        [TestMethod]
-        [Description("Ensures that the source request header is not overwritten if already provided by the user.")]
-        public void RddTestHttpProcessingFrameworkOnBeginDoesNotOverwriteExistingSource()
-        {
-            string sampleHeaderValueWithAppId = RequestResponseHeaders.RequestContextCorrelationSourceKey + "=HelloWorld";
-            var request = WebRequest.Create(this.testUrl);
-
-            request.Headers.Add(RequestResponseHeaders.RequestContextHeader, sampleHeaderValueWithAppId);
-
-            this.httpProcessingFramework.OnRequestSend(request);
-            var actualHeaderValue = request.Headers[RequestResponseHeaders.RequestContextHeader];
-
-            Assert.IsNotNull(actualHeaderValue);
-            Assert.AreEqual(sampleHeaderValueWithAppId, actualHeaderValue);
-
-            string sampleHeaderValueWithoutAppId = "helloWorld";
-            request = WebRequest.Create(this.testUrl);
-
-            request.Headers.Add(RequestResponseHeaders.RequestContextHeader, sampleHeaderValueWithoutAppId);
-
-            this.httpProcessingFramework.OnRequestSend(request);
-            actualHeaderValue = request.Headers[RequestResponseHeaders.RequestContextHeader];
-
-            Assert.IsNotNull(actualHeaderValue);
-            Assert.AreNotEqual(sampleHeaderValueWithAppId, actualHeaderValue);
-        }
-
-        /// <summary>
-        /// Validates HttpProcessingFramework sends correct telemetry on calling OnResponseReceive + OnEndHttpCallback.
-        /// </summary>
-        [TestMethod]
-        [Description("Validates HttpProcessingFramework sends correct telemetry on calling OnResponseReceive + OnEndHttpCallback.")]
-        [Owner("cithomas")]
-        [TestCategory("CVT")]
-        public void RddTestHttpProcessingFrameworkOnEndHttpCallback()
-        {
-            var request = WebRequest.Create(this.testUrl);
-            var returnObjectPassed = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK);
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-            this.httpProcessingFramework.OnRequestSend(request);
-            Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
-            Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");         
-            this.httpProcessingFramework.OnResponseReceive(request, returnObjectPassed);
-            this.httpProcessingFramework.OnEndHttpCallback(ClientServerDependencyTracker.GetIdForRequestObject(request), true, true, 200);
-            stopwatch.Stop();
-
-            Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
-            ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "200");
         }
 
 #endregion //BeginEndCallBacks
@@ -468,16 +267,16 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             Stopwatch stopwatch = Stopwatch.StartNew();
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
             var id1 = ClientServerDependencyTracker.GetIdForRequestObject(request);
-            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnBeginHttpCallback(id1, this.testUrl.ToString());  
             Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
-            this.httpProcessingFramework.OnRequestSend(request);  
+            this.httpProcessingFramework.OnBeginHttpCallback(id1, this.testUrl.ToString());
             Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
             Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
             this.httpProcessingFramework.OnEndHttpCallback(id1, true, false, 200);
             stopwatch.Stop();
 
             Assert.AreEqual(1, this.sendItems.Count, "Exactly one telemetry item should be sent");
-            ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "200");
+            ValidateTelemetryPacketForOnBeginHttpCallback(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "200");
         }        
 
 #endregion AsyncScenarios
@@ -499,13 +298,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             ValidateTelemetryPacket(remoteDependencyTelemetryActual, url, kind, success, valueMin, statusCode, expectedVersion);
         }
 
-        private static void ValidateTelemetryPacketForOnRequestSend(
+/*        private static void ValidateTelemetryPacketForOnRequestSend(
             DependencyTelemetry remoteDependencyTelemetryActual, Uri url, string kind, bool? success, double valueMin, string statusCode)
         {
             Assert.AreEqual("GET " + url.AbsolutePath, remoteDependencyTelemetryActual.Name, true, "Resource name in the sent telemetry is wrong");
             string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), prefix: "rddfd:");
             ValidateTelemetryPacket(remoteDependencyTelemetryActual, url, kind, success, valueMin, statusCode, expectedVersion);
-        }
+        }*/
 
         private static void ValidateTelemetryPacket(
             DependencyTelemetry remoteDependencyTelemetryActual, Uri url, string kind, bool? success, double valueMin, string statusCode, string expectedVersion)
@@ -527,35 +326,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 string.Format(CultureInfo.InvariantCulture, "Value (dependency duration = {0}) in the sent telemetry should not be signigficantly bigger then the time duration between start and end", remoteDependencyTelemetryActual.Duration));
 
             Assert.AreEqual(expectedVersion, remoteDependencyTelemetryActual.Context.GetInternalContext().SdkVersion);
-        }
-
-        private void SimulateWebRequestResponseWithAppId(string appId)
-        {
-            var request = WebRequest.Create(this.testUrl);
-
-            Dictionary<string, string> headers = new Dictionary<string, string>();
-            headers.Add(RequestResponseHeaders.RequestContextHeader, this.GetCorrelationIdHeaderValue(appId));
-
-            var returnObjectPassed = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK, headers);
-
-            this.httpProcessingFramework.OnBeginHttpCallback(ClientServerDependencyTracker.GetIdForRequestObject(request), this.testUrl.OriginalString);
-            this.httpProcessingFramework.OnRequestSend(request);
-            this.httpProcessingFramework.OnResponseReceive(request, returnObjectPassed);
-            this.httpProcessingFramework.OnEndHttpCallback(
-                ClientServerDependencyTracker.GetIdForRequestObject(request),
-                true,
-                true,
-                (int)HttpStatusCode.OK);
-        }
-
-        private string GetCorrelationIdValue(string appId)
-        {
-            return string.Format(CultureInfo.InvariantCulture, "cid-v1:{0}", appId);
-        }
-
-        private string GetCorrelationIdHeaderValue(string appId)
-        {
-            return string.Format(CultureInfo.InvariantCulture, "{0}=cid-v1:{1}", RequestResponseHeaders.RequestContextCorrelationTargetKey, appId);
         }
 
 #endregion Helpers

--- a/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
@@ -298,14 +298,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             ValidateTelemetryPacket(remoteDependencyTelemetryActual, url, kind, success, valueMin, statusCode, expectedVersion);
         }
 
-/*        private static void ValidateTelemetryPacketForOnRequestSend(
-            DependencyTelemetry remoteDependencyTelemetryActual, Uri url, string kind, bool? success, double valueMin, string statusCode)
-        {
-            Assert.AreEqual("GET " + url.AbsolutePath, remoteDependencyTelemetryActual.Name, true, "Resource name in the sent telemetry is wrong");
-            string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), prefix: "rddfd:");
-            ValidateTelemetryPacket(remoteDependencyTelemetryActual, url, kind, success, valueMin, statusCode, expectedVersion);
-        }*/
-
         private static void ValidateTelemetryPacket(
             DependencyTelemetry remoteDependencyTelemetryActual, Uri url, string kind, bool? success, double valueMin, string statusCode, string expectedVersion)
         {

--- a/Src/DependencyCollector/Shared/DependencyCollector.Shared.projitems
+++ b/Src/DependencyCollector/Shared/DependencyCollector.Shared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\AppMapCorrelationEventSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ClientServerDependencyTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\DependencyTargetNameHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\DesktopDiagnosticSourceHttpProcessing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureBlobHttpParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureQueueHttpParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureIotHubHttpParser.cs" />

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -47,7 +47,7 @@
         public bool DisableRuntimeInstrumentation { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to disable runtime instrumentation.
+        /// Gets or sets a value indicating whether to enable Http Desktop DiagnosticSource instrumentation
         /// </summary>
         public bool EnableDiagnosticSourceInstrumentation { get; set; }
 
@@ -288,7 +288,7 @@
             }
             else
             {
-                // if profiler is not attached then default to framework event source
+                // if profiler is not attached then default to diagnositics and framework event source
                 this.InitializeForDiagnosticAndFrameworkEventSource();
 
                 // Log a message to indicate the profiler is not attached

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -47,6 +47,11 @@
         public bool DisableRuntimeInstrumentation { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to disable runtime instrumentation.
+        /// </summary>
+        public bool EnableDiagnosticSourceInstrumentation { get; set; }
+
+        /// <summary>
         /// Gets the component correlation configuration.
         /// </summary>
         public ICollection<string> ExcludeComponentCorrelationHttpHeadersOnDomains
@@ -222,13 +227,16 @@
         private void InitializeForDiagnosticAndFrameworkEventSource()
         {
 #if NET45
-            DesktopDiagnosticSourceHttpProcessing desktopHttpProcessing = new DesktopDiagnosticSourceHttpProcessing(
-                this.telemetryConfiguration, 
-                DependencyTableStore.Instance.WebRequestConditionalHolder,
-                this.SetComponentCorrelationHttpHeaders,
-                this.ExcludeComponentCorrelationHttpHeadersOnDomains,
-                this.EffectiveProfileQueryEndpoint);
-            this.httpDesktopDiagnosticSourceListener = new HttpDesktopDiagnosticSourceListener(desktopHttpProcessing);
+            if (this.EnableDiagnosticSourceInstrumentation)
+            {
+                DesktopDiagnosticSourceHttpProcessing desktopHttpProcessing = new DesktopDiagnosticSourceHttpProcessing(
+                    this.telemetryConfiguration,
+                    DependencyTableStore.Instance.WebRequestConditionalHolder,
+                    this.SetComponentCorrelationHttpHeaders,
+                    this.ExcludeComponentCorrelationHttpHeadersOnDomains,
+                    this.EffectiveProfileQueryEndpoint);
+                this.httpDesktopDiagnosticSourceListener = new HttpDesktopDiagnosticSourceListener(desktopHttpProcessing);
+            }
 
             FrameworkHttpProcessing frameworkHttpProcessing = new FrameworkHttpProcessing(
                 this.telemetryConfiguration,

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -221,9 +221,23 @@
         /// </summary>
         private void InitializeForFrameworkEventSource()
         {
+#if NET45
+            DesktopDiagnosticSourceHttpProcessing desktopHttpProcessing = new DesktopDiagnosticSourceHttpProcessing(
+                this.telemetryConfiguration, 
+                DependencyTableStore.Instance.WebRequestConditionalHolder,
+                this.SetComponentCorrelationHttpHeaders,
+                this.ExcludeComponentCorrelationHttpHeadersOnDomains,
+                this.EffectiveProfileQueryEndpoint);
+            this.httpDesktopDiagnosticSourceListener = new HttpDesktopDiagnosticSourceListener(desktopHttpProcessing);
+#endif
+
 #if !NET40
-            FrameworkHttpProcessing frameworkHttpProcessing = new FrameworkHttpProcessing(this.telemetryConfiguration, DependencyTableStore.Instance.WebRequestCacheHolder, this.SetComponentCorrelationHttpHeaders, this.ExcludeComponentCorrelationHttpHeadersOnDomains, this.EffectiveProfileQueryEndpoint);
-            this.httpDesktopDiagnosticSourceListener = new HttpDesktopDiagnosticSourceListener(frameworkHttpProcessing);
+            FrameworkHttpProcessing frameworkHttpProcessing = new FrameworkHttpProcessing(
+                this.telemetryConfiguration,
+                DependencyTableStore.Instance.WebRequestCacheHolder, 
+                this.SetComponentCorrelationHttpHeaders, 
+                this.ExcludeComponentCorrelationHttpHeadersOnDomains, 
+                this.EffectiveProfileQueryEndpoint);
 
             // In 4.5 EventListener has a race condition issue in constructor so we retry to create listeners
             this.httpEventListener = RetryPolicy.Retry<InvalidOperationException, TelemetryConfiguration, FrameworkHttpEventListener>(

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -219,7 +219,7 @@
         /// <summary>
         /// Initialize for framework event source (not supported for Net40).
         /// </summary>
-        private void InitializeForFrameworkEventSource()
+        private void InitializeForDiagnosticAndFrameworkEventSource()
         {
 #if NET45
             DesktopDiagnosticSourceHttpProcessing desktopHttpProcessing = new DesktopDiagnosticSourceHttpProcessing(
@@ -267,21 +267,21 @@
                     }
                     catch (Exception exp)
                     {
-                        this.InitializeForFrameworkEventSource();
+                        this.InitializeForDiagnosticAndFrameworkEventSource();
                         DependencyCollectorEventSource.Log.ProfilerFailedToAttachError(exp.ToInvariantString());
                     }
                 }
                 else
                 {
                     // if config is set to disable runtime instrumentation then default to framework event source
-                    this.InitializeForFrameworkEventSource();
+                    this.InitializeForDiagnosticAndFrameworkEventSource();
                     DependencyCollectorEventSource.Log.RemoteDependencyModuleVerbose("Runtime instrumentation is set to disabled. Initialize with framework event source instead.");
                 }
             }
             else
             {
                 // if profiler is not attached then default to framework event source
-                this.InitializeForFrameworkEventSource();
+                this.InitializeForDiagnosticAndFrameworkEventSource();
 
                 // Log a message to indicate the profiler is not attached
                 DependencyCollectorEventSource.Log.RemoteDependencyModuleProfilerNotAttached();

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -47,7 +47,7 @@
         public bool DisableRuntimeInstrumentation { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to enable Http Desktop DiagnosticSource instrumentation
+        /// Gets or sets a value indicating whether to enable Http Desktop DiagnosticSource instrumentation.
         /// </summary>
         public bool EnableDiagnosticSourceInstrumentation { get; set; }
 

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -229,9 +229,7 @@
                 this.ExcludeComponentCorrelationHttpHeadersOnDomains,
                 this.EffectiveProfileQueryEndpoint);
             this.httpDesktopDiagnosticSourceListener = new HttpDesktopDiagnosticSourceListener(desktopHttpProcessing);
-#endif
 
-#if !NET40
             FrameworkHttpProcessing frameworkHttpProcessing = new FrameworkHttpProcessing(
                 this.telemetryConfiguration,
                 DependencyTableStore.Instance.WebRequestCacheHolder, 

--- a/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
@@ -106,7 +106,7 @@
 
             Tuple<DependencyTelemetry, bool> telemetryTuple = null;
 
-            if (DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
+            if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated || DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
             {
                 telemetryTuple = DependencyTableStore.Instance.WebRequestConditionalHolder.Get(webRequest);
             }
@@ -139,7 +139,7 @@
             }
 
             var telemetryTuple = new Tuple<DependencyTelemetry, bool>(telemetry, isCustomCreated);
-            if (DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
+            if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated || DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
             {
                 DependencyTableStore.Instance.WebRequestConditionalHolder.Store(webRequest, telemetryTuple);
             }
@@ -165,7 +165,7 @@
 
             Tuple<DependencyTelemetry, bool> telemetryTuple = null;
 
-            if (DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
+            if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated || DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
             {
                 telemetryTuple = DependencyTableStore.Instance.SqlRequestConditionalHolder.Get(sqlRequest);
             }
@@ -198,7 +198,7 @@
             }
 
             var telemetryTuple = new Tuple<DependencyTelemetry, bool>(telemetry, isCustomCreated);
-            if (DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
+            if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated || DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
             {
                 DependencyTableStore.Instance.SqlRequestConditionalHolder.Store(sqlRequest, telemetryTuple);
             }

--- a/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
@@ -165,7 +165,7 @@
 
             Tuple<DependencyTelemetry, bool> telemetryTuple = null;
 
-            if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated || DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
+            if (DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
             {
                 telemetryTuple = DependencyTableStore.Instance.SqlRequestConditionalHolder.Get(sqlRequest);
             }
@@ -198,7 +198,7 @@
             }
 
             var telemetryTuple = new Tuple<DependencyTelemetry, bool>(telemetry, isCustomCreated);
-            if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated || DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
+            if (DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
             {
                 DependencyTableStore.Instance.SqlRequestConditionalHolder.Store(sqlRequest, telemetryTuple);
             }

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -260,6 +260,24 @@
             this.WriteEvent(23, this.ApplicationName);
         }
 
+        [Event(
+            24,
+            Message = "HttpDesktopDiagnosticSourceListener is activated.",
+            Level = EventLevel.Verbose)]
+        public void HttpDesktopDiagnosticSourceListenerIsActivated(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(24, this.ApplicationName);
+        }
+
+        [Event(
+            25,
+            Message = "HttpDesktopDiagnosticSourceListener is deactivated.",
+            Level = EventLevel.Verbose)]
+        public void HttpDesktopDiagnosticSourceListenerIsDeactivated(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(25, this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/DependencyCollector/Shared/Implementation/DependencyTableStore.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyTableStore.cs
@@ -12,6 +12,7 @@
         internal ObjectInstanceBasedOperationHolder SqlRequestConditionalHolder;
 
         internal bool IsProfilerActivated = false;
+        internal bool IsDesktopHttpDiagnosticSourceActivated = false;
         private static DependencyTableStore instance;
 
         private DependencyTableStore() 

--- a/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         private readonly ObjectInstanceBasedOperationHolder telemetryTable;
 
         internal DesktopDiagnosticSourceHttpProcessing(TelemetryConfiguration configuration, ObjectInstanceBasedOperationHolder telemetryTupleHolder, bool setCorrelationHeaders, ICollection<string> correlationDomainExclusionList, string appIdEndpoint)
-            : base(configuration, SdkVersionUtils.GetSdkVersion("rdd" + RddSource.FrameworkAndDiagnostic + ":"), null, setCorrelationHeaders, correlationDomainExclusionList, appIdEndpoint)
+            : base(configuration, SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceDesktop + ":"), null, setCorrelationHeaders, correlationDomainExclusionList, appIdEndpoint)
         {
             if (telemetryTupleHolder == null)
             {

--- a/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     /// </summary>
     internal sealed class DesktopDiagnosticSourceHttpProcessing : HttpProcessing
     {
-        internal ObjectInstanceBasedOperationHolder TelemetryTable;
+        private readonly ObjectInstanceBasedOperationHolder telemetryTable;
 
         internal DesktopDiagnosticSourceHttpProcessing(TelemetryConfiguration configuration, ObjectInstanceBasedOperationHolder telemetryTupleHolder, bool setCorrelationHeaders, ICollection<string> correlationDomainExclusionList, string appIdEndpoint)
             : base(configuration, SdkVersionUtils.GetSdkVersion("rdd" + RddSource.FrameworkAndDiagnostic + ":"), null, setCorrelationHeaders, correlationDomainExclusionList, appIdEndpoint)
@@ -24,7 +24,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 throw new ArgumentNullException("telemetryTupleHolder");
             }
 
-            this.TelemetryTable = telemetryTupleHolder;
+            this.telemetryTable = telemetryTupleHolder;
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         protected override void AddTupleForWebDependencies(WebRequest webRequest, DependencyTelemetry telemetry, bool isCustomCreated)
         {
             var telemetryTuple = new Tuple<DependencyTelemetry, bool>(telemetry, isCustomCreated);
-            this.TelemetryTable.Store(webRequest, telemetryTuple);
+            this.telemetryTable.Store(webRequest, telemetryTuple);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         /// <returns>The tuple for the given request.</returns>
         protected override Tuple<DependencyTelemetry, bool> GetTupleForWebDependencies(WebRequest webRequest)
         {
-            return this.TelemetryTable.Get(webRequest);
+            return this.telemetryTable.Get(webRequest);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         /// <param name="webRequest">The request which acts as the key.</param>
         protected override void RemoveTupleForWebDependencies(WebRequest webRequest)
         {
-            this.TelemetryTable.Remove(webRequest);
+            this.telemetryTable.Remove(webRequest);
         }
     }
 }

--- a/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
@@ -1,0 +1,81 @@
+﻿#if NET45
+namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Web.Implementation;
+
+    /// <summary>
+    /// Concrete class with all processing logic to generate RDD data from the callbacks received from HttpDesktopDiagnosticSourceListener.
+    /// </summary>
+    internal sealed class DesktopDiagnosticSourceHttpProcessing : HttpProcessing
+    {
+        internal ObjectInstanceBasedOperationHolder TelemetryTable;
+
+        internal DesktopDiagnosticSourceHttpProcessing(TelemetryConfiguration configuration, ObjectInstanceBasedOperationHolder telemetryTupleHolder, bool setCorrelationHeaders, ICollection<string> correlationDomainExclusionList, string appIdEndpoint)
+            : base(configuration, SdkVersionUtils.GetSdkVersion("rdd" + RddSource.FrameworkAndDiagnostic + ":"), null, setCorrelationHeaders, correlationDomainExclusionList, appIdEndpoint)
+        {
+            if (telemetryTupleHolder == null)
+            {
+                throw new ArgumentNullException("telemetryTupleHolder");
+            }
+
+            this.TelemetryTable = telemetryTupleHolder;
+        }
+
+        /// <summary>
+        /// On request send callback from Http diagnostic source.
+        /// </summary>
+        /// <param name="request">The WebRequest object.</param>
+        public void OnRequestSend(WebRequest request)
+        {
+            this.OnBegin(request, true);
+        }
+
+        /// <summary>
+        /// On request send callback from Http diagnostic source.
+        /// </summary>
+        /// <param name="request">The WebRequest object.</param>
+        /// <param name="response">The WebResponse object.</param>
+        public void OnResponseReceive(WebRequest request, HttpWebResponse response)
+        {
+            this.OnEnd(null, request, response);
+        }
+
+        /// <summary>
+        /// Implemented by the derived class for adding the tuple to its specific cache.
+        /// </summary>
+        /// <param name="webRequest">The request which acts the key.</param>
+        /// <param name="telemetry">The dependency telemetry for the tuple.</param>
+        /// <param name="isCustomCreated">Boolean value that tells if the current telemetry item is being added by the customer or not.</param>
+        protected override void AddTupleForWebDependencies(WebRequest webRequest, DependencyTelemetry telemetry, bool isCustomCreated)
+        {
+            var telemetryTuple = new Tuple<DependencyTelemetry, bool>(telemetry, isCustomCreated);
+            this.TelemetryTable.Store(webRequest, telemetryTuple);
+        }
+
+        /// <summary>
+        /// Implemented by the derived class for getting the tuple from its specific cache.
+        /// </summary>
+        /// <param name="webRequest">The request which acts as the key.</param>
+        /// <returns>The tuple for the given request.</returns>
+        protected override Tuple<DependencyTelemetry, bool> GetTupleForWebDependencies(WebRequest webRequest)
+        {
+            return this.TelemetryTable.Get(webRequest);
+        }
+
+        /// <summary>
+        /// Implemented by the derived class for removing the tuple from its specific cache.
+        /// </summary>
+        /// <param name="webRequest">The request which acts as the key.</param>
+        protected override void RemoveTupleForWebDependencies(WebRequest webRequest)
+        {
+            this.TelemetryTable.Remove(webRequest);
+        }
+    }
+}
+#endif

--- a/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             ICorrelationIdLookupHelper correlationIdLookupHelper)
         {
             this.client = new TelemetryClient(configuration);
-            this.client.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("rddd");
+            this.client.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceCore + ":");
 
             this.configuration = configuration;
             this.applicationInsightsUrlFilter = new ApplicationInsightsUrlFilter(configuration);

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     /// </summary>
     internal class HttpDesktopDiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
     {
-        private readonly DesktopDiagnosticSourceHttpProcessing httpDesktopProcessingFramework;
+        private readonly DesktopDiagnosticSourceHttpProcessing httpDesktopProcessing;
         private readonly HttpDesktopDiagnosticSourceSubscriber subscribeHelper;
         private readonly PropertyFetcher requestFetcherRequestEvent;
         private readonly PropertyFetcher requestFetcherResponseEvent;
@@ -20,7 +20,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
         internal HttpDesktopDiagnosticSourceListener(DesktopDiagnosticSourceHttpProcessing httpProcessing)
         {
-            this.httpDesktopProcessingFramework = httpProcessing;
+            this.httpDesktopProcessing = httpProcessing;
             this.subscribeHelper = new HttpDesktopDiagnosticSourceSubscriber(this);
             this.requestFetcherRequestEvent = new PropertyFetcher("Request");
             this.requestFetcherResponseEvent = new PropertyFetcher("Request");
@@ -56,7 +56,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         // request is never null
                         var request = (HttpWebRequest)this.requestFetcherRequestEvent.Fetch(value.Value);
                         DependencyCollectorEventSource.Log.BeginCallbackCalled(request.GetHashCode(), value.Key);
-                        this.httpDesktopProcessingFramework.OnRequestSend(request);
+                        this.httpDesktopProcessing.OnRequestSend(request);
                         break;
                     }
 
@@ -70,7 +70,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         var request = (HttpWebRequest)this.requestFetcherResponseEvent.Fetch(value.Value);
                         DependencyCollectorEventSource.Log.EndCallbackCalled(request.GetHashCode().ToString(CultureInfo.InvariantCulture));
                         var response = (HttpWebResponse)this.responseFetcher.Fetch(value.Value);
-                        this.httpDesktopProcessingFramework.OnResponseReceive(request, response);
+                        this.httpDesktopProcessing.OnResponseReceive(request, response);
                         break;
                     }
 

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     /// </summary>
     internal class HttpDesktopDiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
     {
-        private readonly DesktopDiagnosticSourceHttpProcessing httpProcessingFramework;
+        private readonly DesktopDiagnosticSourceHttpProcessing httpDesktopProcessingFramework;
         private readonly HttpDesktopDiagnosticSourceSubscriber subscribeHelper;
         private readonly PropertyFetcher requestFetcherRequestEvent;
         private readonly PropertyFetcher requestFetcherResponseEvent;
@@ -19,7 +19,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
         internal HttpDesktopDiagnosticSourceListener(DesktopDiagnosticSourceHttpProcessing httpProcessing)
         {
-            this.httpProcessingFramework = httpProcessing;
+            this.httpDesktopProcessingFramework = httpProcessing;
             this.subscribeHelper = new HttpDesktopDiagnosticSourceSubscriber(this);
             this.requestFetcherRequestEvent = new PropertyFetcher("Request");
             this.requestFetcherResponseEvent = new PropertyFetcher("Request");
@@ -53,7 +53,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     case "System.Net.Http.Request": 
                     {
                         var request = (HttpWebRequest)this.requestFetcherRequestEvent.Fetch(value.Value);
-                        this.httpProcessingFramework.OnRequestSend(request);
+                        this.httpDesktopProcessingFramework.OnRequestSend(request);
                         break;
                     }
 
@@ -65,7 +65,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     {
                         var request = (HttpWebRequest)this.requestFetcherResponseEvent.Fetch(value.Value);
                         var response = (HttpWebResponse)this.responseFetcher.Fetch(value.Value);
-                        this.httpProcessingFramework.OnResponseReceive(request, response);
+                        this.httpDesktopProcessingFramework.OnResponseReceive(request, response);
                         break;
                     }
                 }

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
@@ -1,4 +1,4 @@
-#if !NET40
+#if NET45
 namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
@@ -10,14 +10,14 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     /// </summary>
     internal class HttpDesktopDiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
     {
-        private readonly FrameworkHttpProcessing httpProcessingFramework;
+        private readonly DesktopDiagnosticSourceHttpProcessing httpProcessingFramework;
         private readonly HttpDesktopDiagnosticSourceSubscriber subscribeHelper;
         private readonly PropertyFetcher requestFetcherRequestEvent;
         private readonly PropertyFetcher requestFetcherResponseEvent;
         private readonly PropertyFetcher responseFetcher;
         private bool disposed = false;
 
-        internal HttpDesktopDiagnosticSourceListener(FrameworkHttpProcessing httpProcessing)
+        internal HttpDesktopDiagnosticSourceListener(DesktopDiagnosticSourceHttpProcessing httpProcessing)
         {
             this.httpProcessingFramework = httpProcessing;
             this.subscribeHelper = new HttpDesktopDiagnosticSourceSubscriber(this);

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
@@ -48,6 +48,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 if (value.Name == "System.Net.Http.Desktop")
                 {
                     this.sourceSubscription = value.Subscribe(this.parent, (Predicate<string>)null);
+                    DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = true;
                 }
             }
         }

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
@@ -49,6 +49,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 {
                     this.sourceSubscription = value.Subscribe(this.parent, (Predicate<string>)null);
                     DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = true;
+                    DependencyCollectorEventSource.Log.HttpDesktopDiagnosticSourceListenerIsActivated();
                 }
             }
         }
@@ -90,6 +91,9 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         this.allListenersSubscription.Dispose();
                     }
                 }
+
+                DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
+                DependencyCollectorEventSource.Log.HttpDesktopDiagnosticSourceListenerIsDeactivated();
 
                 this.disposed = true;
             }

--- a/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
@@ -249,8 +249,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         /// <param name="exception">The exception object if any.</param>
         /// <param name="thisObj">This object.</param>                
         /// <param name="returnValue">Return value of the function if any.</param>
-        /// <param name="endTracking">Whether this method should end the tracking or not.</param>
-        internal void OnEnd(object exception, object thisObj, object returnValue, bool endTracking)
+        internal void OnEnd(object exception, object thisObj, object returnValue)
         {
             try
             {
@@ -284,12 +283,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 // Not custom created
                 if (!telemetryTuple.Item2)
                 {
-                    // Remove it from the tracker only if the caller thinks tracking should end here. If not, the caller
-                    // may want to end tracking outside of this function
-                    if (endTracking)
-                    {
-                        this.RemoveTupleForWebDependencies(webRequest);
-                    }
+                    this.RemoveTupleForWebDependencies(webRequest);
 
                     DependencyTelemetry telemetry = telemetryTuple.Item1;
 
@@ -385,10 +379,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         }
                     }
 
-                    if (endTracking)
-                    {
-                        ClientServerDependencyTracker.EndTracking(this.telemetryClient, telemetry);
-                    }
+                    ClientServerDependencyTracker.EndTracking(this.telemetryClient, telemetry);
                 }
             }
             catch (Exception ex)

--- a/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
@@ -63,7 +63,7 @@
         /// <returns>The resulting return value.</returns>
         public object OnEndForGetResponse(object context, object returnValue, object thisObj)
         {
-            this.OnEnd(null, thisObj, returnValue, true);
+            this.OnEnd(null, thisObj, returnValue);
             return returnValue;
         }
 
@@ -75,7 +75,7 @@
         /// <param name="thisObj">This object.</param>        
         public void OnExceptionForGetResponse(object context, object exception, object thisObj)
         {
-            this.OnEnd(exception, thisObj, null, true);
+            this.OnEnd(exception, thisObj, null);
         }
         
         /// <summary>
@@ -99,7 +99,7 @@
         /// <param name="transportContext">The transport context parameter.</param>
         public void OnExceptionForGetRequestStream(object context, object exception, object thisObj, object transportContext)
         {
-            this.OnEnd(exception, thisObj, null, true);
+            this.OnEnd(exception, thisObj, null);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@
         /// <returns>The return value passed.</returns>
         public object OnEndForEndGetResponse(object context, object returnValue, object thisObj, object asyncResult)
         {
-            this.OnEnd(null, thisObj, returnValue, true);
+            this.OnEnd(null, thisObj, returnValue);
             return returnValue;
         }
 
@@ -137,7 +137,7 @@
         /// <param name="asyncResult">The asyncResult parameter.</param>
         public void OnExceptionForEndGetResponse(object context, object exception, object thisObj, object asyncResult)
         {
-            this.OnEnd(exception, thisObj, null, true);
+            this.OnEnd(exception, thisObj, null);
         }
 
         /// <summary>
@@ -163,7 +163,7 @@
         /// <param name="transportContext">The transportContext parameter.</param>
         public void OnExceptionForEndGetRequestStream(object context, object exception, object thisObj, object asyncResult, object transportContext)
         {
-            this.OnEnd(exception, thisObj, null, true);
+            this.OnEnd(exception, thisObj, null);
         }
 
         #endregion // Http callbacks

--- a/Src/DependencyCollector/Shared/Implementation/RDDSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/RDDSource.cs
@@ -4,6 +4,7 @@
     {
         internal static string Profiler = "p";
         internal static string Framework = "f";
-        internal static string FrameworkAndDiagnostic = "fd";
+        internal static string DiagnosticSourceDesktop = "dsd";
+        internal static string DiagnosticSourceCore = "dsc";
     }
 }

--- a/Src/TestFramework/Shared/SdkVersionHelper.cs
+++ b/Src/TestFramework/Shared/SdkVersionHelper.cs
@@ -1,6 +1,10 @@
 ﻿namespace Microsoft.ApplicationInsights.TestFramework
 {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     using System;
+#if NETCORE
+    using System.Collections.Generic;
+#endif
     using System.Linq;
     using System.Reflection;
 
@@ -8,11 +12,16 @@
     {
         public static string GetExpectedSdkVersion(Type assemblyType, string prefix)
         {
-            string versonStr = Assembly.GetAssembly(assemblyType).GetCustomAttributes(false)
-                    .OfType<AssemblyFileVersionAttribute>()
-                    .First()
-                    .Version;
-            string[] versionParts = new Version(versonStr).ToString().Split('.');
+#if NETCORE
+            IEnumerable<Attribute> assemblyCustomAttributes = assemblyType.GetTypeInfo().Assembly.GetCustomAttributes();
+#else
+            object[] assemblyCustomAttributes = assemblyType.Assembly.GetCustomAttributes(false);
+#endif
+            string versionStr = assemblyCustomAttributes
+                .OfType<AssemblyFileVersionAttribute>()
+                .First()
+                .Version;
+            string[] versionParts = new Version(versionStr).ToString().Split('.');
 
             var expected = prefix + string.Join(".", versionParts[0], versionParts[1], versionParts[2]) + "-" + versionParts[3];
 

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCoreHttpTests.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCoreHttpTests.cs
@@ -107,7 +107,7 @@
         {
             EnsureDotNetCoreInstalled();
 
-            return new ExpectedSDKPrefixChanger("rddd");
+            return new ExpectedSDKPrefixChanger("rdddsc");
         }
 
         private const string AspxCoreTestAppFolder = "..\\TestApps\\AspxCore\\";


### PR DESCRIPTION
See #509 for the details.

Please note:
1. Before this fix, all dependencies are reported, but none of the dependencies instrumented with DiagnosticSource have proper Target with appId.

2. After this fix
  * dependency has proper target if AppId was returned in response header
  * for requests with redirects, only first call is tracked (so the duration and status are wrong). This we should fix in DiagnosticSource. (**Update** [fixed and merged](https://github.com/dotnet/corefx/pull/19195))
  * some dependency calls may be missed if they are done with WebRequest.GetResponse() AND **response is not disposed**. This is fundamental flaw in the reflection hook and there is no know solution for this issue. 
E.g.
```C#
            HttpWebRequest request = WebRequest.CreateHttp("http://localhost:3000");
            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
```
Will never be tracked... Application that does not dispose WebRequests may run short on the available connections, so in most cases uses will dispose them.

```C#
            HttpWebRequest request = WebRequest.CreateHttp("http://localhost:3000");
            using( HttpWebResponse response = (HttpWebResponse)request.GetResponse())
            {
            }
```
Will be tracked.
**This problem does not affect requests done with HttpClient as responses are disposed.** 

------------------------------------
**Considering that some dependencies may not be collected and it does not look fixable, please decide whether this fix should be taken at all.
Otherwise, just keep current implementation (and sacrifice AppId for all dependencies).**