### PR TITLE
Catch and log potential exceptions during DiagnosticSource initialization errors

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -384,7 +384,7 @@
             Level = EventLevel.Error)]
         public void HttpHandlerDiagnosticListenerFailedToInitialize(string error, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(36, error, this.ApplicationName);
+            this.WriteEvent(36, error ?? string.Empty, this.ApplicationName);
         }
 
         [NonEvent]

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -360,9 +360,9 @@
         [Event(
             34,
             Keywords = Keywords.RddEventKeywords,
-            Message = "HttpCoreDiagnosticSubscriber fails to subscribe. Error details '{0}'",
+            Message = "HttpCoreDiagnosticSubscriber failed to subscribe. Error details '{0}'",
             Level = EventLevel.Error)]
-        public void HttpCoreDiagnosticSubscriberFailsToSubscribe(string error, string appDomainName = "Incorrect")
+        public void HttpCoreDiagnosticSubscriberFailedToSubscribe(string error, string appDomainName = "Incorrect")
         {
             this.WriteEvent(34, error, this.ApplicationName);
         }
@@ -370,9 +370,9 @@
         [Event(
             35,
             Keywords = Keywords.RddEventKeywords,
-            Message = "HttpDesktopDiagnosticSubscriber fails to subscribe. Error details '{0}'",
+            Message = "HttpDesktopDiagnosticSubscriber failed to subscribe. Error details '{0}'",
             Level = EventLevel.Error)]
-        public void HttpDesktopDiagnosticSubscriberFailsToSubscribe(string error, string appDomainName = "Incorrect")
+        public void HttpDesktopDiagnosticSubscriberFailedToSubscribe(string error, string appDomainName = "Incorrect")
         {
             this.WriteEvent(35, error, this.ApplicationName);
         }
@@ -380,9 +380,9 @@
         [Event(
             36,
             Keywords = Keywords.RddEventKeywords,
-            Message = "HttpHandlerDiagnosticListener fails to initialize. Error details '{0}'",
+            Message = "HttpHandlerDiagnosticListener failed to initialize. Error details '{0}'",
             Level = EventLevel.Error)]
-        public void HttpHandlerDiagnosticListenerFailsToInitialize(string error, string appDomainName = "Incorrect")
+        public void HttpHandlerDiagnosticListenerFailedToInitialize(string error, string appDomainName = "Incorrect")
         {
             this.WriteEvent(36, error, this.ApplicationName);
         }

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -357,6 +357,36 @@
             this.WriteEvent(33, id, this.ApplicationName);
         }
 
+        [Event(
+            34,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "HttpCoreDiagnosticSubscriber fails to subscribe. Error details '{0}'",
+            Level = EventLevel.Error)]
+        public void HttpCoreDiagnosticSubscriberFailsToSubscribe(string error, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(34, error, this.ApplicationName);
+        }
+
+        [Event(
+            35,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "HttpDesktopDiagnosticSubscriber fails to subscribe. Error details '{0}'",
+            Level = EventLevel.Error)]
+        public void HttpDesktopDiagnosticSubscriberFailsToSubscribe(string error, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(35, error, this.ApplicationName);
+        }
+
+        [Event(
+            36,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "HttpHandlerDiagnosticListener fails to initialize. Error details '{0}'",
+            Level = EventLevel.Error)]
+        public void HttpHandlerDiagnosticListenerFailsToInitialize(string error, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(36, error, this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
@@ -417,7 +417,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 }
                 catch (Exception ex)
                 {
-                    DependencyCollectorEventSource.Log.HttpCoreDiagnosticSubscriberFailsToSubscribe(ex.ToInvariantString());
+                    DependencyCollectorEventSource.Log.HttpCoreDiagnosticSubscriberFailedToSubscribe(ex.ToInvariantString());
                 }
             }
 

--- a/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Web.Implementation;
 
     internal class HttpCoreDiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
@@ -406,10 +407,18 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             {
                 this.httpDiagnosticListener = listener;
                 this.applicationInsightsUrlFilter = applicationInsightsUrlFilter;
-                this.listenerSubscription = DiagnosticListener.AllListeners.Subscribe(this);
 
                 var httpClientVersion = typeof(HttpClient).GetTypeInfo().Assembly.GetName().Version;
                 this.isNetCore20HttpClient = httpClientVersion.CompareTo(new Version(4, 2)) >= 0;
+
+                try
+                {
+                    this.listenerSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+                }
+                catch (Exception ex)
+                {
+                    DependencyCollectorEventSource.Log.HttpCoreDiagnosticSubscriberFailsToSubscribe(ex.ToInvariantString());
+                }
             }
 
             /// <summary>

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
@@ -3,8 +3,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Net;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// Diagnostic listener implementation that listens for Http DiagnosticSource to see all outgoing HTTP dependency requests.
@@ -80,6 +80,15 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         DependencyCollectorEventSource.Log.HttpDesktopEndCallbackCalled(ClientServerDependencyTracker.GetIdForRequestObject(request));
                         var response = (HttpWebResponse)this.responseFetcher.Fetch(value.Value);
                         this.httpDesktopProcessing.OnEnd(null, request, response);
