### PR TITLE
Adds a new DiagnosticSource based Dependency Collector for SqlClient.

### DIFF
--- a/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
+++ b/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
@@ -52,6 +52,9 @@
     <Compile Include="..\Shared\Implementation\HttpCoreDiagnosticSourceListener.cs">
       <Link>HttpCoreDiagnosticSourceListener.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\Implementation\SqlClientDiagnosticSourceListener.cs">
+      <Link>SqlClientDiagnosticSourceListener.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\Implementation\HttpHeadersUtilities.cs">
       <Link>HttpHeadersUtilities.cs</Link>
     </Compile>

--- a/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
+++ b/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\Shared.Tests\Implementation\DependencyCollectorDiagnosticListenerTests.Netstandard16.cs" Link="DependencyCollectorDiagnosticListenerTests.Netstandard16.cs" />
     <Compile Include="..\Shared.Tests\Implementation\DependencyCollectorDiagnosticListenerTests.Netstandard20.cs" Link="DependencyCollectorDiagnosticListenerTests.Netstandard20.cs" />
+    <Compile Include="..\Shared.Tests\Implementation\SqlClientDiagnosticSourceListenerTests.cs" Link="SqlClientDiagnosticSourceListenerTests.cs" />
     <Compile Include="..\Shared.Tests\Implementation\EnumerableAssert.cs" Link="EnumerableAssert.cs" />
     <Compile Include="..\Shared.Tests\Implementation\MockCorrelationIdLookupHelper.cs" Link="MockCorrelationIdLookupHelper.cs" />
     <Compile Include="..\..\TestFramework\Shared\SdkVersionHelper.cs" Link="SdkVersionHelper.cs" />

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -13,7 +13,7 @@
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
 
   <PropertyGroup>
-    <Copyright>Copyright © Microsoft. All Rights Reserved.</Copyright>
+    <Copyright>Copyright Â© Microsoft. All Rights Reserved.</Copyright>
     <VersionPrefix>2.5.0-beta1</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Compile Include="..\Shared\DependencyTrackingTelemetryModule.cs" Link="DependencyTrackingTelemetryModule.cs" />
     <Compile Include="..\Shared\HttpDependenciesParsingTelemetryInitializer.cs" Link="HttpDependenciesParsingTelemetryInitializer.cs" />
+    <Compile Include="..\Shared\Implementation\Operation\ObjectInstanceBasedOperationHolder.cs" Link="ObjectInstanceBasedOperationHolder.cs" />
     <Compile Include="..\Shared\SanitizedHostList.cs" Link="SanitizedHostList.cs" />
     <Compile Include="..\Shared\Implementation\DependencyCollectorEventSource.cs" Link="DependencyCollectorEventSource.cs" />
     <Compile Include="..\Shared\Implementation\ApplicationInsightsUrlFilter.cs" Link="ApplicationInsightsUrlFilter.cs" />

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -39,6 +39,7 @@
     <Compile Include="..\Shared\Implementation\ApplicationInsightsUrlFilter.cs" Link="ApplicationInsightsUrlFilter.cs" />
     <Compile Include="..\Shared\Implementation\RemoteDependencyConstants.cs" Link="RemoteDependencyConstants.cs" />
     <Compile Include="..\Shared\Implementation\HttpCoreDiagnosticSourceListener.cs" Link="HttpCoreDiagnosticSourceListener.cs" />
+    <Compile Include="..\Shared\Implementation\SqlClientDiagnosticSourceListener.cs" Link="SqlClientDiagnosticSourceListener.cs" />
     <Compile Include="..\Shared\Implementation\HttpHeadersUtilities.cs" Link="HttpHeadersUtilities.cs" />
     <Compile Include="..\Shared\Implementation\PropertyFetcher.cs" Link="PropertyFetcher.cs" />
     <Compile Include="..\Shared\Implementation\RDDSource.cs" Link="RDDSource.cs" />
@@ -66,6 +67,7 @@
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.3.1" />
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" developmentDependency="true" />
 
   </ItemGroup>

--- a/Src/DependencyCollector/NuGet/Package.nuspec
+++ b/Src/DependencyCollector/NuGet/Package.nuspec
@@ -27,6 +27,7 @@
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Diagnostics.StackTrace" version="4.3.0" />        
         <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0" />
+        <dependency id="System.Data.SqlClient" version="4.3.1" />
       </group>
     </dependencies>
   </metadata>

