### PR TITLE
Ignore deprecated events from HttpClient on .NET Core 2.0

### DIFF
--- a/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
+++ b/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -34,6 +34,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />

--- a/Src/DependencyCollector/NetCore.Tests/DependencyTrackingTelemetryModuleTestNetCore.cs
+++ b/Src/DependencyCollector/NetCore.Tests/DependencyTrackingTelemetryModuleTestNetCore.cs
@@ -2,16 +2,23 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.TestFramework;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 
     /// <summary>
     /// .NET Core specific tests that verify Http Dependencies are collected for outgoing request
@@ -20,7 +27,43 @@
     public class DependencyTrackingTelemetryModuleTestNetCore
     {
         private const string IKey = "F8474271-D231-45B6-8DD4-D344C309AE69";
-        private const string FakeProfileApiEndpoint = ApplicationInsightsUrlFilter.TelemetryServiceEndpoint;
+        private const string FakeProfileApiEndpoint = "https://dc.services.visualstudio.com/v2/track";
+        private const string localhostUrl = "http://localhost:5050";
+
+        private StubTelemetryChannel channel;
+        private TelemetryConfiguration config;
+        private List<DependencyTelemetry> sentTelemetry;
+
+        /// <summary>
+        /// Initialize.
+        /// </summary>
+        [TestInitialize]
+        public void Initialize()
+        {
+            this.sentTelemetry = new List<DependencyTelemetry>();
+
+            this.channel = new StubTelemetryChannel
+            {
+                OnSend = telemetry =>
+                {
+                    // The correlation id lookup service also makes http call, just make sure we skip that
+                    DependencyTelemetry depTelemetry = telemetry as DependencyTelemetry;
+                    if (depTelemetry != null)
+                    {
+                        this.sentTelemetry.Add(depTelemetry);
+                    }
+                },
+                EndpointAddress = FakeProfileApiEndpoint
+            };
+
+            this.config = new TelemetryConfiguration
+            {
+                InstrumentationKey = IKey,
+                TelemetryChannel = this.channel
+            };
+
+            this.config.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
+        }
 
         /// <summary>
         /// Cleans up.
@@ -41,65 +84,22 @@
         [Timeout(5000)]
         public async Task TestDependencyCollectionNoParentActivity()
         {
-            ITelemetry sentTelemetry = null;
-
-            var channel = new StubTelemetryChannel
-            {
-                OnSend = telemetry =>
-                {
-                    // The correlation id lookup service also makes http call, just make sure we skip that
-                    DependencyTelemetry depTelemetry = telemetry as DependencyTelemetry;
-                    if (depTelemetry != null &&
-                        !depTelemetry.Data.StartsWith(FakeProfileApiEndpoint, StringComparison.OrdinalIgnoreCase))
-                    {
-                        Assert.IsNull(sentTelemetry);
-                        sentTelemetry = telemetry;
-                    }
-                },
-                EndpointAddress = FakeProfileApiEndpoint
-            };
-
-            var config = new TelemetryConfiguration
-            {
-                InstrumentationKey = IKey,
-                TelemetryChannel = channel
-            };
-
-            config.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
-
             using (var module = new DependencyTrackingTelemetryModule())
             {
-                module.ProfileQueryEndpoint = FakeProfileApiEndpoint;
-                module.Initialize(config);
+                module.Initialize(this.config);
 
-                var url = new Uri("http://bing.com");
-
+                var url = new Uri(localhostUrl);
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
-                await new HttpClient().SendAsync(request);
+
+                using (new LocalServer(localhostUrl))
+                {
+                    await new HttpClient().SendAsync(request);
+                }
 
                 // on netcoreapp1.0 DiagnosticSource event is fired asycronously, let's wait for it 
                 Assert.IsTrue(SpinWait.SpinUntil(() => sentTelemetry != null, TimeSpan.FromSeconds(1)));
 
-                var item = (DependencyTelemetry)sentTelemetry;
-                Assert.AreEqual(url, item.Data);
-                Assert.AreEqual(url.Host, item.Target);
-                Assert.AreEqual("GET " + url.AbsolutePath, item.Name);
-                Assert.IsTrue(item.Duration > TimeSpan.FromMilliseconds(0), "Duration has to be positive");
-                Assert.AreEqual(RemoteDependencyConstants.HTTP, item.Type, "HttpAny has to be dependency kind as it includes http and azure calls");
-                Assert.IsTrue(
-                    DateTime.UtcNow.Subtract(item.Timestamp.UtcDateTime).TotalMilliseconds <
-                    TimeSpan.FromMinutes(1).TotalMilliseconds,
-                    "timestamp < now");
-                Assert.IsTrue(
-                    item.Timestamp.Subtract(DateTime.UtcNow).TotalMilliseconds >
-                    -TimeSpan.FromMinutes(1).TotalMilliseconds,
-                    "now - 1 min < timestamp");
-                Assert.AreEqual("200", item.ResultCode);
-
-                var requestId = item.Id;
-                Assert.AreEqual(requestId, request.Headers.GetValues("Request-Id").Single());
-                Assert.AreEqual(requestId, request.Headers.GetValues("x-ms-request-id").Single());
-                Assert.IsTrue(requestId.StartsWith('|' + item.Context.Operation.Id + '.'));
+                this.ValidateTelemetryForDiagnosticSource(this.sentTelemetry.Single(), url, request, true, "200");
             }
         }
 
@@ -110,59 +110,89 @@
         [Timeout(5000)]
         public async Task TestDependencyCollectionWithParentActivity()
         {
-            ITelemetry sentTelemetry = null;
-
-            var channel = new StubTelemetryChannel
-            {
-                OnSend = telemetry =>
-                {
-                    // The correlation id lookup service also makes http call, just make sure we skip that
-                    DependencyTelemetry depTelemetry = telemetry as DependencyTelemetry;
-                    if (depTelemetry != null &&
-                        !depTelemetry.Data.StartsWith(FakeProfileApiEndpoint, StringComparison.OrdinalIgnoreCase))
-                    {
-                        Assert.IsNull(sentTelemetry);
-                        sentTelemetry = telemetry;
-                    }
-                },
-                EndpointAddress = FakeProfileApiEndpoint
-            };
-
-            var config = new TelemetryConfiguration
-            {
-                InstrumentationKey = IKey,
-                TelemetryChannel = channel
-            };
-
-            config.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
-
             using (var module = new DependencyTrackingTelemetryModule())
             {
-                module.ProfileQueryEndpoint = FakeProfileApiEndpoint;
-                module.Initialize(config);
+                module.Initialize(this.config);
 
                 var parent = new Activity("parent").AddBaggage("k", "v").SetParentId("|guid.").Start();
 
-                var url = new Uri("http://bing.com");
+                var url = new Uri(localhostUrl);
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
-                await new HttpClient().SendAsync(request);
+                using (new LocalServer(localhostUrl))
+                {
+                    await new HttpClient().SendAsync(request);
+                }
 
                 // on netcoreapp1.0 DiagnosticSource event is fired asycronously, let's wait for it 
                 Assert.IsTrue(SpinWait.SpinUntil(() => sentTelemetry != null, TimeSpan.FromSeconds(1)));
 
                 parent.Stop();
 
-                var item = (DependencyTelemetry)sentTelemetry;
-                Assert.AreEqual("200", item.ResultCode);
-
-                var requestId = item.Id;
-                Assert.AreEqual(requestId, request.Headers.GetValues("Request-Id").Single());
-                Assert.AreEqual(requestId, request.Headers.GetValues("x-ms-request-id").Single());
-                Assert.IsTrue(requestId.StartsWith(parent.Id));
-                Assert.AreNotEqual(parent.Id, requestId);
-                Assert.AreEqual("v", item.Context.Properties["k"]);
+                this.ValidateTelemetryForDiagnosticSource(this.sentTelemetry.Single(), url, request, true, "200");
 
                 Assert.AreEqual("k=v", request.Headers.GetValues("Correlation-Context").Single());
+            }
+        }
+
+        private void ValidateTelemetryForDiagnosticSource(DependencyTelemetry item, Uri url, HttpRequestMessage request, bool success, string resultCode)
+        {
+            Assert.AreEqual(url, item.Data);
+            Assert.AreEqual(url.Host, item.Target);
+            Assert.AreEqual("GET " + url.AbsolutePath, item.Name);
+            Assert.IsTrue(item.Duration > TimeSpan.FromMilliseconds(0), "Duration has to be positive");
+            Assert.AreEqual(RemoteDependencyConstants.HTTP, item.Type, "HttpAny has to be dependency kind as it includes http and azure calls");
+            Assert.IsTrue(
+                item.Timestamp.UtcDateTime < DateTime.UtcNow.AddMilliseconds(20), // DateTime.UtcNow precesion is ~16ms
+                "timestamp < now");
+            Assert.IsTrue(
+                item.Timestamp.UtcDateTime > DateTime.UtcNow.AddSeconds(-5),
+                "timestamp > now - 5 sec");
+
+            Assert.AreEqual(resultCode, item.ResultCode);
+            Assert.AreEqual(success, item.Success);
+            Assert.AreEqual(
+                SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), "rdddsc:"),
+                item.Context.GetInternalContext().SdkVersion);
+
+            var requestId = item.Id;
+            Assert.IsTrue(requestId.StartsWith('|' + item.Context.Operation.Id + '.'));
+            if (request != null)
+            {
+                Assert.AreEqual(requestId, request.Headers.GetValues(RequestResponseHeaders.RequestIdHeader).Single());
+                Assert.AreEqual(requestId, request.Headers.GetValues(RequestResponseHeaders.StandardParentIdHeader).Single());
+                Assert.AreEqual(item.Context.Operation.Id, request.Headers.GetValues(RequestResponseHeaders.StandardRootIdHeader).Single());
+            }
+        }
+
+        private sealed class LocalServer : IDisposable
+        {
+            private readonly IWebHost host;
+
+            public LocalServer(string url)
+            {
+                this.host = new WebHostBuilder()
+                    .UseKestrel()
+                    .UseStartup<Startup>()
+                    .UseUrls(url)
+                    .Build();
+
+                Task.Run( () => this.host.Run());
+            }
+
+            public void Dispose()
+            {
+                this.host.Dispose();
+            }
+
+            private class Startup
+            {
+                public void Configure(IApplicationBuilder app)
+                {
+                    app.Run(async (context) =>
+                    {
+                        await context.Response.WriteAsync("Hello World!");
+                    });
+                }
             }
         }
     }

