### PR TITLE
Prevent double header injection with Http Desktop DiagnosticSource (#530)

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
@@ -8,7 +8,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     using System.Linq;
     using System.Net;
     using System.Threading;
-    using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -62,16 +61,32 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
 
             var stopwatch = Stopwatch.StartNew();
-            this.httpDesktopProcessingFramework.OnRequestSend(request);
+            this.httpDesktopProcessingFramework.OnBegin(request);
             Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
             Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
             var response = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK);
-            this.httpDesktopProcessingFramework.OnResponseReceive(request, response);
+            this.httpDesktopProcessingFramework.OnEnd(null, request, response);
             stopwatch.Stop();
 
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "200");
         }
+
+         /// <summary>
+         /// Validates that OnBegin does not inject headers when called with injectCorrelationHeadersFlag = false.
+         /// </summary>
+         [TestMethod]
+         public void RddTestHttpProcessingFrameworkDoNotInjectHeadersWhenFlagIsSet()
+         {
+             var activity = new Activity("parent").AddBaggage("k", "v").Start();
+             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
+             this.httpDesktopProcessingFramework.OnBegin(request, false);
+             Assert.IsNull(request.Headers[RequestResponseHeaders.RequestIdHeader]);
+             Assert.IsNull(request.Headers[RequestResponseHeaders.CorrelationContextHeader]);
+             Assert.IsNotNull(request.Headers[RequestResponseHeaders.StandardRootIdHeader]);
+             Assert.IsNotNull(request.Headers[RequestResponseHeaders.StandardParentIdHeader]);
+             activity.Stop();
+         }
 
         /// <summary>
         /// Validates that even if multiple events have fired, as long as there is only
@@ -86,19 +101,19 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             var successResponse = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK);
 
             Stopwatch stopwatch = Stopwatch.StartNew();
-            this.httpDesktopProcessingFramework.OnRequestSend(request);  
-            this.httpDesktopProcessingFramework.OnRequestSend(request);  
-            this.httpDesktopProcessingFramework.OnRequestSend(request);  
-            this.httpDesktopProcessingFramework.OnRequestSend(request);  
-            this.httpDesktopProcessingFramework.OnRequestSend(request);  
+            this.httpDesktopProcessingFramework.OnBegin(request);  
+            this.httpDesktopProcessingFramework.OnBegin(request);  
+            this.httpDesktopProcessingFramework.OnBegin(request);  
+            this.httpDesktopProcessingFramework.OnBegin(request);  
+            this.httpDesktopProcessingFramework.OnBegin(request);  
             Thread.Sleep(this.sleepTimeMsecBetweenBeginAndEnd);
             Assert.AreEqual(0, this.sendItems.Count, "No telemetry item should be processed without calling End");
-            this.httpDesktopProcessingFramework.OnResponseReceive(request, redirectResponse);
+            this.httpDesktopProcessingFramework.OnEnd(null, request, redirectResponse);
             stopwatch.Stop();
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
 
-            this.httpDesktopProcessingFramework.OnResponseReceive(request, redirectResponse);
-            this.httpDesktopProcessingFramework.OnResponseReceive(request, successResponse);
+            this.httpDesktopProcessingFramework.OnEnd(null, request, redirectResponse);
+            this.httpDesktopProcessingFramework.OnEnd(null, request, successResponse);
 
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             ValidateTelemetryPacketForOnRequestSend(this.sendItems[0] as DependencyTelemetry, this.testUrl, RemoteDependencyConstants.HTTP, true, stopwatch.Elapsed.TotalMilliseconds, "302");
@@ -124,8 +139,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
             var response = TestUtils.GenerateHttpWebResponse(HttpStatusCode.OK, headers);
 
-            this.httpDesktopProcessingFramework.OnRequestSend(request);
-            this.httpDesktopProcessingFramework.OnResponseReceive(request, response);
+            this.httpDesktopProcessingFramework.OnBegin(request);
+            this.httpDesktopProcessingFramework.OnEnd(null, request, response);
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             Assert.AreEqual(this.testUrl.Host + " | " + this.GetCorrelationIdValue(appId), ((DependencyTelemetry)this.sendItems[0]).Target);
         }
@@ -141,7 +156,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
             Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
 
-            this.httpDesktopProcessingFramework.OnRequestSend(request);
+            this.httpDesktopProcessingFramework.OnBegin(request);
             Assert.IsNotNull(request.Headers.GetNameValueHeaderValue(RequestResponseHeaders.RequestContextHeader, RequestResponseHeaders.RequestContextCorrelationSourceKey));
         }
 
@@ -158,7 +173,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             var client = new TelemetryClient(this.configuration);
             using (var op = client.StartOperation<RequestTelemetry>("request"))
             {
-                this.httpDesktopProcessingFramework.OnRequestSend(request);
+                this.httpDesktopProcessingFramework.OnBegin(request);
 
                 var actualParentIdHeader = request.Headers[RequestResponseHeaders.StandardParentIdHeader];
                 var actualRequestIdHeader = request.Headers[RequestResponseHeaders.RequestIdHeader];
@@ -213,7 +228,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 new List<string>(),
                 RandomAppIdEndpoint);
 
-            localHttpProcessingFramework.OnRequestSend(request);
+            localHttpProcessingFramework.OnBegin(request);
             Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
             Assert.AreEqual(0, request.Headers.Keys.Cast<string>().Count(x => x.StartsWith("x-ms-", StringComparison.OrdinalIgnoreCase)));
 
@@ -224,7 +239,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 true, 
                 exclusionList,
                 RandomAppIdEndpoint);