--- a/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
@@ -1,0 +1,458 @@
+namespace Microsoft.ApplicationInsights.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.Diagnostics;
+    using System.Linq;
+
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+    [TestClass]
+    public class SqlClientDiagnosticSourceListenerTests
+    {
+        private const string TestConnectionString = "Data Source=(localdb)\\MSSQLLocalDB;Database=master";
+        
+        private IList<ITelemetry> sendItems;
+        private StubTelemetryChannel stubTelemetryChannel;
+        private TelemetryConfiguration configuration;
+        private FakeSqlClientDiagnosticSource fakeSqlClientDiagnosticSource;
+        private SqlClientDiagnosticSourceListener sqlClientDiagnosticSourceListener;
+
+        [TestInitialize]
+        public void TestInit()
+        {
+            this.sendItems = new List<ITelemetry>();
+            this.stubTelemetryChannel = new StubTelemetryChannel {OnSend = item => this.sendItems.Add(item)};
+
+            this.configuration = new TelemetryConfiguration
+            {
+                InstrumentationKey = Guid.NewGuid().ToString(),
+                TelemetryChannel = stubTelemetryChannel
+            };
+
+            this.fakeSqlClientDiagnosticSource = new FakeSqlClientDiagnosticSource();
+            this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(configuration);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this.sqlClientDiagnosticSourceListener.Dispose();
+            this.fakeSqlClientDiagnosticSource.Dispose();
+            this.configuration.Dispose();
+            this.stubTelemetryChannel.Dispose();
+        }
+
+        [TestMethod]
+        public void TracksCommandExecuted()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+            var sqlCommand = sqlConnection.CreateCommand();
+            sqlCommand.CommandText = "select * from orders";
+            
+            var beforeExecuteEventData = new
+            {
+                OperationId = operationId,
+                Timestamp = 1000000L
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,
+                beforeExecuteEventData);
+
+            var afterExecuteEventData = new
+            {
+                OperationId = operationId,
+                Operation = "ExecuteReader",
+                ConnectionId = sqlConnection.ClientConnectionId,
+                Command = sqlCommand,
+                Statistics = sqlConnection.RetrieveStatistics(),
+                Timestamp = 2000000L
+            };
+
+            var now = DateTimeOffset.UtcNow;
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
+                afterExecuteEventData);
+
+            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
+
+            Assert.AreEqual(afterExecuteEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.AreEqual(sqlCommand.CommandText, dependencyTelemetry.Data);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Name);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.IsTrue((bool)dependencyTelemetry.Success);
+            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Timestamp.Ticks < now.Ticks);
+        }
+        
+        [TestMethod]
+        public void TracksCommandError()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+            var sqlCommand = sqlConnection.CreateCommand();
+            sqlCommand.CommandText = "select * from orders";
+
+            var beforeExecuteEventData = new
+            {
+                OperationId = operationId,
+                Timestamp = 1000000L
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,
+                beforeExecuteEventData);
+
+            var commandErrorEventData = new
+            {
+                OperationId = operationId,
+                Operation = "ExecuteReader",
+                ConnectionId = sqlConnection.ClientConnectionId,
+                Command = sqlCommand,
+                Exception = new Exception("Boom!"),
+                Timestamp = 2000000L
+            };
+
+            var now = DateTimeOffset.UtcNow;
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlErrorExecuteCommand,
+                commandErrorEventData);
+
+            var exceptionTelemetry = (ExceptionTelemetry)this.sendItems.Single();
+
+            Assert.AreSame(commandErrorEventData.Exception, exceptionTelemetry.Exception);
+            Assert.AreEqual(commandErrorEventData.Exception.Message, exceptionTelemetry.Message);
+            Assert.IsTrue(exceptionTelemetry.Timestamp.Ticks < now.Ticks);
+        }
+
+        [TestMethod]
+        public void TracksConnectionOpened()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+
+            var beforeOpenEventData = new
+            {
+                OperationId = operationId,
+                Timestamp = 1000000L
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlBeforeOpenConnection,
+                beforeOpenEventData);
+
+            var afterOpenEventData = new
+            {
+                OperationId = operationId,
+                Operation = "Open",
+                ConnectionId = sqlConnection.ClientConnectionId,
+                Connection = sqlConnection,
+                Statistics = sqlConnection.RetrieveStatistics(),
+                Timestamp = 2000000L
+            };
+
+            var now = DateTimeOffset.UtcNow;
+            
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlAfterOpenConnection,
+                afterOpenEventData);
+
+            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
+
+            Assert.AreEqual(afterOpenEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.AreEqual(afterOpenEventData.Operation, dependencyTelemetry.Data);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master | " + afterOpenEventData.Operation, dependencyTelemetry.Name);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.IsTrue((bool)dependencyTelemetry.Success);
+            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Timestamp.Ticks < now.Ticks);
+        }
+        
+        [TestMethod]
+        public void TracksConnectionOpenedError()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+            
+            var beforeOpenEventData = new
+            {
+                OperationId = operationId,
+                Timestamp = 1000000L
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlBeforeOpenConnection,
+                beforeOpenEventData);
+
+            var errorOpenEventData = new
+            {
+                OperationId = operationId,
+                Operation = "Open",
+                ConnectionId = sqlConnection.ClientConnectionId,
+                Connection = sqlConnection,
+                Exception = new Exception("Boom!"),
+                Timestamp = 2000000L
+            };
+
+            var now = DateTimeOffset.UtcNow;
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlErrorOpenConnection,
+                errorOpenEventData);
+
+            var exceptionTelemetry = (ExceptionTelemetry)this.sendItems.Single();
+
+            Assert.AreSame(errorOpenEventData.Exception, exceptionTelemetry.Exception);
+            Assert.AreEqual(errorOpenEventData.Exception.Message, exceptionTelemetry.Message);
+            Assert.IsTrue(exceptionTelemetry.Timestamp.Ticks < now.Ticks);
+        }
+
+        [TestMethod]
+        public void TracksConnectionClosed()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+
+            var beforeCloseEventData = new
+            {
+                OperationId = operationId,
+                Timestamp = 1000000L
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlBeforeCloseConnection,
+                beforeCloseEventData);
+
+            var afterCloseEventData = new
+            {
+                OperationId = operationId,
+                Operation = "Close",
+                ConnectionId = sqlConnection.ClientConnectionId,
+                Connection = sqlConnection,
+                Statistics = sqlConnection.RetrieveStatistics(),
+                Timestamp = 2000000L
+            };
+
+            var now = DateTimeOffset.UtcNow;
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlAfterCloseConnection,
+                afterCloseEventData);
+
+            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
+
+            Assert.AreEqual(afterCloseEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.AreEqual(afterCloseEventData.Operation, dependencyTelemetry.Data);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master | " + afterCloseEventData.Operation, dependencyTelemetry.Name);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.IsTrue((bool)dependencyTelemetry.Success);
+            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Timestamp.Ticks < now.Ticks);
+        }
+
+        [TestMethod]
+        public void TracksConnectionCloseError()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+
+            var beforeOpenEventData = new
+            {
+                OperationId = operationId,
+                Timestamp = 1000000L
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlBeforeCloseConnection,
+                beforeOpenEventData);
+
+            var errorOpenEventData = new
+            {
+                OperationId = operationId,
+                Operation = "Close",
+                ConnectionId = sqlConnection.ClientConnectionId,
+                Connection = sqlConnection,
+                Exception = new Exception("Boom!"),
+                Timestamp = 2000000L
+            };
+
+            var now = DateTimeOffset.UtcNow;
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlErrorCloseConnection,
+                errorOpenEventData);
+
+            var exceptionTelemetry = (ExceptionTelemetry)this.sendItems.Single();
+
+            Assert.AreSame(errorOpenEventData.Exception, exceptionTelemetry.Exception);
+            Assert.AreEqual(errorOpenEventData.Exception.Message, exceptionTelemetry.Message);
+            Assert.IsTrue(exceptionTelemetry.Timestamp.Ticks < now.Ticks);
+        }
+
+        [TestMethod]
+        public void TracksTransactionCommitted()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+
+            var beforeCommitEventData = new
+            {
+                OperationId = operationId,
+                Timestamp = 1000000L
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlBeforeCommitTransaction,
+                beforeCommitEventData);
+
+            var afterCommitEventData = new
+            {
+                OperationId = operationId,
+                Operation = "Commit",
+                IsolationLevel = IsolationLevel.Snapshot,
+                Connection = sqlConnection,
+                Timestamp = 2000000L
+            };
+
+            var now = DateTimeOffset.UtcNow;
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlAfterCommitTransaction,
+                afterCommitEventData);
+
+            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
+
+            Assert.AreEqual(afterCommitEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.AreEqual(afterCommitEventData.Operation, dependencyTelemetry.Data);
+            Assert.AreEqual(
+                "(localdb)\\MSSQLLocalDB | master | " + afterCommitEventData.Operation + " | " + afterCommitEventData.IsolationLevel, 
+                dependencyTelemetry.Name);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.IsTrue((bool)dependencyTelemetry.Success);
+            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Timestamp.Ticks < now.Ticks);
+        }
+
+        [TestMethod]
+        public void TracksTransactionCommitError()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+
+            var beforeCommitEventData = new
+            {
+                OperationId = operationId,
+                Timestamp = 1000000L
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlBeforeCommitTransaction,
+                beforeCommitEventData);
+
+            var errorCommitEventData = new
+            {
+                OperationId = operationId,
+                Operation = "Commit",
+                IsolationLevel = IsolationLevel.Snapshot,
+                Connection = sqlConnection,
+                Exception = new Exception("Boom!"),
+                Timestamp = 2000000L
+            };
+
+            var now = DateTimeOffset.UtcNow;
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlErrorCommitTransaction,
+                errorCommitEventData);
+
+            var exceptionTelemetry = (ExceptionTelemetry)this.sendItems.Single();
+
+            Assert.AreSame(errorCommitEventData.Exception, exceptionTelemetry.Exception);
+            Assert.AreEqual(errorCommitEventData.Exception.Message, exceptionTelemetry.Message);
+            Assert.IsTrue(exceptionTelemetry.Timestamp.Ticks < now.Ticks);
+        }
+
+        [TestMethod]
+        public void TracksTransactionRolledBack()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+
+            var beforeRollbackEventData = new
+            {
+                OperationId = operationId,
+                Timestamp = 1000000L
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlBeforeRollbackTransaction,
+                beforeRollbackEventData);
+
+            var afterRollbackEventData = new
+            {
+                OperationId = operationId,
+                Operation = "Rollback",
+                IsolationLevel = IsolationLevel.Snapshot,
+                Connection = sqlConnection,
+                Timestamp = 2000000L
+            };
+
+            var now = DateTimeOffset.UtcNow;
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticSourceListener.SqlAfterRollbackTransaction,
+                afterRollbackEventData);
+
+            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
+
+            Assert.AreEqual(afterRollbackEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.AreEqual(afterRollbackEventData.Operation, dependencyTelemetry.Data);
+            Assert.AreEqual(
+                "(localdb)\\MSSQLLocalDB | master | " + afterRollbackEventData.Operation + " | " + afterRollbackEventData.IsolationLevel,
+                dependencyTelemetry.Name);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.IsTrue((bool)dependencyTelemetry.Success);
+            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Timestamp.Ticks < now.Ticks);
+        }
+
+        private class FakeSqlClientDiagnosticSource : IDisposable
+        {
+            private readonly DiagnosticListener listener;
+
+            public FakeSqlClientDiagnosticSource()
+            {
+                this.listener = new DiagnosticListener(SqlClientDiagnosticSourceListener.DiagnosticListenerName);
+            }
+
+            public void Write(string name, object value)
+            {
+                this.listener.Write(name, value);
+            }
+
+            public void Dispose()
+            {
+                this.listener.Dispose();
+            }
+        }
+    }
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+}

--- a/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
@@ -190,50 +190,6 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(commandErrorEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
             Assert.IsFalse(dependencyTelemetry.Success.Value);
         }
-
-        [TestMethod]
-        public void TracksConnectionOpened()
-        {
-            var operationId = Guid.NewGuid();
-            var sqlConnection = new SqlConnection(TestConnectionString);
-
-            var beforeOpenEventData = new
-            {
-                OperationId = operationId,
-                Timestamp = 1000000L
-            };
-
-            this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlBeforeOpenConnection,
-                beforeOpenEventData);
-
-            var afterOpenEventData = new
-            {
-                OperationId = operationId,
-                Operation = "Open",
-                ConnectionId = sqlConnection.ClientConnectionId,
-                Connection = sqlConnection,
-                Statistics = sqlConnection.RetrieveStatistics(),
-                Timestamp = 2000000L
-            };
-
-            var now = DateTimeOffset.UtcNow;
-            
-            this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlAfterOpenConnection,
-                afterOpenEventData);
-
-            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
-
-            Assert.AreEqual(afterOpenEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
-            Assert.AreEqual(afterOpenEventData.Operation, dependencyTelemetry.Data);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master | " + afterOpenEventData.Operation, dependencyTelemetry.Name);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
-            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
-            Assert.IsTrue((bool)dependencyTelemetry.Success);
-            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
-            Assert.IsTrue(dependencyTelemetry.Timestamp.Ticks < now.Ticks);
-        }
         
         [TestMethod]
         public void TracksConnectionOpenedError()
