### PR TITLE
Do not parse Framework EventSource payloads when DiagnosticSource is activated

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
@@ -78,13 +78,23 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 switch (eventData.EventId)
                 {
                     case BeginGetResponseEventId:
-                        this.OnBeginGetResponse(eventData);
+                        if (!DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated)
+                        {
+                            // request is handled by Desktop DiagnosticSource Listener
+                            this.OnBeginGetResponse(eventData);
+                        }
+
                         break;
                     case EndGetResponseEventId:
                         this.OnEndGetResponse(eventData);
                         break;
                     case BeginGetRequestStreamEventId:
-                        this.OnBeginGetRequestStream(eventData);
+                        if (!DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated)
+                        {
+                            // request is handled by Desktop DiagnosticSource Listener
+                            this.OnBeginGetRequestStream(eventData);
+                        }
+
                         break;
                     case EndGetRequestStreamEventId:
                         break;

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -41,12 +41,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             try
             {
                 DependencyCollectorEventSource.Log.BeginCallbackCalled(id, resourceName);
-                if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated)
-                {
-                    // request is handled by Desktop DiagnosticSource Listener
-                    DependencyCollectorEventSource.Log.SkipTrackingTelemetryItemWithEventSource(id);
-                    return;
-                }
 
                 if (string.IsNullOrEmpty(resourceName))
                 {


### PR DESCRIPTION
Small optimization: if IsDesktopHttpDiagnosticSourceActivated is true, we do not even need to parse event source payloads