### PR TITLE
Reject AI URLs in DiagnosticSource.IsEnabled call

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DesktopDiagnosticSourceHttpProcessingTests.cs
@@ -42,13 +42,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
             this.httpDesktopProcessingFramework = new DesktopDiagnosticSourceHttpProcessing(this.configuration, new CacheBasedOperationHolder("testCache", 100 * 1000), /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
             this.httpDesktopProcessingFramework.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string> { { this.configuration.InstrumentationKey, "cid-v1:" + this.configuration.InstrumentationKey } }));
-            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
+            DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated = false;
         }
 
         [TestCleanup]
         public void Cleanup()
         {
-            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
+            DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated = false;
         }
         #endregion //TestInitiliaze
 

--- a/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
@@ -47,13 +47,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
             this.httpProcessingFramework = new FrameworkHttpProcessing(this.configuration, new CacheBasedOperationHolder("testCache", 100 * 1000), /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
             this.httpProcessingFramework.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string> { { this.configuration.InstrumentationKey, "cid-v1:" + this.configuration.InstrumentationKey } }));
-            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
+            DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated = false;
         }
 
         [TestCleanup]
         public void Cleanup()
         {
-            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
+            DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated = false;
         }
 #endregion //TestInitiliaze
 
@@ -210,7 +210,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         [TestMethod]
         public void FrameworkHttpProcessingIsDisabledWhenHttpDesktopDiagSourceIsEnabled()
         {
-            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = true;
+            DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated = true;
 
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.testUrl);
             var id = ClientServerDependencyTracker.GetIdForRequestObject(request);

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Runtime.CompilerServices;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
@@ -145,6 +146,10 @@
 #endif
                             DependencyCollectorEventSource.Log.RemoteDependencyModuleError(exc.ToInvariantString(), clrVersion);
                         }
+
+#if !NET40
+                        this.PrepareActivity();
+#endif
 
                         this.isInitialized = true;
                     }
@@ -297,6 +302,20 @@
                 DependencyCollectorEventSource.Log.RemoteDependencyModuleProfilerNotAttached();
             }
         }
+#endif
+
+#if !NET40
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        private void PrepareActivity()
+        {
+            // when the first Activity is created in the process (on .NET Framework), it syncronizes DateTime.UtcNow 
+            // in order to make it's StartTime and duration precise, it may take up to 16ms. 
+            // Let's create the first Activity ever here, so we will not miss those 16ms on the first dependency tracking
+            var activity = new Activity("Microsoft.ApplicationInights.Init");
+            activity.Start();
+            activity.Stop();
+        }
+
 #endif
     }
 }

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -237,7 +237,7 @@
                     this.SetComponentCorrelationHttpHeaders,
                     this.ExcludeComponentCorrelationHttpHeadersOnDomains,
                     this.EffectiveProfileQueryEndpoint);
-                this.httpDesktopDiagnosticSourceListener = new HttpDesktopDiagnosticSourceListener(desktopHttpProcessing);
+                this.httpDesktopDiagnosticSourceListener = new HttpDesktopDiagnosticSourceListener(desktopHttpProcessing, new ApplicationInsightsUrlFilter(this.telemetryConfiguration));
             }
 
             FrameworkHttpProcessing frameworkHttpProcessing = new FrameworkHttpProcessing(

--- a/Src/DependencyCollector/Shared/Implementation/ApplicationInsightsUrlFilter.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ApplicationInsightsUrlFilter.cs
@@ -62,14 +62,41 @@
         /// </summary>
         /// <param name="url">HTTP URL.</param>
         /// <returns>True if URL is application insights url, otherwise false.</returns>
+        internal bool IsApplicationInsightsUrl(Uri url)
+        {
+            // first check that it's not active internal SDK operation 
+            if (SdkInternalOperationsMonitor.IsEntered())
+            {
+                return true;
+            }
+
+            return this.IsApplicationInsightsUrlImpl(url?.ToString());
+        }
+
+        /// <summary>
+        /// Determines whether an URL is application insights URL.
+        /// </summary>
+        /// <param name="url">HTTP URL.</param>
+        /// <returns>True if URL is application insights url, otherwise false.</returns>
         internal bool IsApplicationInsightsUrl(string url)
+        {
+            // first check that it's not active internal SDK operation 
+            if (SdkInternalOperationsMonitor.IsEntered())
+            {
+                return true;
+            }
+
+            return this.IsApplicationInsightsUrlImpl(url);
+        }
+
+        private bool IsApplicationInsightsUrlImpl(string url)
         {
             bool result = false;
             if (!string.IsNullOrEmpty(url))
             {
                 // Check if url matches default values for service endpoint/quick pulse.
                 result = url.StartsWith(ApplicationInsightsUrlFilter.TelemetryServiceEndpoint, StringComparison.OrdinalIgnoreCase)
-                    || url.StartsWith(ApplicationInsightsUrlFilter.QuickPulseServiceEndpoint, StringComparison.OrdinalIgnoreCase);
+                         || url.StartsWith(ApplicationInsightsUrlFilter.QuickPulseServiceEndpoint, StringComparison.OrdinalIgnoreCase);
 
                 if (!result)
                 {
@@ -79,14 +106,10 @@
                     {
                         result = url.StartsWith(endpointUrl, StringComparison.OrdinalIgnoreCase);
                     }
-                }   
-                             
-                return result;
+                }
             }
-            else
-            {
-                return result;
-            }
+
+            return result;
         }
     }
 }

