### PR TITLE
Setting dependency telemetry timestamp to when the activity started

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
@@ -68,6 +68,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector
             Assert.AreEqual("200", telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success);
 
+            Assert.AreEqual(activity.StartTimeUtc, telemetry.Timestamp);
             Assert.AreEqual(1, telemetry.Duration.TotalSeconds);
 
             Assert.AreEqual(activity.RootId, telemetry.Context.Operation.Id);

--- a/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpCoreDiagnosticSourceListener.cs
@@ -239,9 +239,10 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     telemetry.Context.Properties[item.Key] = item.Value;
                 }
             }
-
+            
             this.client.Initialize(telemetry);
 
+            telemetry.Timestamp = currentActivity.StartTimeUtc;
             telemetry.Name = resourceName;
             telemetry.Target = requestUri.Host;
             telemetry.Type = RemoteDependencyConstants.HTTP;


### PR DESCRIPTION
In .NET Core 2.0, a dependency telemetry timestamp is set when the activity finished, not when it started. This PR is to set the correct timestamp. 

I started to notice this when I upgraded an app to .NET Core 2.0 and looked at the telemetry data in App Insights. Below is a screenshot of a dependency that took 112ms to complete. Notice the placement dependency in the graph.

![screenshot at aug 17 18-04-04](https://user-images.githubusercontent.com/2847527/29435838-9b65c2c2-8376-11e7-9cb9-d99840c86ac0.png)

The request telemetry JSON (abbreviated)
```json
{
    "name": "Microsoft.ApplicationInsights.Dev.foo.Request",
    "time": "2017-08-17T20:48:03.9571942Z",
    "iKey": "...",
    "data": {
        "baseType": "RequestData",
        "baseData": {
            "ver": 2,
            "id": "...",
            "name": "...",
            "duration": "00:00:00.1258569",
            "success": true,
            "responseCode": "200"
        }
    }
}
```

The dependency telemetry JSON (abbreviated)
```json
{
    "name": "Microsoft.ApplicationInsights.Dev.foo.RemoteDependency",
    "time": "2017-08-17T20:48:04.0709835Z",
    "iKey": "...",
    "data": {
        "baseType": "RemoteDependencyData",
        "baseData": {
            "ver": 2,
            "name": "...",
            "id": "...",
            "data": "...",
            "duration": "00:00:00.1122218",
            "resultCode": "200",
            "success": true,
            "type": "Http (tracked component)",
            "target": "..."
        }
    }
}
```

If you take the difference between when the request started ```2017-08-17T20:48:03.9571942Z``` and when the dependency is reported as started ```2017-08-17T20:48:04.0709835Z``` you'll notice its around 112ms, which is the same value as the duration.