--- a/Src/DependencyCollector/NetCore.Tests/DependencyTrackingTelemetryModuleTestNetCore.cs
+++ b/Src/DependencyCollector/NetCore.Tests/DependencyTrackingTelemetryModuleTestNetCore.cs
@@ -96,7 +96,8 @@
                     await new HttpClient().SendAsync(request);
                 }
 
-                // on netcoreapp1.0 DiagnosticSource event is fired asychronously, let's wait for it 
+                // DiagnosticSource Response event is fired after SendAsync returns on netcoreapp1.*
+                // let's wait until dependency is collected
                 Assert.IsTrue(SpinWait.SpinUntil(() => sentTelemetry != null, TimeSpan.FromSeconds(1)));
 
                 this.ValidateTelemetryForDiagnosticSource(this.sentTelemetry.Single(), url, request, true, "200");
@@ -123,14 +124,15 @@
                     await new HttpClient().SendAsync(request);
                 }
 
-                // on netcoreapp1.0 DiagnosticSource event is fired asychronously, let's wait for it 
+                // DiagnosticSource Response event is fired after SendAsync returns on netcoreapp1.*
+                // let's wait until dependency is collected
                 Assert.IsTrue(SpinWait.SpinUntil(() => sentTelemetry != null, TimeSpan.FromSeconds(1)));
 
                 parent.Stop();
 
                 this.ValidateTelemetryForDiagnosticSource(this.sentTelemetry.Single(), url, request, true, "200");
 