@@ -269,52 +225,15 @@ namespace Microsoft.ApplicationInsights.Tests
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(errorOpenEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
-            Assert.IsFalse(dependencyTelemetry.Success.Value);
-        }
-
-        [TestMethod]
-        public void TracksConnectionClosed()
-        {
-            var operationId = Guid.NewGuid();
-            var sqlConnection = new SqlConnection(TestConnectionString);
-
-            var beforeCloseEventData = new
-            {
-                OperationId = operationId,
-                Timestamp = 1000000L
-            };
-
-            this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlBeforeCloseConnection,
-                beforeCloseEventData);
-
-            var afterCloseEventData = new
-            {
-                OperationId = operationId,
-                Operation = "Close",
-                ConnectionId = sqlConnection.ClientConnectionId,
-                Connection = sqlConnection,
-                Statistics = sqlConnection.RetrieveStatistics(),
-                Timestamp = 2000000L
-            };
-
-            var now = DateTimeOffset.UtcNow;
-
-            this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlAfterCloseConnection,
-                afterCloseEventData);
-
-            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
-
-            Assert.AreEqual(afterCloseEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
-            Assert.AreEqual(afterCloseEventData.Operation, dependencyTelemetry.Data);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master | " + afterCloseEventData.Operation, dependencyTelemetry.Name);
+            Assert.AreEqual(errorOpenEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.AreEqual(errorOpenEventData.Operation, dependencyTelemetry.Data);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master | " + errorOpenEventData.Operation, dependencyTelemetry.Name);
             Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
             Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
-            Assert.IsTrue((bool)dependencyTelemetry.Success);
             Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
             Assert.IsTrue(dependencyTelemetry.Timestamp.Ticks < now.Ticks);
+            Assert.AreEqual(errorOpenEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
+            Assert.IsFalse(dependencyTelemetry.Success.Value);
         }
 
         [TestMethod]
@@ -351,6 +270,13 @@ namespace Microsoft.ApplicationInsights.Tests
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
+            Assert.AreEqual(errorCloseEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.AreEqual(errorCloseEventData.Operation, dependencyTelemetry.Data);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master | " + errorCloseEventData.Operation, dependencyTelemetry.Name);
+            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Timestamp.Ticks < now.Ticks);
             Assert.AreEqual(errorCloseEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
             Assert.IsFalse(dependencyTelemetry.Success.Value);
         }

--- a/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
@@ -144,7 +144,8 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
             Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
             Assert.IsTrue((bool)dependencyTelemetry.Success);
-            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
             Assert.IsTrue(DateTimeOffset.UtcNow >= dependencyTelemetry.Timestamp);
         }
 
@@ -171,7 +172,7 @@ namespace Microsoft.ApplicationInsights.Tests
             {
                 OperationId = operationId,
                 Command = sqlCommand,
-                Timestamp = Stopwatch.GetTimestamp() + 2000000L
+                Timestamp = Stopwatch.GetTimestamp()
             };
 
             this.fakeSqlClientDiagnosticSource.Write(
@@ -186,7 +187,8 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
             Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
             Assert.IsTrue((bool)dependencyTelemetry.Success);
-            Assert.IsTrue(dependencyTelemetry.Duration.Ticks > 2000000L);
+            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
         }
 
         [TestMethod]
@@ -342,7 +344,8 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual("(localdb)\\MSSQLLocalDB | master | " + beforeOpenEventData.Operation, dependencyTelemetry.Name);
             Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
             Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
-            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
             Assert.IsTrue(DateTimeOffset.UtcNow >= dependencyTelemetry.Timestamp);
             Assert.AreEqual(errorOpenEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
             Assert.IsFalse(dependencyTelemetry.Success.Value);
@@ -454,7 +457,8 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
             Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
             Assert.IsTrue((bool)dependencyTelemetry.Success);
-            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
             Assert.IsTrue(DateTimeOffset.UtcNow >= dependencyTelemetry.Timestamp);
         }
 
@@ -537,7 +541,8 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
             Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
             Assert.IsTrue((bool)dependencyTelemetry.Success);
-            Assert.AreEqual(1000000L, dependencyTelemetry.Duration.Ticks);
+            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
             Assert.IsTrue(DateTimeOffset.UtcNow >= dependencyTelemetry.Timestamp);
         }
 

--- a/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.ApplicationInsights.Tests
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
@@ -184,11 +185,10 @@ namespace Microsoft.ApplicationInsights.Tests
                 SqlClientDiagnosticSourceListener.SqlErrorExecuteCommand,
                 commandErrorEventData);
 
-            var exceptionTelemetry = (ExceptionTelemetry)this.sendItems.Single();
+            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreSame(commandErrorEventData.Exception, exceptionTelemetry.Exception);
-            Assert.AreEqual(commandErrorEventData.Exception.Message, exceptionTelemetry.Message);
-            Assert.IsTrue(exceptionTelemetry.Timestamp.Ticks < now.Ticks);
+            Assert.AreEqual(commandErrorEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
+            Assert.IsFalse(dependencyTelemetry.Success.Value);
         }
 
         [TestMethod]
@@ -267,11 +267,10 @@ namespace Microsoft.ApplicationInsights.Tests
                 SqlClientDiagnosticSourceListener.SqlErrorOpenConnection,
                 errorOpenEventData);
 
-            var exceptionTelemetry = (ExceptionTelemetry)this.sendItems.Single();
+            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreSame(errorOpenEventData.Exception, exceptionTelemetry.Exception);
-            Assert.AreEqual(errorOpenEventData.Exception.Message, exceptionTelemetry.Message);
-            Assert.IsTrue(exceptionTelemetry.Timestamp.Ticks < now.Ticks);
+            Assert.AreEqual(errorOpenEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
+            Assert.IsFalse(dependencyTelemetry.Success.Value);
         }
 
         [TestMethod]
@@ -334,7 +333,7 @@ namespace Microsoft.ApplicationInsights.Tests
                 SqlClientDiagnosticSourceListener.SqlBeforeCloseConnection,
                 beforeOpenEventData);
 
-            var errorOpenEventData = new
+            var errorCloseEventData = new
             {
                 OperationId = operationId,
                 Operation = "Close",
@@ -348,13 +347,12 @@ namespace Microsoft.ApplicationInsights.Tests
 
             this.fakeSqlClientDiagnosticSource.Write(
                 SqlClientDiagnosticSourceListener.SqlErrorCloseConnection,
-                errorOpenEventData);
+                errorCloseEventData);
 
-            var exceptionTelemetry = (ExceptionTelemetry)this.sendItems.Single();
+            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreSame(errorOpenEventData.Exception, exceptionTelemetry.Exception);
-            Assert.AreEqual(errorOpenEventData.Exception.Message, exceptionTelemetry.Message);
-            Assert.IsTrue(exceptionTelemetry.Timestamp.Ticks < now.Ticks);
+            Assert.AreEqual(errorCloseEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
+            Assert.IsFalse(dependencyTelemetry.Success.Value);
         }
 
         [TestMethod]
@@ -434,11 +432,10 @@ namespace Microsoft.ApplicationInsights.Tests
                 SqlClientDiagnosticSourceListener.SqlErrorCommitTransaction,
                 errorCommitEventData);
 
-            var exceptionTelemetry = (ExceptionTelemetry)this.sendItems.Single();
+            var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreSame(errorCommitEventData.Exception, exceptionTelemetry.Exception);
-            Assert.AreEqual(errorCommitEventData.Exception.Message, exceptionTelemetry.Message);
-            Assert.IsTrue(exceptionTelemetry.Timestamp.Ticks < now.Ticks);
+            Assert.AreEqual(errorCommitEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
+            Assert.IsFalse(dependencyTelemetry.Success.Value);
         }
 
         [TestMethod]

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -30,11 +30,12 @@
 #endif
 
         private HttpCoreDiagnosticSourceListener httpCoreDiagnosticSourceListener;
+        private SqlClientDiagnosticSourceListener sqlClientDiagnosticSourceListener;
 
 #if !NETCORE
         private ProfilerSqlCommandProcessing sqlCommandProcessing;
         private ProfilerSqlConnectionProcessing sqlConnectionProcessing;
-        private ProfilerHttpProcessing httpProcessing;        
+        private ProfilerHttpProcessing httpProcessing;
 #endif
         private TelemetryConfiguration telemetryConfiguration;
         private bool isInitialized = false;
@@ -134,6 +135,8 @@
                                 this.ExcludeComponentCorrelationHttpHeadersOnDomains, 
                                 null);
 
