### PR TITLE
Add comment about know issue in MemoryCache

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/Operation/CacheBasedOperationHolder.cs
+++ b/Src/DependencyCollector/Shared/Implementation/Operation/CacheBasedOperationHolder.cs
@@ -41,6 +41,11 @@
             return this.memoryCache.Remove(id.ToString(CultureInfo.InvariantCulture)) != null;
         }
 
+        /// <summary>
+        /// Adds telemetry tuple to MemoryCache. DO NOT call it for the id that already exists in the cache.
+        /// This is a known Memory Cache race-condition issue when items with same id are added concurrently
+        /// and MemoryCache leaks memory. It should be fixed sometime AFTER .NET 4.7.1.
+        /// </summary>
         public void Store(long id, Tuple<DependencyTelemetry, bool> telemetryTuple)
         {
             if (telemetryTuple == null)


### PR DESCRIPTION
MemoryCache has a know race-condition issue when items with the same key are added concurrently.
This does not affect ApplicationInsights scenarios now, but keeping a comment could help to avoid running into this issue later.