-                Assert.AreEqual("k=v", request.Headers.GetValues("Correlation-Context").Single());
+                Assert.AreEqual("k=v", request.Headers.GetValues(RequestResponseHeaders.CorrelationContextHeader).Single());
             }
         }
 

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
@@ -160,9 +160,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector
         [TestMethod]
         public void OnResponseWithResponseEventButNoMatchingRequest()
         {
-            this.listener.OnResponse(new HttpResponseMessage(), Guid.NewGuid());
-            Assert.AreEqual(0, this.sentTelemetry.Count);
-
             var response = new HttpResponseMessage
             {
                 RequestMessage = new HttpRequestMessage(HttpMethod.Get, RequestUrlWithScheme)

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -307,6 +307,56 @@
             this.WriteEvent(28, id, this.ApplicationName);
         }
 
+        [Event(
+            29,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "System.Net.Http.HttpRequestOut.Start id = '{0}'",
+            Level = EventLevel.Verbose)]
+        public void HttpCoreDiagnosticSourceListenerStart(string id, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(29, id, this.ApplicationName);
+        }
+
+        [Event(
+            30,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "System.Net.Http.HttpRequestOut.Stop id = '{0}'",
+            Level = EventLevel.Verbose)]
+        public void HttpCoreDiagnosticSourceListenerStop(string id, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(30, id, this.ApplicationName);
+        }
+
+        [Event(
+            31,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "System.Net.Http.Request id = '{0}'",
+            Level = EventLevel.Verbose)]
+        public void HttpCoreDiagnosticSourceListenerRequest(Guid id, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(31, id, this.ApplicationName);
+        }
+
+        [Event(
+            32,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "System.Net.Http.Response id = '{0}'",
+            Level = EventLevel.Verbose)]
+        public void HttpCoreDiagnosticSourceListenerResponse(Guid id, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(32, id, this.ApplicationName);
+        }
+
+        [Event(
+            33,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "System.Net.Http.Exception id = '{0}'",
+            Level = EventLevel.Verbose)]
+        public void HttpCoreDiagnosticSourceListenerException(string id, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(33, id, this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
@@ -8,6 +8,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Reflection;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Common;
@@ -19,6 +20,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     internal class HttpCoreDiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
     {
         private const string DependencyErrorPropertyKey = "Error";
+        private const string HttpOutEventName = "System.Net.Http.HttpRequestOut";
+        private const string HttpOutStartEventName = "System.Net.Http.HttpRequestOut.Start";
+        private const string HttpOutStopEventName = "System.Net.Http.HttpRequestOut.Stop";
+        private const string HttpExceptionEventName = "System.Net.Http.Exception";
+        private const string DeprecatedRequestEventName = "System.Net.Http.Request";
+        private const string DeprecatedResponseEventName = "System.Net.Http.Response";
+
         private readonly IEnumerable<string> correlationDomainExclusionList;
         private readonly ApplicationInsightsUrlFilter applicationInsightsUrlFilter;
         private readonly bool setComponentCorrelationHttpHeaders;
@@ -62,7 +70,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.correlationIdLookupHelper = correlationIdLookupHelper ?? new CorrelationIdLookupHelper(effectiveProfileQueryEndpoint);
             this.correlationDomainExclusionList = correlationDomainExclusionList ?? Enumerable.Empty<string>();
 
-            this.subscriber = new HttpCoreDiagnosticSourceSubscriber(this);
+            this.subscriber = new HttpCoreDiagnosticSourceSubscriber(this, this.applicationInsightsUrlFilter);
         }
 
         /// <summary>
@@ -91,13 +99,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         {
             switch (evnt.Key)
             {
-                case "System.Net.Http.HttpRequestOut.Start":
+                case HttpOutStartEventName:
                 {
                     this.OnActivityStart((HttpRequestMessage)this.startRequestFetcher.Fetch(evnt.Value));
                     break;
                 }
 
-                case "System.Net.Http.HttpRequestOut.Stop":
+                case HttpOutStopEventName:
                 {
                     this.OnActivityStop(
                         (HttpResponseMessage)this.stopResponseFetcher.Fetch(evnt.Value),
@@ -106,13 +114,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     break;
                 }
 
-                case "System.Net.Http.Exception":
+                case HttpExceptionEventName:
                 {
                     this.OnException((Exception)this.exceptiontFetcher.Fetch(evnt.Value));
                     break;
                 }
 
-                case "System.Net.Http.Request":
+                case DeprecatedRequestEventName:
                 {
                     this.OnRequest(
                         (HttpRequestMessage)this.deprecatedRequestFetcher.Fetch(evnt.Value),
@@ -120,7 +128,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     break;
                 }
 
-                case "System.Net.Http.Response":
+                case DeprecatedResponseEventName:
                 {
                     this.OnResponse(
                         (HttpResponseMessage)this.deprecatedResponseFetcher.Fetch(evnt.Value),
@@ -170,11 +178,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 return;
             }
 
-            if (request != null &&
-                !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
-            {
-                this.InjectRequestHeaders(request, this.configuration.InstrumentationKey);
-            }
+            this.InjectRequestHeaders(request, this.configuration.InstrumentationKey);
         }
 
         //// netcoreapp 2.0 event
@@ -191,51 +195,47 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 return;
             }
 
-            if (request != null && request.RequestUri != null &&
-                !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
+            Uri requestUri = request.RequestUri;
+            var resourceName = request.Method.Method + " " + requestUri.AbsolutePath;
+
+            DependencyTelemetry telemetry = new DependencyTelemetry();
+
+            // properly fill dependency telemetry operation context: OperationCorrelationTelemetryInitializer initializes child telemetry
+            telemetry.Context.Operation.Id = currentActivity.RootId;
+            telemetry.Context.Operation.ParentId = currentActivity.ParentId;
+            telemetry.Id = currentActivity.Id;
+            foreach (var item in currentActivity.Baggage)
             {
-                Uri requestUri = request.RequestUri;
-                var resourceName = request.Method.Method + " " + requestUri.AbsolutePath;
-
-                DependencyTelemetry telemetry = new DependencyTelemetry();
-
-                // properly fill dependency telemetry operation context: OperationCorrelationTelemetryInitializer initializes child telemetry
-                telemetry.Context.Operation.Id = currentActivity.RootId;
-                telemetry.Context.Operation.ParentId = currentActivity.ParentId;
-                telemetry.Id = currentActivity.Id;
-                foreach (var item in currentActivity.Baggage)
+                if (!telemetry.Context.Properties.ContainsKey(item.Key))
                 {
-                    if (!telemetry.Context.Properties.ContainsKey(item.Key))
-                    {
-                        telemetry.Context.Properties[item.Key] = item.Value;
-                    }
+                    telemetry.Context.Properties[item.Key] = item.Value;
                 }
-
-                this.client.Initialize(telemetry);
-
-                telemetry.Name = resourceName;
-                telemetry.Target = requestUri.Host;
-                telemetry.Type = RemoteDependencyConstants.HTTP;
-                telemetry.Data = requestUri.OriginalString;
-                telemetry.Duration = currentActivity.Duration;
-                if (response != null)
-                {
-                    this.ParseResponse(response, telemetry);
-                }
-                else
-                {
-                    Exception exception;
-                    if (this.pendingExceptions.TryRemove(currentActivity.Id, out exception))
-                    {
-                        telemetry.Context.Properties[DependencyErrorPropertyKey] = exception.GetBaseException().Message;
-                    }
-
-                    telemetry.ResultCode = requestTaskStatus.ToString();
-                    telemetry.Success = false;
-                }
-
-                this.client.Track(telemetry);
             }
+
+            this.client.Initialize(telemetry);
+
+            telemetry.Name = resourceName;
+            telemetry.Target = requestUri.Host;
+            telemetry.Type = RemoteDependencyConstants.HTTP;
+            telemetry.Data = requestUri.OriginalString;
+            telemetry.Duration = currentActivity.Duration;
+            if (response != null)
+            {
+                this.ParseResponse(response, telemetry);
+            }
+            else
+            {
+                Exception exception;
+                if (this.pendingExceptions.TryRemove(currentActivity.Id, out exception))
+                {
+                    telemetry.Context.Properties[DependencyErrorPropertyKey] = exception.GetBaseException().Message;
+                }
+
+                telemetry.ResultCode = requestTaskStatus.ToString();
+                telemetry.Success = false;
+            }
+
+            this.client.Track(telemetry);
         }
 
         //// netcoreapp1.1 and prior event. See https://github.com/dotnet/corefx/blob/release/1.0.0-rc2/src/Common/src/System/Net/Http/HttpHandlerDiagnosticListenerExtensions.cs.
@@ -386,13 +386,20 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         private class HttpCoreDiagnosticSourceSubscriber : IObserver<DiagnosticListener>, IDisposable
         {
             private readonly HttpCoreDiagnosticSourceListener httpDiagnosticListener;
-            private IDisposable listenerSubscription;
+            private readonly IDisposable listenerSubscription;
+            private readonly ApplicationInsightsUrlFilter applicationInsightsUrlFilter;
+            private readonly bool isNetCore20HttpClient;
+
             private IDisposable eventSubscription;
 
-            internal HttpCoreDiagnosticSourceSubscriber(HttpCoreDiagnosticSourceListener listener)
+            internal HttpCoreDiagnosticSourceSubscriber(HttpCoreDiagnosticSourceListener listener, ApplicationInsightsUrlFilter applicationInsightsUrlFilter)
             {
                 this.httpDiagnosticListener = listener;
+                this.applicationInsightsUrlFilter = applicationInsightsUrlFilter;
                 this.listenerSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+
+                var httpClientVersion = typeof(HttpClient).GetTypeInfo().Assembly.GetName().Version;
+                this.isNetCore20HttpClient = httpClientVersion.CompareTo(new Version(4, 2)) >= 0;
             }
 
             /// <summary>
@@ -412,7 +419,31 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     // Comes from https://github.com/dotnet/corefx/blob/master/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs#L12
                     if (value.Name == "HttpHandlerDiagnosticListener")
                     {
-                        this.eventSubscription = value.Subscribe(this.httpDiagnosticListener);
+                        this.eventSubscription = value.Subscribe(
+                            this.httpDiagnosticListener,
+                            (evnt, r, _) =>
+                            {
+                                if (isNetCore20HttpClient)
+                                {
+                                    if (evnt == HttpExceptionEventName)
+                                    {
+                                        return true;
+                                    }
+
+                                    if (!evnt.StartsWith(HttpOutEventName, StringComparison.Ordinal))
+                                    {
+                                        return false;
+                                    }
+
+                                    if (evnt == HttpOutEventName && r != null)
+                                    {
+                                        var request = (HttpRequestMessage)r;
+                                        return !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri);
+                                    }
+                                }
+
+                                return true;
+                            });
                     }
                 }
             }

--- a/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
@@ -161,6 +161,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 return;
             }
 
+            DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerException(currentActivity.Id);
+
             this.pendingExceptions.TryAdd(currentActivity.Id, exception);
             this.client.TrackException(exception);
         }
@@ -172,11 +174,14 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         /// </summary>
         internal void OnActivityStart(HttpRequestMessage request)
         {
-            if (Activity.Current == null)
+            var currentActivity = Activity.Current;
+            if (currentActivity == null)
             {
                 DependencyCollectorEventSource.Log.CurrentActivityIsNull();
                 return;
             }
+
+            DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerStart(currentActivity.Id);
 
             this.InjectRequestHeaders(request, this.configuration.InstrumentationKey);
         }
@@ -194,6 +199,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 DependencyCollectorEventSource.Log.CurrentActivityIsNull();
                 return;
             }
+
+            DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerStop(currentActivity.Id);
 
             Uri requestUri = request.RequestUri;
             var resourceName = request.Method.Method + " " + requestUri.AbsolutePath;
@@ -248,6 +255,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             if (request != null && request.RequestUri != null &&
                 !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
             {
+                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerRequest(loggingRequestId);
+
                 Uri requestUri = request.RequestUri;
                 var resourceName = request.Method.Method + " " + requestUri.AbsolutePath;
 
@@ -271,6 +280,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         {
             if (response != null)
             {
+                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerResponse(loggingRequestId);
                 var request = response.RequestMessage;
                 IOperationHolder<DependencyTelemetry> dependency;
                 if (request != null && this.pendingTelemetry.TryGetValue(request, out dependency))


### PR DESCRIPTION
1. It fixes #566 : ignores deprecated events on .net core 2.0 and appinsights internal urls in IsEnabled callback
2. Uses local endpoint in tests and addresses #494 for .net core tests
