### PR TITLE
Improve Telemetry Id overflow handling if Parent Id has only root node (NET40)

### DIFF
--- a/Src/Common/ApplicationInsightsActivity.cs
+++ b/Src/Common/ApplicationInsightsActivity.cs
@@ -123,7 +123,7 @@
             }
 
             // ParentId is not valid Request-Id, let's generate proper one.
-            if (trimPosition == 0)
+            if (trimPosition == 1)
             {
                 return GenerateRootId();
             }


### PR DESCRIPTION
Minor improvement for some invalid corner-case scenario.

Without this change this corner case causes generation of not-unique-enough Id for telemetry on .NET40, but nothing breaks.

See more details in https://github.com/dotnet/corefx/pull/20647
