### PR TITLE
correct message about exclude correlation header

### DIFF
--- a/Src/DependencyCollector/NuGet/ApplicationInsights.config.install.xdt
+++ b/Src/DependencyCollector/NuGet/ApplicationInsights.config.install.xdt
@@ -6,8 +6,7 @@
     <Add xdt:Transform="InsertIfMissing" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector">
       <ExcludeComponentCorrelationHttpHeadersOnDomains>
         <!-- 
-        Requests to the following hostnames will not be modified by adding correlation headers. 
-        This is only applicable if Profiler is installed via either StatusMonitor or Azure Extension.
+        Requests to the following hostnames will not be modified by adding correlation headers.         
         Add entries here to exclude additional hostnames.
         NOTE: this configuration will be lost upon NuGet upgrade.
         -->


### PR DESCRIPTION
The part about status monitor or extension is incorrect now. 