+                            this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(configuration);
+
                             DependencyCollectorEventSource.Log.RemoteDependencyModuleVerbose("Initializing DependencyTrackingModule completed successfully.");
                         }
                         catch (Exception exc)
@@ -217,6 +220,11 @@
                     {
                         this.httpCoreDiagnosticSourceListener.Dispose();
                     }
+
+                    if (this.sqlClientDiagnosticSourceListener != null)
+                    {
+                        this.sqlClientDiagnosticSourceListener.Dispose();
+                    }
                 }
 
                 this.disposed = true;
@@ -289,7 +297,7 @@
             }
             else
             {
-                // if profiler is not attached then default to diagnositics and framework event source
+                // if profiler is not attached then default to diagnostics and framework event source
                 this.InitializeForDiagnosticAndFrameworkEventSource();
 
                 // Log a message to indicate the profiler is not attached

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -412,6 +412,16 @@
             this.WriteEvent(39, id, name ?? string.Empty, this.ApplicationName);
         }
 
+        [Event(
+            40,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "SqlClientDiagnosticSourceListener OnNext failed to call event handler. Error details '{0}'",
+            Level = EventLevel.Error)]
+        public void SqlClientDiagnosticSourceListenerOnNextFailed(string error, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(40, error, this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -392,6 +392,26 @@
             this.WriteEvent(37, error, this.ApplicationName);
         }
 
+        [Event(
+            37,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "SqlClientDiagnosticSubscriber failed to subscribe. Error details '{0}'",
+            Level = EventLevel.Error)]
+        public void SqlClientDiagnosticSubscriberFailedToSubscribe(string error, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(37, error, this.ApplicationName);
+        }
+
+        [Event(
+            38,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "SqlClientDiagnosticSubscriber: Callback called for id = '{0}', name= '{1}'",
+            Level = EventLevel.Verbose)]
+        public void SqlClientDiagnosticSubscriberCallbackCalled(Guid id, string name)
+        {
+            this.WriteEvent(38, id, name, this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -393,23 +393,23 @@
         }
 
         [Event(
-            37,
+            38,
             Keywords = Keywords.RddEventKeywords,
             Message = "SqlClientDiagnosticSubscriber failed to subscribe. Error details '{0}'",
             Level = EventLevel.Error)]
         public void SqlClientDiagnosticSubscriberFailedToSubscribe(string error, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(37, error, this.ApplicationName);
+            this.WriteEvent(38, error, this.ApplicationName);
         }
 
         [Event(
-            38,
+            39,
             Keywords = Keywords.RddEventKeywords,
             Message = "SqlClientDiagnosticSubscriber: Callback called for id = '{0}', name= '{1}'",
             Level = EventLevel.Verbose)]
-        public void SqlClientDiagnosticSubscriberCallbackCalled(Guid id, string name)
+        public void SqlClientDiagnosticSubscriberCallbackCalled(Guid id, string name, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(38, id, name, this.ApplicationName);
+            this.WriteEvent(39, id, name ?? string.Empty, this.ApplicationName);
         }
 
         [NonEvent]

--- a/Src/DependencyCollector/Shared/Implementation/Operation/ObjectInstanceBasedOperationHolder.cs
+++ b/Src/DependencyCollector/Shared/Implementation/Operation/ObjectInstanceBasedOperationHolder.cs
@@ -13,7 +13,7 @@
         {
             if (holderInstance == null)
             {
-                throw new ArgumentNullException("holderInstnce");
+                throw new ArgumentNullException("holderInstance");
             }
 
             Tuple<DependencyTelemetry, bool> result = null;
@@ -29,7 +29,7 @@
         {
             if (holderInstance == null)
             {
-                throw new ArgumentNullException("holderInstnce");
+                throw new ArgumentNullException("holderInstance");
             }
 
             return this.weakTableForCorrelation.Remove(holderInstance);
@@ -39,7 +39,7 @@
         {
             if (holderInstance == null)
             {
-                throw new ArgumentNullException("holderInstnce");
+                throw new ArgumentNullException("holderInstance");
             }
 
             if (telemetryTuple == null)

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
                     this.operationStartTimestamps.TryAdd(
                         operationId,
-                        ConnectionBefore.Timestamp.Fetch(evnt.Value) as long? ?? Stopwatch.GetTimestamp()); // TODO corefx#20748 - timestamp missing from event data
+                        CommandBefore.Timestamp.Fetch(evnt.Value) as long? ?? Stopwatch.GetTimestamp()); // TODO corefx#20748 - timestamp missing from event data
 
                     break;
                 }
@@ -138,7 +138,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 }
 
                 case SqlErrorOpenConnection:
-                case SqlErrorCloseConnection:
                 {
                     var operationId = (Guid)ConnectionError.OperationId.Fetch(evnt.Value);
 
@@ -234,9 +233,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             telemetry.Success = false;
             telemetry.Properties["Exception"] = exception.ToInvariantString();
 
-            var sqlException = exception as SqlException;
-
-            if (sqlException != null)
+            if (exception is SqlException sqlException)
             {
                 telemetry.ResultCode = sqlException.Number.ToString(CultureInfo.InvariantCulture);
             }
@@ -387,8 +384,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
         private TimeSpan DeriveDuration(Guid operationId, long endTimestamp)
         {
-            return this.operationStartTimestamps.TryRemove(operationId, out var startTimestamp1)
-                ? TimeSpan.FromTicks(endTimestamp - startTimestamp1)
+            return this.operationStartTimestamps.TryRemove(operationId, out var startTimestamp)
+                ? TimeSpan.FromTicks(endTimestamp - startTimestamp)
                 : default(TimeSpan);
         }
 

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
@@ -1,0 +1,565 @@
+namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.Diagnostics;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.Web.Implementation;
+
+    internal class SqlClientDiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
+    {
+        // Event ids defined at: https://github.com/dotnet/corefx/blob/master/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+        public const string DiagnosticListenerName = "SqlClientDiagnosticListener";
+
+        public const string SqlBeforeExecuteCommand = SqlClientPrefix + "WriteCommandBefore";
+        public const string SqlAfterExecuteCommand = SqlClientPrefix + "WriteCommandAfter";
+        public const string SqlErrorExecuteCommand = SqlClientPrefix + "WriteCommandError";
+        
+        public const string SqlBeforeOpenConnection = SqlClientPrefix + "WriteConnectionOpenBefore";
+        public const string SqlAfterOpenConnection = SqlClientPrefix + "WriteConnectionOpenAfter";
+        public const string SqlErrorOpenConnection = SqlClientPrefix + "WriteConnectionOpenError";
+
+        public const string SqlBeforeCloseConnection = SqlClientPrefix + "WriteConnectionCloseBefore";
+        public const string SqlAfterCloseConnection = SqlClientPrefix + "WriteConnectionCloseAfter";
+        public const string SqlErrorCloseConnection = SqlClientPrefix + "WriteConnectionCloseError";
+
+        public const string SqlBeforeCommitTransaction = SqlClientPrefix + "WriteTransactionCommitBefore";
+        public const string SqlAfterCommitTransaction = SqlClientPrefix + "WriteTransactionCommitAfter";
+        public const string SqlErrorCommitTransaction = SqlClientPrefix + "WriteTransactionCommitError";
+
+        public const string SqlBeforeRollbackTransaction = SqlClientPrefix + "WriteTransactionRollbackBefore";
+        public const string SqlAfterRollbackTransaction = SqlClientPrefix + "WriteTransactionRollbackAfter";
+        public const string SqlErrorRollbackTransaction = SqlClientPrefix + "WriteTransactionRollbackError";
+
+        private const string SqlClientPrefix = "System.Data.SqlClient.";
+
+        private readonly TelemetryClient client;
+        private readonly SqlClientDiagnosticSourceSubscriber subscriber;
+
+        private readonly ConcurrentDictionary<Guid, long> operationStartTimestamps = new ConcurrentDictionary<Guid, long>();
+
+        public SqlClientDiagnosticSourceListener(TelemetryConfiguration configuration)
+        {
+            this.client = new TelemetryClient(configuration);
+            this.client.Context.GetInternalContext().SdkVersion =
+                SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceCore + ":");
+
+            this.subscriber = new SqlClientDiagnosticSourceSubscriber(this);
+        }
+
+        public void Dispose()
+        {
+            if (this.subscriber != null)
+            {
+                this.subscriber.Dispose();
+            }
+        }
+        
+        void IObserver<KeyValuePair<string, object>>.OnCompleted()
+        {
+        }
+
+        void IObserver<KeyValuePair<string, object>>.OnError(Exception error)
+        {
+        }
+
+        void IObserver<KeyValuePair<string, object>>.OnNext(KeyValuePair<string, object> evnt)
+        {
+            switch (evnt.Key)
+            {
+                case SqlBeforeExecuteCommand:
+                {
+                    var operationId = (Guid)CommandBefore.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                    this.operationStartTimestamps.TryAdd(
+                        operationId,
+                        ConnectionBefore.Timestamp.Fetch(evnt.Value) as long? ?? Stopwatch.GetTimestamp()); // TODO corefx#20748 - timestamp missing from event data
+
+                    break;
+                }
+
+                case SqlAfterExecuteCommand:
+                {
+                    var operationId = (Guid)CommandAfter.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+                    
+                    this.OnAfterCommandEvent(
+                        operationId,
+                        (string)CommandAfter.Operation.Fetch(evnt.Value),
+                        (Guid)CommandAfter.ConnectionId.Fetch(evnt.Value),
+                        (SqlCommand)CommandAfter.Command.Fetch(evnt.Value),
+                        (IDictionary)CommandAfter.Statistics.Fetch(evnt.Value),
+                        (long)CommandAfter.Timestamp.Fetch(evnt.Value));
+
+                    break;
+                }
+
+                case SqlErrorExecuteCommand:
+                {
+                    var operationId = (Guid)CommandError.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+                    
+                    this.OnCommandErrorEvent(
+                        operationId,
+                        (string)CommandError.Operation.Fetch(evnt.Value),
+                        (Guid)CommandError.ConnectionId.Fetch(evnt.Value),
+                        (Exception)CommandError.Exception.Fetch(evnt.Value),
+                        (long)CommandError.Timestamp.Fetch(evnt.Value));
+
+                    break;
+                }
+                    
+                case SqlBeforeOpenConnection:
+                case SqlBeforeCloseConnection:
+                {
+                    var operationId = (Guid)ConnectionBefore.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+                    
+                    this.operationStartTimestamps.TryAdd(
+                        operationId,
+                        (long)ConnectionBefore.Timestamp.Fetch(evnt.Value));
+
+                    break;
+                }
+
+                case SqlAfterOpenConnection:
+                case SqlAfterCloseConnection:
+                {
+                    var operationId = (Guid)ConnectionAfter.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+                    
+                    this.OnAfterConnectionEvent(
+                        operationId,
+                        (string)ConnectionAfter.Operation.Fetch(evnt.Value),
+                        (Guid)ConnectionAfter.ConnectionId.Fetch(evnt.Value),
+                        (SqlConnection)ConnectionAfter.Connection.Fetch(evnt.Value),
+                        (IDictionary)ConnectionAfter.Statistics.Fetch(evnt.Value),
+                        (long)ConnectionAfter.Timestamp.Fetch(evnt.Value));
+
+                    break;
+                }
+
+                case SqlErrorOpenConnection:
+                case SqlErrorCloseConnection:
+                {
+                    var operationId = (Guid)ConnectionError.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+                    
+                    this.OnErrorConnectionEvent(
+                        operationId,
+                        (string)ConnectionError.Operation.Fetch(evnt.Value),
+                        (Guid)ConnectionError.ConnectionId.Fetch(evnt.Value),
+                        (Exception)ConnectionError.Exception.Fetch(evnt.Value),
+                        (long)ConnectionError.Timestamp.Fetch(evnt.Value));
+
+                    break;
+                }
+
+                case SqlBeforeCommitTransaction:
+                case SqlBeforeRollbackTransaction:
+                {
+                    var operationId = (Guid)TransactionBefore.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+                    
+                    this.operationStartTimestamps.TryAdd(
+                        operationId,
+                        (long)TransactionBefore.Timestamp.Fetch(evnt.Value));
+
+                    break;
+                }
+
+                case SqlAfterCommitTransaction:
+                case SqlAfterRollbackTransaction:
+                {
+                    var operationId = (Guid)TransactionAfter.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+                    
+                    this.OnAfterTransactionEvent(
+                        operationId,
+                        (string)TransactionAfter.Operation.Fetch(evnt.Value),
+                        (IsolationLevel)TransactionAfter.IsolationLevel.Fetch(evnt.Value),
+                        (SqlConnection)TransactionAfter.Connection.Fetch(evnt.Value),
+                        (long)TransactionAfter.Timestamp.Fetch(evnt.Value));
+
+                    break;
+                }
+
+                case SqlErrorCommitTransaction:
+                case SqlErrorRollbackTransaction:
+                {
+                    var operationId = (Guid)TransactionError.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+                    
+                    this.OnErrorTransactionEvent(
+                        operationId,
+                        (string)TransactionError.Operation.Fetch(evnt.Value),
+                        (IsolationLevel)TransactionError.IsolationLevel.Fetch(evnt.Value),
+                        (SqlConnection)TransactionError.Connection.Fetch(evnt.Value),
+                        (Exception)TransactionError.Exception.Fetch(evnt.Value),
+                        (long)TransactionError.Timestamp.Fetch(evnt.Value));
+
+                    break;
+                }
+            }
+        }
+
+        private static void InitializeTelemetry(ITelemetry telemetry, Guid operationId)
+        {
+            var activity = Activity.Current;
+
+            if (activity != null)
+            {
+                telemetry.Context.Operation.Id = activity.RootId;
+                telemetry.Context.Operation.ParentId = activity.ParentId;
+
+                foreach (var item in activity.Baggage)
+                {
+                    if (!telemetry.Context.Properties.ContainsKey(item.Key))
+                    {
+                        telemetry.Context.Properties[item.Key] = item.Value;
+                    }
+                }
+            }
+            else
+            {
+                telemetry.Context.Operation.Id = operationId.ToString("N");
+            }
+        }
+
+        private static void CorrelateErrorTelemetry(ExceptionTelemetry telemetry, Guid operationId)
+        {
+            telemetry.Context.Operation.ParentId = operationId.ToString("N");
+        }
+
+        private void OnAfterCommandEvent(
+            Guid operationId,
+            string operation,
+            Guid connectionId,
+            SqlCommand command,
+            IDictionary statistics,
+            long endTimestamp)
+        {
+            // Call DeriveDuration first to ensure we remove any start timestamp from operationStartTimestamps
+            var duration = this.DeriveDuration(operationId, endTimestamp);
+
+            var dependencyName = string.Empty;
+            var target = string.Empty;
+
+            if (command.Connection != null)
+            {
+                target = string.Join(" | ", command.Connection.DataSource, command.Connection.Database);
+
+                var commandName = command.CommandType == CommandType.StoredProcedure
+                    ? command.CommandText
+                    : string.Empty;
+
+                dependencyName = string.IsNullOrEmpty(commandName)
+                    ? string.Join(" | ", command.Connection.DataSource, command.Connection.Database)
+                    : string.Join(" | ", command.Connection.DataSource, command.Connection.Database, commandName);
+            }
+
+            var telemetry = new DependencyTelemetry()
+            {
+                Id = operationId.ToString("N"),
+                Name = dependencyName,
+                Type = RemoteDependencyConstants.SQL,
+                Target = target,
+                Data = command.CommandText,
+                Duration = duration,
+                Timestamp = DateTimeOffset.UtcNow - duration,
+                Success = true
+            };
+
+            InitializeTelemetry(telemetry, operationId);
+            
+            this.client.Track(telemetry);
+        }
+
+        private void OnCommandErrorEvent(
+            Guid operationId,
+            string operation,
+            Guid connectionId,
+            Exception exception,
+            long endTimestamp)
+        {
+            var duration = this.DeriveDuration(operationId, endTimestamp);
+
+            var telemetry = new ExceptionTelemetry(exception)
+            {
+                Message = exception.Message,
+                Timestamp = DateTimeOffset.UtcNow - duration,
+                SeverityLevel = SeverityLevel.Critical
+            };
+
+            InitializeTelemetry(telemetry, operationId);
+            CorrelateErrorTelemetry(telemetry, operationId);
+
+            this.client.Track(telemetry);
+        }
+
+        private void OnAfterConnectionEvent(
+            Guid operationId, 
+            string operation,
+            Guid connectionId,
+            SqlConnection connection, 
+            IDictionary statistics, 
+            long endTimestamp)
+        {
+            var duration = this.DeriveDuration(operationId, endTimestamp);
+            
+            var telemetry = new DependencyTelemetry()
+            {
+                Id = operationId.ToString("N"),
+                Name = string.Join(" | ", connection.DataSource, connection.Database, operation),
+                Type = RemoteDependencyConstants.SQL,
+                Target = string.Join(" | ", connection.DataSource, connection.Database),
+                Data = operation,
+                Duration = duration,
+                Timestamp = DateTimeOffset.UtcNow - duration,
+                Success = true
+            };
+
+            InitializeTelemetry(telemetry, operationId);
+
+            this.client.Track(telemetry);
+        }
+
+        private void OnErrorConnectionEvent(
+            Guid operationId,
+            string operation,
+            Guid connectionId,
+            Exception exception,
+            long endTimestamp)
+        {
+            var duration = this.DeriveDuration(operationId, endTimestamp);
+
+            var telemetry = new ExceptionTelemetry(exception)
+            {
+                Message = exception.Message,
+                Timestamp = DateTimeOffset.UtcNow - duration,
+                SeverityLevel = SeverityLevel.Critical
+            };
+
+            InitializeTelemetry(telemetry, operationId);
+            CorrelateErrorTelemetry(telemetry, operationId);
+
+            this.client.Track(telemetry);
+        }
+
+        private void OnAfterTransactionEvent(
+            Guid operationId,
+            string operation,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            long endTimestamp)
+        {
+            var duration = this.DeriveDuration(operationId, endTimestamp);
+
+            var telemetry = new DependencyTelemetry()
+            {
+                Id = operationId.ToString("N"),
+                Name = string.Join(" | ", connection.DataSource, connection.Database, operation, isolationLevel),
+                Type = RemoteDependencyConstants.SQL,
+                Target = string.Join(" | ", connection.DataSource, connection.Database),
+                Data = operation,
+                Duration = duration,
+                Timestamp = DateTimeOffset.UtcNow - duration,
+                Success = true
+            };
+
+            InitializeTelemetry(telemetry, operationId);
+
+            this.client.Track(telemetry);
+        }
+
+        private void OnErrorTransactionEvent(
+            Guid operationId,
+            string operation,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            Exception exception,
+            long endTimestamp)
+        {
+            var duration = this.DeriveDuration(operationId, endTimestamp);
+
+            var telemetry = new ExceptionTelemetry(exception)
+            {
+                Message = exception.Message,
+                Timestamp = DateTimeOffset.UtcNow - duration,
+                SeverityLevel = SeverityLevel.Critical
+            };
+
+            InitializeTelemetry(telemetry, operationId);
+            CorrelateErrorTelemetry(telemetry, operationId);
+
+            this.client.Track(telemetry);
+        }
+
+        private TimeSpan DeriveDuration(Guid operationId, long endTimestamp)
+        {
+            return this.operationStartTimestamps.TryRemove(operationId, out var startTimestamp1)
+                ? TimeSpan.FromTicks(endTimestamp - startTimestamp1)
+                : default(TimeSpan);
+        }
+        
+        #region Fetchers
+
+        // Fetchers for execute command before event
+        private static class CommandBefore
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for execute command after event
+        private static class CommandAfter
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
+            public static readonly PropertyFetcher ConnectionId = new PropertyFetcher(nameof(ConnectionId));
+            public static readonly PropertyFetcher Command = new PropertyFetcher(nameof(Command));
+            public static readonly PropertyFetcher Statistics = new PropertyFetcher(nameof(Statistics));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for execute command error event
+        private static class CommandError
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
+            public static readonly PropertyFetcher ConnectionId = new PropertyFetcher(nameof(ConnectionId));
+            public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for connection open/close before events
+        private static class ConnectionBefore
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for connection open/close after events
+        private static class ConnectionAfter
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
+            public static readonly PropertyFetcher ConnectionId = new PropertyFetcher(nameof(ConnectionId));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Statistics = new PropertyFetcher(nameof(Statistics));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for connection open/close error events
+        private static class ConnectionError
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
+            public static readonly PropertyFetcher ConnectionId = new PropertyFetcher(nameof(ConnectionId));
+            public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for transaction commit/rollback before events
+        private static class TransactionBefore
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for transaction commit/rollback after events
+        private static class TransactionAfter
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
+            public static readonly PropertyFetcher IsolationLevel = new PropertyFetcher(nameof(IsolationLevel));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for transaction commit/rollback error events
+        private static class TransactionError
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
+            public static readonly PropertyFetcher IsolationLevel = new PropertyFetcher(nameof(IsolationLevel));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        #endregion
+
+        private sealed class SqlClientDiagnosticSourceSubscriber : IObserver<DiagnosticListener>, IDisposable
+        {
+            private readonly SqlClientDiagnosticSourceListener sqlDiagnosticListener;
+            private readonly IDisposable listenerSubscription;
+
+            private IDisposable eventSubscription;
+
+            internal SqlClientDiagnosticSourceSubscriber(SqlClientDiagnosticSourceListener listener)
+            {
+                this.sqlDiagnosticListener = listener;
+
+                try
+                {
+                    this.listenerSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+                }
+                catch (Exception ex)
+                {
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberFailedToSubscribe(ex.ToInvariantString());
+                }
+            }
+
+            public void OnNext(DiagnosticListener value)
+            {
+                if (value != null)
+                {
+                    if (value.Name == DiagnosticListenerName)
+                    {
+                        this.eventSubscription = value.Subscribe(this.sqlDiagnosticListener);
+                    }
+                }
+            }
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void Dispose()
+            {
+                if (this.eventSubscription != null)
+                {
+                    this.eventSubscription.Dispose();
+                }
+
+                if (this.listenerSubscription != null)
+                {
+                    this.listenerSubscription.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
@@ -136,6 +136,17 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     break;
                 }
 
+                case SqlAfterOpenConnection:
+                {
+                    var operationId = (Guid)ConnectionAfter.OperationId.Fetch(evnt.Value);
+
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                    this.operationStartTimestamps.TryRemove(operationId, out var startTimestamp);
+
+                    break;
+                }
+
                 case SqlErrorOpenConnection:
                 {
                     var operationId = (Guid)ConnectionError.OperationId.Fetch(evnt.Value);

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
@@ -124,7 +124,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 }
                     
                 case SqlBeforeOpenConnection:
-                case SqlBeforeCloseConnection:
                 {
                     var operationId = (Guid)ConnectionBefore.OperationId.Fetch(evnt.Value);
 

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnosticSourceListener.cs
@@ -142,7 +142,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
                     DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
 
-                    this.operationStartTimestamps.TryRemove(operationId, out var startTimestamp);
+                    this.operationStartTimestamps.TryRemove(operationId, out _);
 
                     break;
                 }
@@ -243,7 +243,9 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             telemetry.Success = false;
             telemetry.Properties["Exception"] = exception.ToInvariantString();
 
-            if (exception is SqlException sqlException)
+            var sqlException = exception as SqlException;
+
+            if (sqlException != null)
             {
                 telemetry.ResultCode = sqlException.Number.ToString(CultureInfo.InvariantCulture);
             }

--- a/Test/DependencyCollector/FunctionalTests/FW45Shared/SqlCommandHelper.cs
+++ b/Test/DependencyCollector/FunctionalTests/FW45Shared/SqlCommandHelper.cs
@@ -42,6 +42,7 @@
             await ExecuteReaderAsyncInternal(connectionString, commandText, commandType);
         }
 
+#if !NETCOREAPP2_0 && !NETCOREAPP1_0
         public static void BeginExecuteReader(string connectionString, string commandText, int numberOfAsyncArgs)
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -67,6 +68,7 @@
             executor.BeginExecute();
             mre.WaitOne(1000);
         }
+#endif
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities")]
         public static void AsyncExecuteReaderInTasks(string connectionString, string commandText)
@@ -75,8 +77,12 @@
             connection.Open();
             var command = connection.CreateCommand();
             command.CommandText = commandText;
+
+            // TODO: There is race condition here. SqlConnection is not threadsafe
+            // and these tasks need to be serialized.
             var task1 = command.ExecuteReaderAsync();
             var task2 = command.ExecuteReaderAsync();
+
             task1.Wait();
             task2.Wait();
         }
@@ -124,6 +130,7 @@
             await ExecuteNonQueryAsyncInternal(connectionString, commandText);
         }
 
+#if !NETCOREAPP2_0 && !NETCOREAPP1_0
         public static void BeginExecuteNonQuery(string connectionString, string commandText, int numberOfArgs)
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -144,6 +151,7 @@
                 command.ExecuteNonQuery();
             }
         }
