### PR TITLE
Handle failed dependencies with EventSource and DiagnosticSource

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.sendItems = new List<ITelemetry>();
             this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
-            this.httpDesktopProcessingFramework = new DesktopDiagnosticSourceHttpProcessing(this.configuration, new ObjectInstanceBasedOperationHolder(), /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
+            this.httpDesktopProcessingFramework = new DesktopDiagnosticSourceHttpProcessing(this.configuration, new CacheBasedOperationHolder("testCache", 100 * 1000), /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
             this.httpDesktopProcessingFramework.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string> { { this.configuration.InstrumentationKey, "cid-v1:" + this.configuration.InstrumentationKey } }));
             DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
         }
@@ -208,7 +208,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
             var localHttpProcessingFramework = new DesktopDiagnosticSourceHttpProcessing(
                 this.configuration, 
-                new ObjectInstanceBasedOperationHolder(),  
+                new CacheBasedOperationHolder("testCache", 100 * 1000),  
                 false, 
                 new List<string>(),
                 RandomAppIdEndpoint);
@@ -220,7 +220,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             ICollection<string> exclusionList = new SanitizedHostList() { "randomstringtoexclude", hostnamepart };
             localHttpProcessingFramework = new DesktopDiagnosticSourceHttpProcessing(
                 this.configuration,
-                new ObjectInstanceBasedOperationHolder(),
+                new CacheBasedOperationHolder("testCache", 100 * 1000), 
                 true, 
                 exclusionList,
                 RandomAppIdEndpoint);

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -47,9 +47,9 @@
         public bool DisableRuntimeInstrumentation { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to enable Http Desktop DiagnosticSource instrumentation.
+        /// Gets or sets a value indicating whether to disable Http Desktop DiagnosticSource instrumentation.
         /// </summary>
-        public bool EnableDiagnosticSourceInstrumentation { get; set; }
+        public bool DisableDiagnosticSourceInstrumentation { get; set; }
 
         /// <summary>
         /// Gets the component correlation configuration.
@@ -227,11 +227,11 @@
         private void InitializeForDiagnosticAndFrameworkEventSource()
         {
 #if NET45
-            if (this.EnableDiagnosticSourceInstrumentation)
+            if (!this.DisableDiagnosticSourceInstrumentation)
             {
                 DesktopDiagnosticSourceHttpProcessing desktopHttpProcessing = new DesktopDiagnosticSourceHttpProcessing(
                     this.telemetryConfiguration,
-                    DependencyTableStore.Instance.WebRequestConditionalHolder,
+                    DependencyTableStore.Instance.WebRequestCacheHolder,
                     this.SetComponentCorrelationHttpHeaders,
                     this.ExcludeComponentCorrelationHttpHeadersOnDomains,
                     this.EffectiveProfileQueryEndpoint);

--- a/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
@@ -106,7 +106,7 @@
 
             Tuple<DependencyTelemetry, bool> telemetryTuple = null;
 
-            if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated || DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
+            if (DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
             {
                 telemetryTuple = DependencyTableStore.Instance.WebRequestConditionalHolder.Get(webRequest);
             }
@@ -139,7 +139,7 @@
             }
 
             var telemetryTuple = new Tuple<DependencyTelemetry, bool>(telemetry, isCustomCreated);
-            if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated || DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
+            if (DependencyTableStore.Instance.IsProfilerActivated || PretendProfilerIsAttached)
             {
                 DependencyTableStore.Instance.WebRequestConditionalHolder.Store(webRequest, telemetryTuple);
             }

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -278,6 +278,15 @@
             this.WriteEvent(25, this.ApplicationName);
         }
 
+        [Event(
+            26,
+            Message = "Telemetry for id = '{0}' is tracked with HttpDesktopDiagnosticSourceListener.",
+            Level = EventLevel.Verbose)]
+        public void SkipTrackingTelemetryItemWithEventSource(long id, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(26, id, this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
@@ -14,9 +14,9 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     /// </summary>
     internal sealed class DesktopDiagnosticSourceHttpProcessing : HttpProcessing
     {
-        private readonly ObjectInstanceBasedOperationHolder telemetryTable;
+        private readonly CacheBasedOperationHolder telemetryTable;
 
-        internal DesktopDiagnosticSourceHttpProcessing(TelemetryConfiguration configuration, ObjectInstanceBasedOperationHolder telemetryTupleHolder, bool setCorrelationHeaders, ICollection<string> correlationDomainExclusionList, string appIdEndpoint)
+        internal DesktopDiagnosticSourceHttpProcessing(TelemetryConfiguration configuration, CacheBasedOperationHolder telemetryTupleHolder, bool setCorrelationHeaders, ICollection<string> correlationDomainExclusionList, string appIdEndpoint)
             : base(configuration, SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceDesktop + ":"), null, setCorrelationHeaders, correlationDomainExclusionList, appIdEndpoint)
         {
             if (telemetryTupleHolder == null)
@@ -55,7 +55,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         protected override void AddTupleForWebDependencies(WebRequest webRequest, DependencyTelemetry telemetry, bool isCustomCreated)
         {
             var telemetryTuple = new Tuple<DependencyTelemetry, bool>(telemetry, isCustomCreated);
-            this.telemetryTable.Store(webRequest, telemetryTuple);
+            this.telemetryTable.Store(ClientServerDependencyTracker.GetIdForRequestObject(webRequest), telemetryTuple);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         /// <returns>The tuple for the given request.</returns>
         protected override Tuple<DependencyTelemetry, bool> GetTupleForWebDependencies(WebRequest webRequest)
         {
-            return this.telemetryTable.Get(webRequest);
+            return this.telemetryTable.Get(ClientServerDependencyTracker.GetIdForRequestObject(webRequest));
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         /// <param name="webRequest">The request which acts as the key.</param>
         protected override void RemoveTupleForWebDependencies(WebRequest webRequest)
         {
-            this.telemetryTable.Remove(webRequest);
+            this.telemetryTable.Remove(ClientServerDependencyTracker.GetIdForRequestObject(webRequest));
         }
     }
 }


### PR DESCRIPTION
**DEPENDS ON #516**, do not merge until that one is merged

Http Desktop DiagnosticListener never reports failed requests (resulted in exception because of network issue, SSL cert issue , timed out,  etc).

However they are reported by FramewrokEventSource.

This change reports such failed requests based on EventSoucrce event.