--- a/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
@@ -50,7 +50,7 @@
                 // if there is no parent Activity, ID Activity generates is not random enough to work well with 
                 // ApplicationInsights sampling algorithm
                 // This code should go away when Activity is fixed: https://github.com/dotnet/corefx/issues/18418
-                if (Activity.Current == null)
+                if (currentActivity == null)
                 {
                     activity.SetParentId(telemetry.Id);
                 }

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -287,6 +287,26 @@
             this.WriteEvent(26, id, this.ApplicationName);
         }
 
+        [Event(
+            27,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "HttpDesktopDiagnosticSourceListener: Begin callback called for id = '{0}', name= '{1}'",
+            Level = EventLevel.Verbose)]
+        public void HttpDesktopBeginCallbackCalled(long id, string name, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(27, id, name ?? string.Empty, this.ApplicationName);
+        }
+
+        [Event(
+            28,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "HttpDesktopDiagnosticSourceListener: End callback called for id = '{0}'",
+            Level = EventLevel.Verbose)]
+        public void HttpDesktopEndCallbackCalled(long id, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(28, id, this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/DependencyCollector/Shared/Implementation/DependencyTableStore.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyTableStore.cs
@@ -6,13 +6,13 @@
 
     internal class DependencyTableStore : IDisposable
     {
+        internal static bool IsDesktopHttpDiagnosticSourceActivated = false;
         internal CacheBasedOperationHolder WebRequestCacheHolder;
         internal CacheBasedOperationHolder SqlRequestCacheHolder;
         internal ObjectInstanceBasedOperationHolder WebRequestConditionalHolder;
         internal ObjectInstanceBasedOperationHolder SqlRequestConditionalHolder;
 
         internal bool IsProfilerActivated = false;
-        internal bool IsDesktopHttpDiagnosticSourceActivated = false;
 
         private static readonly object SyncRoot = new object();
         private static DependencyTableStore instance;

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
@@ -78,7 +78,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 switch (eventData.EventId)
                 {
                     case BeginGetResponseEventId:
-                        if (!DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated)
+                        if (!DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated)
                         {
                             // request is handled by Desktop DiagnosticSource Listener
                             this.OnBeginGetResponse(eventData);
@@ -89,7 +89,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         this.OnEndGetResponse(eventData);
                         break;
                     case BeginGetRequestStreamEventId:
-                        if (!DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated)
+                        if (!DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated)
                         {
                             // request is handled by Desktop DiagnosticSource Listener
                             this.OnBeginGetRequestStream(eventData);

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -79,7 +79,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 bool isCustomCreated = false;
 
                 var telemetry = ClientServerDependencyTracker.BeginTracking(this.telemetryClient);
-
                 telemetry.Type = RemoteDependencyConstants.HTTP;
                 telemetry.Name = url.AbsolutePath;
                 telemetry.Target = DependencyTargetNameHelper.GetDependencyTargetName(url);
@@ -117,7 +116,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
                 if (statusCode.HasValue)
                 {
-                    if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated && statusCode.Value > 0)
+                    if (DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated && statusCode.Value > 0)
                     {
                         // HttpDesktopDiagnosticSourceListener do not get notifications about exceptions during requests processing.
                         // We will report them here, and we will let HttpDesktopDiagnosticSourceListener track the dependency for successful response

--- a/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
@@ -171,7 +171,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             }
 
             if (request != null &&
-                !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri.ToString()))
+                !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
             {
                 this.InjectRequestHeaders(request, this.configuration.InstrumentationKey);
             }
@@ -192,7 +192,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             }
 
             if (request != null && request.RequestUri != null &&
-                !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri.ToString()))
+                !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
             {
                 Uri requestUri = request.RequestUri;
                 var resourceName = request.Method.Method + " " + requestUri.AbsolutePath;
@@ -246,7 +246,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         internal void OnRequest(HttpRequestMessage request, Guid loggingRequestId)
         {
             if (request != null && request.RequestUri != null &&
-                !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri.ToString()))
+                !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
             {
                 Uri requestUri = request.RequestUri;
                 var resourceName = request.Method.Method + " " + requestUri.AbsolutePath;

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                             return true;
                         });
 
-                    DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = true;
+                    DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated = true;
                     DependencyCollectorEventSource.Log.HttpDesktopDiagnosticSourceListenerIsActivated();
                 }
             }
@@ -110,7 +110,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     }
                 }
 