+#endif
 
         #endregion
 
@@ -166,15 +174,16 @@
             }
         }
 
-        #endregion
+#endregion
 
-        #region ExecuteXmlReader
+#region ExecuteXmlReader
 
         public static async void ExecuteXmlReaderAsync(string connectionString, string commandText)
         {
             await ExecuteXmlReaderAsyncInternal(connectionString, commandText);
         }
 
+#if !NETCOREAPP2_0 && !NETCOREAPP1_0
         public static void BeginExecuteXmlReader(string connectionString, string commandText)
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -197,6 +206,7 @@
                 }
             }    
         }
+#endif
 
         #endregion
 
@@ -261,6 +271,7 @@
             }
         }
 
+#if !NETCOREAPP2_0 && !NETCOREAPP1_0
         private sealed class AsyncExecuteReaderWrapper : IDisposable
         {
             private readonly SqlCommand command;
@@ -586,5 +597,6 @@
                 }
             }          
         }
+#endif
     }
 }

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCore20HttpTests.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCore20HttpTests.cs
@@ -108,7 +108,7 @@
         {
             EnsureDotNetCoreInstalled();
 
-            return new ExpectedSDKPrefixChanger("rdddsc", null);
+            return new ExpectedSDKPrefixChanger("rdddsc", "rdddsc");
         }
         
 
