### PR TITLE
Update DiagnosticSource to new preview1

### DIFF
--- a/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
+++ b/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -36,7 +36,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25305-02\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
@@ -80,21 +80,21 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Shared.Tests\Implementation\DependencyCollectorDiagnosticListenerTests.Netstandard16.cs" >
-      <Link>DependencyCollectorDiagnosticListenerTests.Netstandard16.cs</Link>    
+    <Compile Include="..\Shared.Tests\Implementation\DependencyCollectorDiagnosticListenerTests.Netstandard16.cs">
+      <Link>DependencyCollectorDiagnosticListenerTests.Netstandard16.cs</Link>
     </Compile>
-    <Compile Include="..\Shared.Tests\Implementation\DependencyCollectorDiagnosticListenerTests.Netstandard20.cs" >
-      <Link>DependencyCollectorDiagnosticListenerTests.Netstandard20.cs</Link>    
+    <Compile Include="..\Shared.Tests\Implementation\DependencyCollectorDiagnosticListenerTests.Netstandard20.cs">
+      <Link>DependencyCollectorDiagnosticListenerTests.Netstandard20.cs</Link>
     </Compile>
-    <Compile Include="..\Shared.Tests\Implementation\EnumerableAssert.cs" >
-      <Link>EnumerableAssert.cs</Link>    
-    </Compile>    
-    <Compile Include="..\Shared.Tests\Implementation\HttpHeadersUtilitiesTests.cs" >
-      <Link>HttpHeadersUtilitiesTests.cs</Link>    
-    </Compile>    
-    <Compile Include="..\Shared.Tests\Implementation\MockCorrelationIdLookupHelper.cs" >
-      <Link>MockCorrelationIdLookupHelper.cs</Link>    
-    </Compile>    
+    <Compile Include="..\Shared.Tests\Implementation\EnumerableAssert.cs">
+      <Link>EnumerableAssert.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared.Tests\Implementation\HttpHeadersUtilitiesTests.cs">
+      <Link>HttpHeadersUtilitiesTests.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared.Tests\Implementation\MockCorrelationIdLookupHelper.cs">
+      <Link>MockCorrelationIdLookupHelper.cs</Link>
+    </Compile>
     <Compile Include="HttpWebRequestUtils.cs" />
     <Compile Include="DependencyTrackingTelemetryModuleTest.cs" />
   </ItemGroup>

--- a/Src/DependencyCollector/Net45.Tests/packages.config
+++ b/Src/DependencyCollector/Net45.Tests/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net451" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />

--- a/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
+++ b/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -34,7 +34,7 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25305-02\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/DependencyCollector/Net45/packages.config
+++ b/Src/DependencyCollector/Net45/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" targetFramework="net45" />
 </packages>

--- a/Src/DependencyCollector/Net46.Tests/DependencyCollector.Net46.Tests.csproj
+++ b/Src/DependencyCollector/Net46.Tests/DependencyCollector.Net46.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -36,7 +36,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25305-02\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/DependencyCollector/Net46.Tests/packages.config
+++ b/Src/DependencyCollector/Net46.Tests/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net46" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net46" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta3" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0-preview1-25214-03" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0-preview1-25305-02" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/Src/DependencyCollector/NuGet/Package.nuspec
+++ b/Src/DependencyCollector/NuGet/Package.nuspec
@@ -23,14 +23,14 @@
       <group targetFramework="net45">
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.7" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" />
       </group>
       <group targetFramework="netstandard1.6">
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.Extensions.PlatformAbstractions" version="1.1.0" />
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Diagnostics.StackTrace" version="4.3.0" />        
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" />
       </group>
     </dependencies>
   </metadata>

--- a/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -36,7 +36,7 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25305-02\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/Web/Web.Net45.Tests/packages.config
+++ b/Src/Web/Web.Net45.Tests/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net451" />
   <package id="OpenCover" version="4.6.519" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net451" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />

--- a/Src/Web/Web.Net45/Web.Net45.csproj
+++ b/Src/Web/Web.Net45/Web.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -32,7 +32,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25305-02\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/Web/Web.Net45/packages.config
+++ b/Src/Web/Web.Net45/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0-preview1-10414-01" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" targetFramework="net45" />
 </packages>

--- a/Src/Web/Web.Nuget/Package.nuspec
+++ b/Src/Web/Web.Nuget/Package.nuspec
@@ -25,7 +25,7 @@
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="$version$" />
         <dependency id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0-preview1-10414-01" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" />
       </group>
     </dependencies>
   </metadata>

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\Test.Common.props" />
   <PropertyGroup>
@@ -57,7 +57,7 @@
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25305-02\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/packages.config
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta3" targetFramework="net451" />
@@ -7,5 +7,5 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" targetFramework="net451" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -57,7 +57,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25305-02\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="AspNet.ScriptManager.bootstrap" version="3.0.0" targetFramework="net45" />
@@ -33,6 +33,6 @@
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Respond" version="1.2.0" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" targetFramework="net45" />
   <package id="WebGrease" version="1.5.2" targetFramework="net45" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -70,7 +70,7 @@
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25305-02\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0-preview1-10407-02" targetFramework="net451" />  
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0-preview1-10407-02" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" targetFramework="net451" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -70,7 +70,7 @@
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25305-02\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0-beta3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0-preview1-10407-02" targetFramework="net451" />  
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0-preview1-10407-02" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25305-02" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
new DiagnosticSource version was published on nuget on May 9.

Changes: 
* Http**Desktop**DiagnosticSourceListener fires `System.Net.Http.Desktop.HttpRequestOut*` callbacks
* precise start time and duration on .NET Desktop 

Changes that did NOT make it YET to preview1:
* Activity Id generation to support AI sampling algo (#538)
* Redirect support in Http**Desktop**DiagnosticSourceListener 
* Http**Desktop**DiagnosticSourceListener on .NET 45

There will be another update of DiagnosticSource (I'm working with .net team to clarify when it will be published and speed up the process) with redirects and sampling.


For now this change is needed to verify perf optimization together with #553