### PR TITLE
Remove dependency from storage if there was no status code (NET 4.5.2)

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
@@ -33,10 +33,11 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         private int sleepTimeMsecBetweenBeginAndEnd = 100;       
         private TelemetryConfiguration configuration;
         private List<ITelemetry> sendItems;
-        private FrameworkHttpProcessing httpProcessingFramework;        
-#endregion //Fields
+        private FrameworkHttpProcessing httpProcessingFramework;
+        private CacheBasedOperationHolder cache = new CacheBasedOperationHolder("testCache", 100 * 1000);
+        #endregion //Fields
 
-#region TestInitialize
+        #region TestInitialize
 
         [TestInitialize]
         public void TestInitialize()
@@ -45,7 +46,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.sendItems = new List<ITelemetry>(); 
             this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
-            this.httpProcessingFramework = new FrameworkHttpProcessing(this.configuration, new CacheBasedOperationHolder("testCache", 100 * 1000), /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
+            this.httpProcessingFramework = new FrameworkHttpProcessing(this.configuration, this.cache, /*setCorrelationHeaders*/ true, new List<string>(), RandomAppIdEndpoint);
             this.httpProcessingFramework.OverrideCorrelationIdLookupHelper(new CorrelationIdLookupHelper(new Dictionary<string, string> { { this.configuration.InstrumentationKey, "cid-v1:" + this.configuration.InstrumentationKey } }));
             DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = false;
         }
@@ -232,6 +233,31 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             var actual = this.sendItems[0] as DependencyTelemetry;
 
             Assert.IsFalse(actual.Success.Value);
+        }
+
+        [TestMethod]
+        public void OnEndHttpCallbackWithoutStatusCodeRemovesTelemetryFromCache()
+        {
+            this.httpProcessingFramework.OnBeginHttpCallback(100, this.testUrl.OriginalString);
+            Assert.IsNotNull(this.cache.Get(100));
+
+            this.httpProcessingFramework.OnEndHttpCallback(100, null, false, null);
+
+            Assert.AreEqual(0, this.sendItems.Count, "Telemetry item should not be sent");
+            Assert.IsNull(DependencyTableStore.Instance.WebRequestCacheHolder.Get(100));
+        }
+
+        [TestMethod]
+        public void OnEndHttpCallbackWithoutStatusCodeDoesNotRemoveTelemetryFromCacheWhenDiagnosticSourceIsActivated()
+        {
+            this.httpProcessingFramework.OnBeginHttpCallback(100, this.testUrl.OriginalString);
+            Assert.IsNotNull(this.cache.Get(100));
+
+            DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated = true;
+            this.httpProcessingFramework.OnEndHttpCallback(100, null, false, null);
+
+            Assert.AreEqual(0, this.sendItems.Count, "Telemetry item should not be sent");
+            Assert.IsNotNull(this.cache.Get(100));
         }
 
         [TestMethod]

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -146,7 +146,11 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     // We never collected statusCode or success before 2.1.0-beta4
                     // We also had duplicates if runtime is also 4.5.2 (4.6 runtime has no such problem)
                     // So starting with 2.1.0-beta4 we are cutting support for HTTP dependencies in .NET 4.5.2.
-                    this.TelemetryTable.Remove(id);
+                    // But we will let DesktopDiagnosticSourceListener collect dependency if it is activated 
+                    if (!DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated)
+                    {
+                        this.TelemetryTable.Remove(id);
+                    }
                 }
             }
         }

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -146,6 +146,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     // We never collected statusCode or success before 2.1.0-beta4
                     // We also had duplicates if runtime is also 4.5.2 (4.6 runtime has no such problem)
                     // So starting with 2.1.0-beta4 we are cutting support for HTTP dependencies in .NET 4.5.2.
+                    this.TelemetryTable.Remove(id);
                 }
             }
         }


### PR DESCRIPTION
Fixing issue introduced in #542 