@@ -148,6 +148,111 @@
             {
                 // Execute and verify calls which fails.            
                 HttpTestHelper.ExecuteSyncHttpTests(AspxCoreTestWebApplication, false, 1, HttpTestConstants.AccessTimeMaxHttpInitial, "200", HttpTestConstants.QueryStringOutboundHttpFailed);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForSqlExecuteReaderAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteReaderAsync);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForSqlExecuteScalarAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteScalarAsync);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForExecuteReaderStoredProcedureAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteReaderStoredProcedureAsync);
+            }
+        }
+
+        [TestMethod]
+        [Ignore] // Can't run this until race condition in SqlCommandHelper.AsyncExecuteReaderInTasks is fixed.
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestExecuteReaderTwiceWithTasksAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundTestExecuteReaderTwiceWithTasks);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestExecuteNonQueryAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteNonQueryAsync);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestExecuteXmlReaderAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteXmlReaderAsync);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestSqlCommandExecuteScalarAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundSqlCommandExecuteScalar);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestSqlCommandExecuteScalarErrorAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, false, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundSqlCommandExecuteScalarError);
             }
         }
 

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCoreHttpTests.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCoreHttpTests.cs
@@ -107,7 +107,7 @@
         {
             EnsureDotNetCoreInstalled();
 
-            return new ExpectedSDKPrefixChanger("rdddsc", null);
+            return new ExpectedSDKPrefixChanger("rdddsc", "rdddsc");
         }
 
         private const string AspxCoreTestAppFolder = "..\\TestApps\\AspxCore\\";