-                DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
+                DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated = false;
                 DependencyCollectorEventSource.Log.HttpDesktopDiagnosticSourceListenerIsDeactivated();
 
                 this.disposed = true;

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                             {
                                 // request is never null
                                 var request = (HttpWebRequest)r;
-                                return !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri.ToString());
+                                return !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri);
                             }
 
                             return true;

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
     using System.Diagnostics;
+    using System.Net;
 
     /// <summary>
     /// A helper subscriber class helping the parent object, which is a HttpDiagnosticSourceListener, to subscribe
@@ -13,12 +14,16 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     {
         private readonly HttpDesktopDiagnosticSourceListener parent;
         private readonly IDisposable allListenersSubscription;
+        private readonly ApplicationInsightsUrlFilter applicationInsightsUrlFilter;
         private IDisposable sourceSubscription;
         private bool disposed = false;
 
-        internal HttpDesktopDiagnosticSourceSubscriber(HttpDesktopDiagnosticSourceListener parent)
+        internal HttpDesktopDiagnosticSourceSubscriber(
+            HttpDesktopDiagnosticSourceListener parent,
+            ApplicationInsightsUrlFilter applicationInsightsUrlFilter)
         {
             this.parent = parent;
+            this.applicationInsightsUrlFilter = applicationInsightsUrlFilter;
             this.allListenersSubscription = DiagnosticListener.AllListeners.Subscribe(this);
         }
 
@@ -47,7 +52,20 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             {
                 if (value.Name == "System.Net.Http.Desktop")
                 {
-                    this.sourceSubscription = value.Subscribe(this.parent, (Predicate<string>)null);
+                    this.sourceSubscription = value.Subscribe(
+                        this.parent, 
+                        (evnt, r, _) =>
+                        {
+                            if (r != null && evnt == "System.Net.Http.Desktop.HttpRequestOut")
+                            {
+                                // request is never null
+                                var request = (HttpWebRequest)r;
+                                return !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri.ToString());
+                            }
+
+                            return true;
+                        });
+
                     DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = true;
                     DependencyCollectorEventSource.Log.HttpDesktopDiagnosticSourceListenerIsActivated();
                 }

--- a/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
@@ -126,7 +126,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
                 DependencyCollectorEventSource.Log.BeginCallbackCalled(thisObj.GetHashCode(), resourceName);
 
-                if (this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(url.ToString()))
+                if (this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(url))
                 {
                     // Not logging as we will be logging for all outbound AI calls
                     return null;


### PR DESCRIPTION
Before HTTP hook in DiagnosticSource (>= preview2) sends Start event, is calls IsEnabled method and passes request object there.

ApplicationInsgiths needs to reject AI url at this stage to prevent any further notifications regarding this request from DiagnosticSource.