### PR TITLE
Perf collector functional test fix

### DIFF
--- a/Test/PerformanceCollector/FunctionalTests/Test40.cs
+++ b/Test/PerformanceCollector/FunctionalTests/Test40.cs
@@ -7,6 +7,7 @@
     using Functional.IisExpress;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using PerfCounterCollector.FunctionalTests;
+    using System;
 
     [TestClass]
     public class Test40 : SingleWebHostTestBase

--- a/Test/PerformanceCollector/FunctionalTests/Test40.cs
+++ b/Test/PerformanceCollector/FunctionalTests/Test40.cs
@@ -38,7 +38,15 @@
                     IKey = "fafa4b10-03d3-4bb0-98f4-364f0bdf5df8",
                 });
 
-            base.LaunchAndVerifyApplication();
+            try
+            {
+                base.LaunchAndVerifyApplication();
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine("Exception occured while verifying application, exception:" + ex.Message);
+                this.StopWebAppHost();
+            }
         }
 
         [TestCleanup]

--- a/Test/PerformanceCollector/FunctionalTests/Test40.cs
+++ b/Test/PerformanceCollector/FunctionalTests/Test40.cs
@@ -47,6 +47,9 @@
             {
                 Trace.WriteLine("Exception occured while verifying application, exception:" + ex.Message);
                 this.StopWebAppHost();
+
+                // Throwing to prevent tests from continuing to execute.
+                throw ex;
             }
         }
 

--- a/Test/PerformanceCollector/FunctionalTests/Test45.cs
+++ b/Test/PerformanceCollector/FunctionalTests/Test45.cs
@@ -49,6 +49,9 @@
             {
                 Trace.WriteLine("Exception occured while verifying application, exception:" + ex.Message);                
                 this.StopWebAppHost();
+                
+                // Throwing to prevent tests from continuing to execute.
+                throw ex;
             }
         }
 

--- a/Test/PerformanceCollector/FunctionalTests/Test45.cs
+++ b/Test/PerformanceCollector/FunctionalTests/Test45.cs
@@ -7,6 +7,7 @@
     using Functional.IisExpress;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using PerfCounterCollector.FunctionalTests;
+    using System;
 
     [TestClass]
     public class Test45 : SingleWebHostTestBase
@@ -40,7 +41,15 @@
                     IKey = "fafa4b10-03d3-4bb0-98f4-364f0bdf5df8",
                 });
 
-            base.LaunchAndVerifyApplication();
+            try
+            {
+                base.LaunchAndVerifyApplication();
+            }
+            catch(Exception ex)
+            {
+                Trace.WriteLine("Exception occured while verifying application, exception:" + ex.Message);                
+                this.StopWebAppHost();
+            }
         }
 
         [TestCleanup]


### PR DESCRIPTION
Performance Collector Functional Test did not clean up if an exception occurred in test initialize. This is to fix it so as to prevent all future tests from failing due to port conflicts.