### PR TITLE
Small perf improvments.

### DIFF
--- a/Src/Web/Web.Shared.Net/ApplicationInsightsHttpModule.cs
+++ b/Src/Web/Web.Shared.Net/ApplicationInsightsHttpModule.cs
@@ -20,7 +20,8 @@
         private readonly ExceptionTrackingTelemetryModule exceptionModule;
         private MethodInfo addOnSendingHeadersMethod;
         private bool? addOnSendingHeadersMethodExists;
-        object[] paramsForReflectiveCall;
+        private object[] paramsForReflectiveCall;
+
         /// <summary>
         /// Indicates if module initialized successfully.
         /// </summary>
@@ -144,10 +145,10 @@
                 {
                     // We use reflection here because 'AddOnSendingHeaders' is only available post .net framework 4.5.2. Hence we call it if we can find it.
                     // Not using reflection would result in MissingMethodException when 4.5 or 4.5.1 is present. 
-                    if(this.addOnSendingHeadersMethodExists == null)
+                    if (this.addOnSendingHeadersMethodExists == null)
                     {
                         this.addOnSendingHeadersMethod = httpApplication.Response.GetType().GetMethod("AddOnSendingHeaders");
-                        this.addOnSendingHeadersMethodExists = (this.addOnSendingHeadersMethod != null);
+                        this.addOnSendingHeadersMethodExists = this.addOnSendingHeadersMethod != null;
                     }
                     
                     if (this.addOnSendingHeadersMethod != null)

--- a/Src/Web/Web.Shared.Net/ApplicationInsightsHttpModule.cs
+++ b/Src/Web/Web.Shared.Net/ApplicationInsightsHttpModule.cs
@@ -156,10 +156,12 @@
                 if (httpApplication != null && httpApplication.Response != null)
                 {                                     
                     if (this.addOnSendingHeadersMethodExists)
-                    {
-                        this.addOnSendingHeadersMethod.Invoke(httpApplication.Response, this.addOnSendingHeadersMethodParams);
+                    {                        
 #if !NET40
+                        // Faster delegate based invocation.
                         this.openDelegateForInvokingAddOnSendingHeadersMethod.Invoke(httpApplication.Response, this.addOnSendingHeadersMethodParam);
+#else
+                        this.addOnSendingHeadersMethod.Invoke(httpApplication.Response, this.addOnSendingHeadersMethodParams);
 #endif
                     }
                 }


### PR DESCRIPTION
1.Caches reflective lookup of method addOnSendingHeadersMethod to improve performance

2. Params for reflective call is a Action, which is now created once , and re-used vs creating new action every time. Again, this is to improve performance, and no functionality change is expected.

Address a portion of https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/510