-            localHttpProcessingFramework.OnRequestSend(request);
+            localHttpProcessingFramework.OnBegin(request);
             Assert.IsNull(request.Headers[RequestResponseHeaders.RequestContextHeader]);
             Assert.AreEqual(0, request.Headers.Keys.Cast<string>().Count(x => x.StartsWith("x-ms-", StringComparison.OrdinalIgnoreCase)));
         }
@@ -241,7 +256,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
             request.Headers.Add(RequestResponseHeaders.RequestContextHeader, sampleHeaderValueWithAppId);
 
-            this.httpDesktopProcessingFramework.OnRequestSend(request);
+            this.httpDesktopProcessingFramework.OnBegin(request);
             var actualHeaderValue = request.Headers[RequestResponseHeaders.RequestContextHeader];
 
             Assert.IsNotNull(actualHeaderValue);
@@ -252,7 +267,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
             request.Headers.Add(RequestResponseHeaders.RequestContextHeader, sampleHeaderValueWithoutAppId);
 
-            this.httpDesktopProcessingFramework.OnRequestSend(request);
+            this.httpDesktopProcessingFramework.OnBegin(request);
             actualHeaderValue = request.Headers[RequestResponseHeaders.RequestContextHeader];
 
             Assert.IsNotNull(actualHeaderValue);

--- a/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
@@ -28,25 +28,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         }
 
         /// <summary>
-        /// On request send callback from Http diagnostic source.
-        /// </summary>
-        /// <param name="request">The WebRequest object.</param>
-        public void OnRequestSend(WebRequest request)
-        {
-            this.OnBegin(request, true);
-        }
-
-        /// <summary>
-        /// On request send callback from Http diagnostic source.
-        /// </summary>
-        /// <param name="request">The WebRequest object.</param>
-        /// <param name="response">The WebResponse object.</param>
-        public void OnResponseReceive(WebRequest request, HttpWebResponse response)
-        {
-            this.OnEnd(null, request, response);
-        }
-
-        /// <summary>
         /// Implemented by the derived class for adding the tuple to its specific cache.
         /// </summary>
         /// <param name="webRequest">The request which acts the key.</param>

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
@@ -48,6 +48,15 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 switch (value.Key)
                 {
                     case "System.Net.Http.Desktop.HttpRequestOut.Start":
+                    {
+                        var request = (HttpWebRequest)this.requestFetcherRequestEvent.Fetch(value.Value);
+                        DependencyCollectorEventSource.Log.BeginCallbackCalled(request.GetHashCode(), value.Key);
+
+                        // With this event, DiagnosticSource injects headers himself (after the event)
+                        // ApplicationInsights must not do this
+                        this.httpDesktopProcessing.OnBegin(request, false);
+                        break;
+                    }
 
                     // remove "System.Net.Http.Request" in 2.5.0 (but keep the same code for "System.Net.Http.Desktop.HttpRequestOut.Start")
                     // event was temporarily introduced in DiagnosticSource and removed before stable release
@@ -56,7 +65,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         // request is never null
                         var request = (HttpWebRequest)this.requestFetcherRequestEvent.Fetch(value.Value);
                         DependencyCollectorEventSource.Log.BeginCallbackCalled(request.GetHashCode(), value.Key);
-                        this.httpDesktopProcessing.OnRequestSend(request);
+                        this.httpDesktopProcessing.OnBegin(request);
                         break;
                     }
 
@@ -70,7 +79,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         var request = (HttpWebRequest)this.requestFetcherResponseEvent.Fetch(value.Value);
                         DependencyCollectorEventSource.Log.EndCallbackCalled(request.GetHashCode().ToString(CultureInfo.InvariantCulture));
                         var response = (HttpWebResponse)this.responseFetcher.Fetch(value.Value);
-                        this.httpDesktopProcessing.OnResponseReceive(request, response);
+                        this.httpDesktopProcessing.OnEnd(null, request, response);
                         break;
                     }
 

--- a/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
@@ -51,7 +51,7 @@
         /// <returns>The context for end callback.</returns>
         public object OnBeginForGetResponse(object thisObj)
         {
-            return this.OnBegin(thisObj, true);
+            return this.OnBegin(thisObj);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@
         /// <returns>The context for end callback.</returns>
         public object OnBeginForGetRequestStream(object thisObj, object transportContext)
         {
-            return this.OnBegin(thisObj, true);
+            return this.OnBegin(thisObj);
         }       
 
         /// <summary>
@@ -111,7 +111,7 @@
         /// <returns>The context for end callback.</returns>
         public object OnBeginForBeginGetResponse(object thisObj, object callback, object state)
         {
-            return this.OnBegin(thisObj, true);
+            return this.OnBegin(thisObj);
         }
 
         /// <summary>
@@ -149,7 +149,7 @@
         /// <returns>The context for end callback.</returns>
         public object OnBeginForBeginGetRequestStream(object thisObj, object callback, object state)
         {
-            return this.OnBegin(thisObj, true);
+            return this.OnBegin(thisObj);
         }
 
         /// <summary>


### PR DESCRIPTION
When `HttpDesktopDiagnosticSourceListener` receives `System.Net.Http.Desktop.HttpRequestOut.Start` event from DiagnosticSource, it injects Request-Id and Correlation-Context headers.

After that DiagnosticSource injects it too.

AppInsights must only inject the header if request is instrumented with profiler .

This issue does not break customers since they use version of DiagnosticSource that does not inject headers (the only one available on nuget.org).

However the fix is needed in the stable release with updated DiagnosticSource.