+                        break;
+                    }
+
+                    case "System.Net.Http.InitializationFailed":
+                    {
+                        DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated = false;
+
+                        Exception ex = (Exception)value.Value.GetType().GetProperty("Exception")?.GetValue(value.Value);
+                        DependencyCollectorEventSource.Log.HttpHandlerDiagnosticListenerFailsToInitialize(ex?.ToInvariantString());
                         break;
                     }
 

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
@@ -88,7 +88,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         DependencyTableStore.IsDesktopHttpDiagnosticSourceActivated = false;
 
                         Exception ex = (Exception)value.Value.GetType().GetProperty("Exception")?.GetValue(value.Value);
-                        DependencyCollectorEventSource.Log.HttpHandlerDiagnosticListenerFailsToInitialize(ex?.ToInvariantString());
+                        DependencyCollectorEventSource.Log.HttpHandlerDiagnosticListenerFailedToInitialize(ex?.ToInvariantString());
                         break;
                     }
 

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
@@ -4,6 +4,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     using System;
     using System.Diagnostics;
     using System.Net;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// A helper subscriber class helping the parent object, which is a HttpDiagnosticSourceListener, to subscribe
@@ -24,7 +25,14 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         {
             this.parent = parent;
             this.applicationInsightsUrlFilter = applicationInsightsUrlFilter;
-            this.allListenersSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+            try
+            {
+                this.allListenersSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+            }
+            catch (Exception ex)
+            {
+                DependencyCollectorEventSource.Log.HttpDesktopDiagnosticSubscriberFailsToSubscribe(ex.ToInvariantString());
+            }
         }
 
         /// <summary>

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceSubscriber.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             }
             catch (Exception ex)
             {
-                DependencyCollectorEventSource.Log.HttpDesktopDiagnosticSubscriberFailsToSubscribe(ex.ToInvariantString());
+                DependencyCollectorEventSource.Log.HttpDesktopDiagnosticSubscriberFailedToSubscribe(ex.ToInvariantString());
             }
         }
 


### PR DESCRIPTION
Based on SDK telemetry findings, there is issue, that reproduces in some customer environment.

The issue has never reproduced in any AppInsights/.NET tests and assumption is that issue is quite rare or specific to some setup.

When the issue reproduces, neither DiagnosticListener nor EventListener collect dependencies.
Mitigation for now is to gracefully fallback to event source and log issue.

The nature of issue is not known so far, I will continue looking for the root cause.
```
AI (Internal): [msg=RemoteDependencyModule failed];[msg=System.TypeInitializationException: The type initializer for 'System.Diagnostics.HttpHandlerDiagnosticListener' threw an exception. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Diagnostics.DiagnosticListener..ctor(String name)
   at System.Diagnostics.HttpHandlerDiagnosticListener..cctor()
   --- End of inner exception stack trace ---
   at System.Diagnostics.DiagnosticListener.get_AllListeners()
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.HttpDesktopDiagnosticSourceSubscriber..ctor(HttpDesktopDiagnosticSourceListener parent)
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.HttpDesktopDiagnosticSourceListener..ctor(DesktopDiagnosticSourceHttpProcessing httpProcessing)
   at Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule.InitializeForDiagnosticAndFrameworkEventSource()
   at Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule.InitializeForRuntimeInstrumentationOrFramework()
at Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule.Initialize(TelemetryConfiguration configuration)];[fwv=4.0.30319.42000];

AI (Internal): [msg=RemoteDependencyModule failed];[msg=System.TypeInitializationException: The type initializer for 'System.Diagnostics.HttpHandlerDiagnosticListener' threw an exception. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Diagnostics.DiagnosticListener..ctor(String name)
   at System.Diagnostics.HttpHandlerDiagnosticListener..ctor()
   at System.Diagnostics.HttpHandlerDiagnosticListener..cctor()
   --- End of inner exception stack trace ---
   at System.Diagnostics.DiagnosticListener.get_AllListeners()
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.HttpCoreDiagnosticSourceListener.HttpCoreDiagnosticSourceSubscriber..ctor(HttpCoreDiagnosticSourceListener listener)
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.HttpCoreDiagnosticSourceListener..ctor(TelemetryConfiguration configuration, String effectiveProfileQueryEndpoint, Boolean setComponentCorrelationHttpHeaders, IEnumerable`1 correlationDomainExclusionList, ICorrelationIdLookupHelper correlationIdLookupHelper)
   at Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule.Initialize(TelemetryConfiguration configuration)];[fwv=4.0.30319.42000];
```

Important for 2.4.0 stable.

