### PR TITLE
Re-enable Aspnet.Core functional test for dependency, breaking cyclic dependency

### DIFF
--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -109,6 +109,7 @@
         public void Initialize(TelemetryConfiguration configuration)
         {
             DependencyCollectorEventSource.Log.RemoteDependencyModuleVerbose("Initializing DependencyTrackingModule");
+
             // Temporary fix to make sure that we initialize module once.
             // It should be removed when configuration reading logic is moved to Web SDK.
             if (!this.isInitialized)

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -108,6 +108,7 @@
         /// </summary>
         public void Initialize(TelemetryConfiguration configuration)
         {
+            DependencyCollectorEventSource.Log.RemoteDependencyModuleVerbose("Initializing DependencyTrackingModule");
             // Temporary fix to make sure that we initialize module once.
             // It should be removed when configuration reading logic is moved to Web SDK.
             if (!this.isInitialized)
@@ -118,7 +119,7 @@
                     {
                         try
                         {                            
-                            this.telemetryConfiguration = configuration;
+                            this.telemetryConfiguration = configuration;                            
 
 #if !NETCORE
                             // Net40 only supports runtime instrumentation
@@ -135,6 +136,7 @@
                                 this.ExcludeComponentCorrelationHttpHeadersOnDomains, 
                                 null);
 #endif
+                            DependencyCollectorEventSource.Log.RemoteDependencyModuleVerbose("Initializing DependencyTrackingModule completed successfully.");
                         }
                         catch (Exception exc)
                         {

--- a/Test/DependencyCollector/FunctionalTests.sln
+++ b/Test/DependencyCollector/FunctionalTests.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FW45Shared", "FunctionalTes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationInsightsTypes", "..\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj", "{4B0BC3B7-C7FC-4333-9E28-5790D9153F07}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspxCore", "FunctionalTests\TestApps\AspxCore\AspxCore.csproj", "{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -158,6 +160,30 @@ Global
 		{4B0BC3B7-C7FC-4333-9E28-5790D9153F07}.Signed|Win32.Build.0 = Debug|Any CPU
 		{4B0BC3B7-C7FC-4333-9E28-5790D9153F07}.Signed|x64.ActiveCfg = Debug|Any CPU
 		{4B0BC3B7-C7FC-4333-9E28-5790D9153F07}.Signed|x64.Build.0 = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Debug|Win32.Build.0 = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Debug|x64.Build.0 = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Release|Win32.ActiveCfg = Release|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Release|Win32.Build.0 = Release|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Release|x64.ActiveCfg = Release|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Release|x64.Build.0 = Release|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Signed|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Signed|Any CPU.Build.0 = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Signed|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Signed|Mixed Platforms.Build.0 = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Signed|Win32.ActiveCfg = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Signed|Win32.Build.0 = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Signed|x64.ActiveCfg = Debug|Any CPU
+		{A7BCCF0F-8142-4358-81DC-3DFCEA8EFDB8}.Signed|x64.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCoreHttpTests.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/AspNetCoreHttpTests.cs
@@ -117,7 +117,6 @@
         [TestMethod]
         [TestCategory(TestCategory.NetCore)]
         [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
-        [Ignore] //Temp ignore to unlock a release
         public void TestRddForSyncHttpAspxCore()
         {
             using (DotNetCoreTestSetup())
@@ -130,7 +129,6 @@
         [TestMethod]
         [TestCategory(TestCategory.NetCore)]
         [DeploymentItem(AspxCoreTestAppFolder, AspxCoreAppFolder)]
-        [Ignore] //Temp ignore to unlock a release
         public void TestRddForSyncHttpPostCallAspxCore()
         {
             using (DotNetCoreTestSetup())

--- a/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/AspxCore.csproj
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/AspxCore.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>    
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.1" />

--- a/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/AspxCore.csproj
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/AspxCore.csproj
@@ -17,8 +17,7 @@
     <ProjectReference Include="..\..\..\..\..\Src\DependencyCollector\NetCore\DependencyCollector.NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.0" />
+  <ItemGroup>    
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.1" />

--- a/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Startup.cs
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Startup.cs
@@ -15,13 +15,7 @@ namespace AspxCore
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
-
-            if (env.IsEnvironment("Development"))
-            {
-                // This will push telemetry data through Application Insights pipeline faster, allowing you to view the results immediately.
-                //builder.AddApplicationInsightsSettings(developerMode: true);
-            }
-
+            
             builder.AddEnvironmentVariables();
             Configuration = builder.Build();
         }
@@ -31,9 +25,7 @@ namespace AspxCore
         // This method gets called by the runtime. Use this method to add services to the container
         public void ConfigureServices(IServiceCollection services)
         {
-            // Add framework services.
-            //services.AddApplicationInsightsTelemetry(Configuration);
-
+            // Add framework services.            
             services.AddMvc();
         }
 
@@ -47,6 +39,8 @@ namespace AspxCore
 
             var teleConfig = TelemetryConfiguration.Active;
             teleConfig.TelemetryChannel.DeveloperMode = true;            
+
+            // Fake endpoint.
             teleConfig.TelemetryChannel.EndpointAddress = "http://localhost:8789/v2/track";
             teleConfig.InstrumentationKey = "fafa4b10-03d3-4bb0-98f4-364f0bdf5df8";
             

--- a/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Startup.cs
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Startup.cs
@@ -19,7 +19,7 @@ namespace AspxCore
             if (env.IsEnvironment("Development"))
             {
                 // This will push telemetry data through Application Insights pipeline faster, allowing you to view the results immediately.
-                builder.AddApplicationInsightsSettings(developerMode: true);
+                //builder.AddApplicationInsightsSettings(developerMode: true);
             }
 
             builder.AddEnvironmentVariables();
@@ -32,7 +32,7 @@ namespace AspxCore
         public void ConfigureServices(IServiceCollection services)
         {
             // Add framework services.
-            services.AddApplicationInsightsTelemetry(Configuration);
+            //services.AddApplicationInsightsTelemetry(Configuration);
 
             services.AddMvc();
         }

--- a/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Startup.cs
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Startup.cs
@@ -45,6 +45,11 @@ namespace AspxCore
 
             app.UseMvc();
 
+            var teleConfig = TelemetryConfiguration.Active;
+            teleConfig.TelemetryChannel.DeveloperMode = true;            
+            teleConfig.TelemetryChannel.EndpointAddress = "http://localhost:8789/v2/track";
+            teleConfig.InstrumentationKey = "fafa4b10-03d3-4bb0-98f4-364f0bdf5df8";
+            
             new DependencyTrackingTelemetryModule().Initialize(TelemetryConfiguration.Active);
         }
     }

--- a/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Startup.cs
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/AspxCore/Startup.cs
@@ -18,7 +18,7 @@ namespace AspxCore
 
             if (env.IsEnvironment("Development"))
             {
-                // This will push telemetry data through Application Insights pipeline faster, allowing you to view results immediately.
+                // This will push telemetry data through Application Insights pipeline faster, allowing you to view the results immediately.
                 builder.AddApplicationInsightsSettings(developerMode: true);
             }
 

--- a/dirs.proj
+++ b/dirs.proj
@@ -13,9 +13,8 @@
           
     <MSBuild Projects="@(Solution)" ContinueOnError="ErrorAndStop" Properties="PreReleaseVersion=$(PreReleaseVersion)"/> 
     
-	<!--
     <Exec Command="dotnet publish Test\DependencyCollector\FunctionalTests\TestApps\AspxCore\AspxCore.csproj -c $(Configuration) -o $(BinRoot)\$(Configuration)\Test\DependencyCollector\FunctionalTests\TestApps\AspxCore\netcoreapp1.0\publish /property:DoNotSign=true" />
-	-->
+
   </Target>
   <Target Name="Clean">
     <RemoveDir Directories="$(BinRoot)\$(Configuration)" />


### PR DESCRIPTION
Aspnet Core test app is modified to NOT have nuget reference to application insights aspnet core sdk. Instead it'll have nuget reference to base sdk, and project reference to dependency collector project.
This is done to avoid ambiguous ref to dependency module - one via project, and one via nuget transitive.

(This is pre-req before adding test app for dotnet core 2.0)