@@ -148,6 +148,111 @@
             {
                 // Execute and verify calls which fails.            
                 HttpTestHelper.ExecuteSyncHttpTests(AspxCoreTestWebApplication, false, 1, HttpTestConstants.AccessTimeMaxHttpInitial, "200", HttpTestConstants.QueryStringOutboundHttpFailed);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForSqlExecuteReaderAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteReaderAsync);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForSqlExecuteScalarAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteScalarAsync);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForExecuteReaderStoredProcedureAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteReaderStoredProcedureAsync);
+            }
+        }
+
+        [TestMethod]
+        [Ignore] // Can't run this until race condition in SqlCommandHelper.AsyncExecuteReaderInTasks is fixed.
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestExecuteReaderTwiceWithTasksAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundTestExecuteReaderTwiceWithTasks);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestExecuteNonQueryAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteNonQueryAsync);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestExecuteXmlReaderAsyncAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundExecuteXmlReaderAsync);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestSqlCommandExecuteScalarAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, true, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundSqlCommandExecuteScalar);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory.NetCore20)]
+        [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
+        public void TestRddForTestSqlCommandExecuteScalarErrorAspxCore()
+        {
+            using (DotNetCoreTestSetup())
+            {
+                // Execute and verify calls which succeeds            
+                HttpTestHelper.ExecuteSqlTest(
+                    AspxCoreTestWebApplication, false, 1, HttpTestConstants.AccessTimeMaxHttpNormal, HttpTestConstants.QueryStringOutboundSqlCommandExecuteScalarError);
             }
         }
 

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpTestConstants.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpTestConstants.cs
@@ -95,6 +95,46 @@ namespace FuncTest.Helpers
         internal static string QueryStringOutboundHttpAsyncAwait1Failed = "?type=failedhttpasyncawait1&count=";
 
         /// <summary>
+        /// Query string to specify Outbound SQL Call .
+        /// </summary>
+        internal static string QueryStringOutboundExecuteReaderAsync = "?type=ExecuteReaderAsync&success=true&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound SQL Call .
+        /// </summary>
+        internal static string QueryStringOutboundExecuteScalarAsync = "?type=ExecuteScalarAsync&success=true&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound SQL Call .
+        /// </summary>
+        internal static string QueryStringOutboundExecuteReaderStoredProcedureAsync = "?type=ExecuteReaderStoredProcedureAsync&storedProcedureName=GetTopTenMessages&success=true&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound SQL Call .
+        /// </summary>
+        internal static string QueryStringOutboundTestExecuteReaderTwiceWithTasks = "?type=TestExecuteReaderTwiceWithTasks&success=true&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound SQL Call .
+        /// </summary>
+        internal static string QueryStringOutboundExecuteNonQueryAsync = "?type=ExecuteNonQueryAsync&success=true&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound SQL Call .
+        /// </summary>
+        internal static string QueryStringOutboundExecuteXmlReaderAsync = "?type=ExecuteXmlReaderAsync&success=true&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound SQL Call .
+        /// </summary>
+        internal static string QueryStringOutboundSqlCommandExecuteScalar = "?type=SqlCommandExecuteScalar&success=true&count=";
+
+        /// <summary>
+        /// Query string to specify Outbound SQL Call .
+        /// </summary>
+        internal static string QueryStringOutboundSqlCommandExecuteScalarError = "?type=SqlCommandExecuteScalar&success=false&count=";
+
+        /// <summary>
         /// Maximum access time for the initial call - This includes an additional 1-2 delay introduced before the very first call by Profiler V2.
         /// </summary>        
         internal static TimeSpan AccessTimeMaxHttpInitial = TimeSpan.FromSeconds(10);

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpTestHelper.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpTestHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using AI;
 using FuncTest.Serialization;
@@ -23,6 +24,27 @@ namespace FuncTest.Helpers
         /// Resource Name for failed at DNS request.
         /// </summary>
         internal static Uri ResourceNameHttpToFailedAtDnsRequest = new Uri("https://abcdefzzzzeeeeadadad.com");
+
+        /// <summary>
+        /// Resource Name for dev database.
+        /// </summary>
+        private const string ResourceNameSQLToDevApm = @".\SQLEXPRESS | RDDTestDatabase";                
+        
+        /// <summary>
+        /// Valid SQL Query. The wait for delay of 6 ms is used to prevent access time of less than 1 ms. SQL is not accurate below 3, so used 6 ms delay.
+        /// </summary> 
+        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "Reviewed.")]
+        private const string ValidSqlQueryToApmDatabase = "WAITFOR DELAY '00:00:00:006'; select * from dbo.Messages";
+
+        /// <summary>
+        /// Valid SQL Query to get count.
+        /// </summary> 
+        private const string ValidSqlQueryCountToApmDatabase = "WAITFOR DELAY '00:00:00:006'; SELECT count(*) FROM dbo.Messages";
+
+        /// <summary>
+        /// Invalid SQL query only needed here because the test web app we use to run queries will throw a 500 and we can't get back the invalid query from it.
+        /// </summary>        
+        private const string InvalidSqlQueryToApmDatabase = "SELECT TOP 2 * FROM apm.[Database1212121]";
 
         /// <summary>
         /// Helper to execute Async Http tests.
@@ -281,6 +303,98 @@ namespace FuncTest.Helpers
             }
 
             DeploymentAndValidationTools.Validate(itemToValidate, accessTimeMax, successFlagExpected, resultCodeExpected);
