### PR TITLE
Removed locking from DependencyTableStore

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/DependencyTableStore.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyTableStore.cs
@@ -14,10 +14,9 @@
         internal bool IsProfilerActivated = false;
         internal bool IsDesktopHttpDiagnosticSourceActivated = false;
 
-        private static readonly object SyncRoot = new object();
-        private static DependencyTableStore instance;
+        private static readonly DependencyTableStore instance = new DependencyTableStore();
 
-        private DependencyTableStore() 
+        private DependencyTableStore()
         {
 #if !NET40
             this.WebRequestCacheHolder = new CacheBasedOperationHolder("aisdkwebrequests", 100 * 1000);
@@ -29,25 +28,14 @@
 
         internal static DependencyTableStore Instance
         {
-           get 
-           {
-               if (instance == null)
-               {
-                   lock (SyncRoot)
-                   {
-                       if (instance == null)
-                       {
-                           instance = new DependencyTableStore();
-                       }
-                   }
-               }
-
-               return instance;
-           }
+            get
+            {
+                return instance;
+            }
         }
 
         public void Dispose()
-        {            
+        {
             this.WebRequestCacheHolder.Dispose();
             this.SqlRequestCacheHolder.Dispose();
             GC.SuppressFinalize(this);


### PR DESCRIPTION
Removed locking from DependencyTableStore as lock is perf deterrent in this hot path. Instead the instance in static constructed, so its thread safe and wont need locks.