### PR TITLE
SyntheticUserAgentTelemetryInitializer perf optimization

### DIFF
--- a/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
@@ -125,7 +125,6 @@
             Assert.AreEqual("Bot", eventTelemetry2.Context.Operation.SyntheticSource, "Incorrect result for " + userAgent);
         }
 
-
         private void AssertSyntheticSourceIsSet(string userAgent)
         {
             var eventTelemetry = new EventTelemetry("name");

--- a/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
@@ -107,6 +107,25 @@
             this.AssertSyntheticSourceIsSet("Innovazion Crawler 123");
         }
 
+        [TestMethod]
+        public void SyntheticSourceIsSetForMultipleItemsFromSameContext()
+        {
+            string userAgent = "YottaaMonitor 123";
+
+            var eventTelemetry1 = new EventTelemetry("name1");
+            var eventTelemetry2 = new EventTelemetry("name2");
+            var source = new TestableSyntheticUserAgentTelemetryInitializer(new Dictionary<string, string>
+                {
+                    { "User-Agent", userAgent }
+                });
+            source.Filters = this.botSubstrings;            
+            source.Initialize(eventTelemetry1);
+            source.Initialize(eventTelemetry2);
+            Assert.AreEqual("Bot", eventTelemetry2.Context.Operation.SyntheticSource, "Incorrect result for " + userAgent);
+            Assert.AreEqual("Bot", eventTelemetry2.Context.Operation.SyntheticSource, "Incorrect result for " + userAgent);
+        }
+
+
         private void AssertSyntheticSourceIsSet(string userAgent)
         {
             var eventTelemetry = new EventTelemetry("name");

--- a/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
+++ b/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
@@ -11,8 +11,8 @@
     /// </summary>
     public class SyntheticUserAgentTelemetryInitializer : WebTelemetryInitializerBase
     {
-        private const string syntheticSourceNameKey = "operationsyntheticsource";
-        private const string syntheticSourceName = "Bot";
+        private const string SyntheticSourceNameKey = "Microsoft.ApplicationInsights.RequestTelemetry.SyntheticSource";
+        private const string SyntheticSourceName = "Bot";
         private string filters = string.Empty;
         private string[] filterPatterns;        
 
@@ -51,9 +51,9 @@
             {
                 if (platformContext != null)
                 {
-                    if (platformContext.Items.Contains(syntheticSourceNameKey))
+                    if (platformContext.Items.Contains(SyntheticSourceNameKey))
                     {
-                        telemetry.Context.Operation.SyntheticSource = platformContext.Items[syntheticSourceNameKey].ToString();
+                        telemetry.Context.Operation.SyntheticSource = platformContext.Items[SyntheticSourceNameKey].ToString();
                     }
                     else
                     {
@@ -67,8 +67,8 @@
                             {
                                 if (userAgent.IndexOf(this.filterPatterns[i], StringComparison.OrdinalIgnoreCase) != -1)
                                 {
-                                    telemetry.Context.Operation.SyntheticSource = syntheticSourceName;
-                                    platformContext.Items.Add(syntheticSourceNameKey, syntheticSourceName);
+                                    telemetry.Context.Operation.SyntheticSource = SyntheticSourceName;
+                                    platformContext.Items.Add(SyntheticSourceNameKey, SyntheticSourceName);
                                     return;
                                 }
                             }

--- a/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
+++ b/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
@@ -55,10 +55,10 @@
                     {
                         // We expect customers to configure telemetry initializer before they add it to active configuration
                         // So we will not protect fiterPatterns array with locks (to improve perf)
-                        foreach (string pattern in this.filterPatterns)
+                        string userAgent = request.UserAgent;
+                        for (int i = 0; i < this.filterPatterns.Length; i++)
                         {
-                            if (!string.IsNullOrWhiteSpace(pattern) &&
-                                request.UserAgent.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) != -1)
+                            if (userAgent.IndexOf(this.filterPatterns[i], StringComparison.OrdinalIgnoreCase) != -1)
                             {
                                 telemetry.Context.Operation.SyntheticSource = "Bot";
                                 return;

--- a/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
+++ b/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
@@ -11,8 +11,10 @@
     /// </summary>
     public class SyntheticUserAgentTelemetryInitializer : WebTelemetryInitializerBase
     {
+        private const string syntheticSourceNameKey = "operationsyntheticsource";
+        private const string syntheticSourceName = "Bot";
         private string filters = string.Empty;
-        private string[] filterPatterns;
+        private string[] filterPatterns;        
 
         /// <summary>
         /// Gets or sets the configured patterns for matching synthetic traffic filters through user agent string.
@@ -49,19 +51,26 @@
             {
                 if (platformContext != null)
                 {
-                    var request = platformContext.GetRequest();
-
-                    if (request != null && !string.IsNullOrEmpty(request.UserAgent))
+                    if (platformContext.Items.Contains(syntheticSourceNameKey))
                     {
-                        // We expect customers to configure telemetry initializer before they add it to active configuration
-                        // So we will not protect fiterPatterns array with locks (to improve perf)
-                        string userAgent = request.UserAgent;
-                        for (int i = 0; i < this.filterPatterns.Length; i++)
+                        telemetry.Context.Operation.SyntheticSource = platformContext.Items[syntheticSourceNameKey].ToString();
+                    }
+                    else
+                    {
+                        var request = platformContext.GetRequest();
+                        if (request != null && !string.IsNullOrEmpty(request.UserAgent))
                         {
-                            if (userAgent.IndexOf(this.filterPatterns[i], StringComparison.OrdinalIgnoreCase) != -1)
+                            // We expect customers to configure telemetry initializer before they add it to active configuration
+                            // So we will not protect fiterPatterns array with locks (to improve perf)
+                            string userAgent = request.UserAgent;
+                            for (int i = 0; i < this.filterPatterns.Length; i++)
                             {
-                                telemetry.Context.Operation.SyntheticSource = "Bot";
-                                return;
+                                if (userAgent.IndexOf(this.filterPatterns[i], StringComparison.OrdinalIgnoreCase) != -1)
+                                {
+                                    telemetry.Context.Operation.SyntheticSource = syntheticSourceName;
+                                    platformContext.Items.Add(syntheticSourceNameKey, syntheticSourceName);
+                                    return;
+                                }
                             }
                         }
                     }

--- a/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
+++ b/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
@@ -53,16 +53,17 @@
                 {
                     if (platformContext.Items.Contains(SyntheticSourceNameKey))
                     {
-                        telemetry.Context.Operation.SyntheticSource = platformContext.Items[SyntheticSourceNameKey].ToString();
+                        // The value does not really matter.
+                        telemetry.Context.Operation.SyntheticSource = SyntheticSourceName;
                     }
                     else
                     {
                         var request = platformContext.GetRequest();
-                        if (request != null && !string.IsNullOrEmpty(request.UserAgent))
+                        string userAgent = request.UserAgent;
+                        if (request != null && !string.IsNullOrEmpty(userAgent))
                         {
                             // We expect customers to configure telemetry initializer before they add it to active configuration
-                            // So we will not protect fiterPatterns array with locks (to improve perf)
-                            string userAgent = request.UserAgent;
+                            // So we will not protect filterPatterns array with locks (to improve perf)                            
                             for (int i = 0; i < this.filterPatterns.Length; i++)
                             {
                                 if (userAgent.IndexOf(this.filterPatterns[i], StringComparison.OrdinalIgnoreCase) != -1)


### PR DESCRIPTION
SyntheticUserAgentTelemetryInitializer optimize to store and re-use syntheticsource from a cache. This improves performance where there are multiple telemetry items from the same context - after the 1st item, syntheticsource is read from cache.

Attempt to address item 4 from https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/510