-        }        
+        }
+
+        /// <summary>
+        /// Helper to execute Sync SQL tests
+        /// </summary>
+        /// <param name="testWebApplication">The test application for which tests are to be executed</param>
+        /// <param name="success">indicates if the tests should test success or failure case</param>   
+        /// <param name="count">number to RDD calls to be made by the test application.  </param> 
+        /// <param name="accessTimeMax">approximate maximum time taken by RDD Call.  </param>
+        /// <param name="queryString">The query string. </param> 
+        public static void ExecuteSqlTest(
+            TestWebApplication testWebApplication, bool success, int count, TimeSpan accessTimeMax, string queryString)
+        {
+            testWebApplication.DoTest(
+                application =>
+                {
+                    application.ExecuteAnonymousRequest(queryString + count);
+
+                    //// The above request would have trigged RDD module to monitor and create RDD telemetry
+                    //// Listen in the fake endpoint and see if the RDDTelemtry is captured
+                    var allItems = DeploymentAndValidationTools.SdkEventListener
+                        .ReceiveAllItemsDuringTimeOfType<TelemetryItem<RemoteDependencyData>>(DeploymentAndValidationTools.SleepTimeForSdkToSendEvents);
+
+                    var sqlItems = allItems.Where(i => i.data.baseData.type == "SQL").ToArray();
+
+                    Assert.AreEqual(
+                        count,
+                        sqlItems.Length,
+                        "Total Count of Remote Dependency items for HTTP collected is wrong.");
+
+                    var validQuery 
+                        = queryString.Contains("CommandExecuteScalar")
+                            ? ValidSqlQueryCountToApmDatabase
+                            : ValidSqlQueryToApmDatabase;
+
+                    var queryToValidate 
+                        = success 
+                            ? queryString.Contains("StoredProcedure")
+                                ? "GetTopTenMessages"
+                                : queryString.Contains("Xml")
+                                    ? validQuery + " FOR XML AUTO"   
+                                    : validQuery
+                            : InvalidSqlQueryToApmDatabase;
+
+                    foreach (var sqlItem in sqlItems)
+                    {
+                        Validate(
+                            sqlItem,
+                            ResourceNameSQLToDevApm,
+                            queryToValidate,
+                            TimeSpan.FromSeconds(20),
+                            successFlagExpected: success,
+                            sqlErrorCodeExpected: success ? string.Empty : "208",
+                            sqlErrorMessageExpected: null);
+                    }
+                });
+        }
+
+        private static void Validate(TelemetryItem<RemoteDependencyData> itemToValidate,
+            string targetExpected,
+            string commandNameExpected,
+            TimeSpan accessTimeMax,
+            bool successFlagExpected,
+            string sqlErrorCodeExpected,
+            string sqlErrorMessageExpected)
+        {
+            Assert.IsTrue(itemToValidate.data.baseData.target.Contains(targetExpected),
+                "The remote dependancy target is incorrect. Expected: " + targetExpected +
+                ". Collected: " + itemToValidate.data.baseData.target);
+
+            Assert.AreEqual(sqlErrorCodeExpected, itemToValidate.data.baseData.resultCode);
+
+            //If the command name is expected to be empty, the deserializer will make the CommandName null
+            if ("rdddsc" == DeploymentAndValidationTools.ExpectedSqlSDKPrefix)
+            {
+                // Additional checks for profiler collection
+                if (!string.IsNullOrEmpty(sqlErrorMessageExpected))
+                {
+                    Assert.AreEqual(sqlErrorMessageExpected, itemToValidate.data.baseData.properties["ErrorMessage"]);
+                }
+
+                if (string.IsNullOrEmpty(commandNameExpected))
+                {
+                    Assert.IsNull(itemToValidate.data.baseData.data);
+                }
+                else
+                {
+                    Assert.AreEqual(commandNameExpected, itemToValidate.data.baseData.data, "The command name is incorrect");
+                }
+            }
+
+            DeploymentAndValidationTools.Validate(itemToValidate, accessTimeMax, successFlagExpected, sqlErrorCodeExpected);
+        }
     }
 }

--- a/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/AspxCore.csproj
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/AspxCore.csproj
@@ -27,21 +27,25 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\FW45Shared\SqlCommandHelper.cs" Link="SqlCommandHelper.cs" />
+  </ItemGroup>
+  
   <!--
   <ItemGroup>
     <Reference Include="Microsoft.AI.DependencyCollector">
       <HintPath>$(BinRoot)\$(Configuration)\Src\DependencyCollector\NetCore\netstandard1.6\Microsoft.AI.DependencyCollector.dll</HintPath>
     </Reference>
-  </ItemGroup>   
+  </ItemGroup>
   -->
-  
-  
- <ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\Src\DependencyCollector\NetCore\DependencyCollector.NetCore.csproj" />
   </ItemGroup>
-
+   
   <ItemGroup>
     <Content Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Controllers/ExternalCallsController.cs
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Controllers/ExternalCallsController.cs
@@ -1,7 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text;
+using FW45Shared;
 
 namespace AspxCore.Controllers
 {
@@ -11,6 +14,32 @@ namespace AspxCore.Controllers
      /// Invalid Hostname to trigger exception being thrown
      /// </summary>
         private const string InvalidHostName = "https://www.zzkaodkoakdahdjghejajdnad.com";
+
+        /// <summary>
+        /// Connection string to APM Development database.
+        /// </summary> 
+        private const string ConnectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=RDDTestDatabase;Integrated Security=True";
+
+        /// <summary>
+        /// Valid SQL Query. The wait for delay of 6 ms is used to prevent access time of less than 1 ms. SQL is not accurate below 3, so used 6 ms delay.
+        /// </summary> 
+        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "Reviewed.")]
+        private const string ValidSqlQueryToApmDatabase = "WAITFOR DELAY '00:00:00:006'; select * from dbo.Messages";
+
+        /// <summary>
+        /// Valid SQL Query to get count.
+        /// </summary> 
+        private const string ValidSqlQueryCountToApmDatabase = "WAITFOR DELAY '00:00:00:006'; SELECT count(*) FROM dbo.Messages";
+
+        /// <summary>
+        /// Invalid SQL Query.
+        /// </summary> 
+        private const string InvalidSqlQueryToApmDatabase = "SELECT TOP 2 * FROM apm.[Database1212121]";
+
+        /// <summary>
+        /// Label used to identify the query being executed.
+        /// </summary> 
+        private const string QueryToExecuteLabel = "Query Executed:";
 
         private string GetQueryValue(string valueKey)
         {
@@ -26,6 +55,9 @@ namespace AspxCore.Controllers
 
             string type = GetQueryValue("type");
             string countStr = GetQueryValue("count");
+
+            bool.TryParse(GetQueryValue("success"), out var success);
+            string sqlQueryTouse = success ? ValidSqlQueryToApmDatabase : InvalidSqlQueryToApmDatabase;
 
             int count;
             if (!int.TryParse(countStr, out count))
@@ -46,6 +78,32 @@ namespace AspxCore.Controllers
                 case "failedhttp":
                     title = "Made failing Sync GET HTTP call to bing";
                     response = MakeHttpCallSyncFailed(count);
+                    break;
+                case "ExecuteReaderAsync":
+                    SqlCommandHelper.ExecuteReaderAsync(ConnectionString, sqlQueryTouse);
+                    response = QueryToExecuteLabel + sqlQueryTouse;
+                    break;
+                case "ExecuteScalarAsync":
+                    SqlCommandHelper.ExecuteScalarAsync(ConnectionString, sqlQueryTouse);
+                    break;
+                case "ExecuteReaderStoredProcedureAsync":
+                    this.ExecuteReaderStoredProcedureAsync();
+                    break;
+                case "TestExecuteReaderTwiceWithTasks":
+                    SqlCommandHelper.AsyncExecuteReaderInTasks(ConnectionString, sqlQueryTouse);
+                    break;
+                case "ExecuteNonQueryAsync":
+                    SqlCommandHelper.ExecuteNonQueryAsync(ConnectionString, sqlQueryTouse);
+                    break;
+                case "ExecuteXmlReaderAsync":
+                    sqlQueryTouse += " FOR XML AUTO";
+                    SqlCommandHelper.ExecuteXmlReaderAsync(ConnectionString, sqlQueryTouse);
+                    break;
+                case "SqlCommandExecuteScalar":
+                    sqlQueryTouse = success
+                        ? ValidSqlQueryCountToApmDatabase
+                        : InvalidSqlQueryToApmDatabase;
+                    SqlCommandHelper.ExecuteScalar(ConnectionString, sqlQueryTouse);
                     break;
                 default:
                     title = $"Unrecognized request type '{type}'";
@@ -119,6 +177,20 @@ namespace AspxCore.Controllers
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Executes reader stored procedure.
+        /// </summary>        
+        private void ExecuteReaderStoredProcedureAsync()
+        {
+            var storedProcedureName = GetQueryValue("storedProcedureName");
+            if (string.IsNullOrEmpty(storedProcedureName))
+            {
+                throw new ArgumentException("storedProcedureName query string parameter is not defined.");
+            }
+
+            SqlCommandHelper.ExecuteReaderAsync(ConnectionString, storedProcedureName, CommandType.StoredProcedure);
         }
     }
 }

--- a/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore20/AspxCore20.csproj
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore20/AspxCore20.csproj
@@ -27,7 +27,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0	" />				
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0	" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />				
+  </ItemGroup>
+    
+  <ItemGroup>
+    <Compile Include="..\..\FW45Shared\SqlCommandHelper.cs" Link="SqlCommandHelper.cs" />
   </ItemGroup>
 
   <!--
@@ -35,16 +40,13 @@
     <Reference Include="Microsoft.AI.DependencyCollector">
       <HintPath>$(BinRoot)\$(Configuration)\Src\DependencyCollector\NetCore\netstandard1.6\Microsoft.AI.DependencyCollector.dll</HintPath>
     </Reference>
-  </ItemGroup>   
+  </ItemGroup>
   -->
-  
-  
- <ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\Src\DependencyCollector\NetCore\DependencyCollector.NetCore.csproj" />
   </ItemGroup>
   
-  
-
   <ItemGroup>
     <Content Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Part of #522 - Add support for EntityFramework diagnostic source listener

**Update:** Pushed a new version that contains full support for SqlClient events.
