### PR TITLE
Revert "Do not parse Framework EventSource payloads when DiagnosticSource is activated"

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpEventListener.cs
@@ -78,23 +78,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 switch (eventData.EventId)
                 {
                     case BeginGetResponseEventId:
-                        if (!DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated)
-                        {
-                            // request is handled by Desktop DiagnosticSource Listener
-                            this.OnBeginGetResponse(eventData);
-                        }
-
+                        this.OnBeginGetResponse(eventData);
                         break;
                     case EndGetResponseEventId:
                         this.OnEndGetResponse(eventData);
                         break;
                     case BeginGetRequestStreamEventId:
-                        if (!DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated)
-                        {
-                            // request is handled by Desktop DiagnosticSource Listener
-                            this.OnBeginGetRequestStream(eventData);
-                        }
-
+                        this.OnBeginGetRequestStream(eventData);
                         break;
                     case EndGetRequestStreamEventId:
                         break;

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -41,6 +41,12 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             try
             {
                 DependencyCollectorEventSource.Log.BeginCallbackCalled(id, resourceName);
+                if (DependencyTableStore.Instance.IsDesktopHttpDiagnosticSourceActivated)
+                {
+                    // request is handled by Desktop DiagnosticSource Listener
+                    DependencyCollectorEventSource.Log.SkipTrackingTelemetryItemWithEventSource(id);
+                    return;
+                }
 
                 if (string.IsNullOrEmpty(resourceName))
                 {


### PR DESCRIPTION
Reverts Microsoft/ApplicationInsights-dotnet-server#556