### PR TITLE
fix for Rest Api filtering bug

### DIFF
--- a/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
+++ b/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
@@ -314,7 +314,7 @@
 
             AspNetDiagnosticTelemetryModule result = new AspNetDiagnosticTelemetryModule();
 
-            var requestModule = new RequestTrackingTelemetryModule();
+            var requestModule = new RequestTrackingTelemetryModule(enableSafeRequestTracking: true);
             var exceptionModule = new ExceptionTrackingTelemetryModule();
             requestModule.Initialize(this.configuration);
             exceptionModule.Initialize(this.configuration);

--- a/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
+++ b/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
@@ -314,7 +314,10 @@
 
             AspNetDiagnosticTelemetryModule result = new AspNetDiagnosticTelemetryModule();
 
-            var requestModule = new RequestTrackingTelemetryModule(enableChildRequestsSuppression: false);
+            var requestModule = new RequestTrackingTelemetryModule()
+            {
+                EnableChildRequestTrackingSuppression = false
+            };
             var exceptionModule = new ExceptionTrackingTelemetryModule();
             requestModule.Initialize(this.configuration);
             exceptionModule.Initialize(this.configuration);

--- a/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
+++ b/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
@@ -314,7 +314,7 @@
 
             AspNetDiagnosticTelemetryModule result = new AspNetDiagnosticTelemetryModule();
 
-            var requestModule = new RequestTrackingTelemetryModule(enableSafeRequestTracking: true);
+            var requestModule = new RequestTrackingTelemetryModule(enableChildRequestsSuppression: false);
             var exceptionModule = new ExceptionTrackingTelemetryModule();
             requestModule.Initialize(this.configuration);
             exceptionModule.Initialize(this.configuration);

--- a/Src/Web/Web.Nuget/Resources/net45/ApplicationInsights.config.install.xdt
+++ b/Src/Web/Web.Nuget/Resources/net45/ApplicationInsights.config.install.xdt
@@ -24,7 +24,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
+++ b/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
@@ -65,13 +65,6 @@
             Thread.GetDomain().SetData(".appPath", string.Empty);
             Thread.GetDomain().SetData(".appVPath", string.Empty);
 
-            if (headers == null)
-            {
-                headers = new Dictionary<string, string>();
-            }
-
-            headers["AppInsights-RequestTrackingTelemetryModule-Request-Id"] = "test-request-id";
-
             var workerRequest = new SimpleWorkerRequestWithHeaders(UrlPath, UrlQueryString, new StringWriter(CultureInfo.InvariantCulture), headers, remoteAddr);
             
             var context = new HttpContext(workerRequest);

--- a/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
+++ b/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
@@ -65,13 +65,20 @@
             Thread.GetDomain().SetData(".appPath", string.Empty);
             Thread.GetDomain().SetData(".appVPath", string.Empty);
 
+            if (headers == null)
+            {
+                headers = new Dictionary<string, string>();
+            }
+
+            headers["AppInsights-RequestTrackingTelemetryModule-Request-Id"] = "test-request-id";
+
             var workerRequest = new SimpleWorkerRequestWithHeaders(UrlPath, UrlQueryString, new StringWriter(CultureInfo.InvariantCulture), headers, remoteAddr);
             
             var context = new HttpContext(workerRequest);
             HttpContext.Current = context;
             return context;
         }
-
+        
         public static HttpContextBase GetFakeHttpContextBase(IDictionary<string, string> headers = null)
         {
             return new HttpContextWrapper(GetFakeHttpContext(headers));

--- a/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
+++ b/Src/Web/Web.Shared.Net.Tests/Helpers/HttpModuleHelper.cs
@@ -71,7 +71,7 @@
             HttpContext.Current = context;
             return context;
         }
-        
+
         public static HttpContextBase GetFakeHttpContextBase(IDictionary<string, string> headers = null)
         {
             return new HttpContextWrapper(GetFakeHttpContext(headers));

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -525,7 +525,7 @@
 
         private RequestTrackingTelemetryModule RequestTrackingTelemetryModuleFactory(TelemetryConfiguration config = null, CorrelationIdLookupHelper correlationHelper = null)
         {
-            var module = new RequestTrackingTelemetryModule(enableSafeRequestTracking: true);
+            var module = new RequestTrackingTelemetryModule(enableChildRequestsSuppression: false);
             module.OverrideCorrelationIdLookupHelper(correlationHelper ?? this.correlationIdLookupHelper);
             module.Initialize(config ?? this.CreateDefaultConfig(HttpModuleHelper.GetFakeHttpContext()));
             return module;

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -525,7 +525,7 @@
 
         private RequestTrackingTelemetryModule RequestTrackingTelemetryModuleFactory(TelemetryConfiguration config = null, CorrelationIdLookupHelper correlationHelper = null)
         {
-            var module = new RequestTrackingTelemetryModule();
+            var module = new RequestTrackingTelemetryModule(enableSafeRequestTracking: true);
             module.OverrideCorrelationIdLookupHelper(correlationHelper ?? this.correlationIdLookupHelper);
             module.Initialize(config ?? this.CreateDefaultConfig(HttpModuleHelper.GetFakeHttpContext()));
             return module;

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -525,7 +525,10 @@
 
         private RequestTrackingTelemetryModule RequestTrackingTelemetryModuleFactory(TelemetryConfiguration config = null, CorrelationIdLookupHelper correlationHelper = null)
         {
-            var module = new RequestTrackingTelemetryModule(enableChildRequestsSuppression: false);
+            var module = new RequestTrackingTelemetryModule()
+            {
+                EnableChildRequestTrackingSuppression = false
+            };
             module.OverrideCorrelationIdLookupHelper(correlationHelper ?? this.correlationIdLookupHelper);
             module.Initialize(config ?? this.CreateDefaultConfig(HttpModuleHelper.GetFakeHttpContext()));
             return module;

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -4,7 +4,6 @@
 #if NET45
     using System.Diagnostics.Tracing;
 #endif
-    using System.Globalization;
 
     /// <summary>
     /// ETW EventSource tracing class.
@@ -374,7 +373,7 @@
                 38,
                 this.ApplicationName);
         }
-        
+
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -4,8 +4,7 @@
 #if NET45
     using System.Diagnostics.Tracing;
 #endif
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-
+    
     /// <summary>
     /// ETW EventSource tracing class.
     /// </summary>
@@ -34,13 +33,13 @@
          }
 
         [Event(
-            1, 
-            Message = "ApplicationInsightsHttpModule failed at initialization with exception: {0}", 
+            1,
+            Message = "ApplicationInsightsHttpModule failed at initialization with exception: {0}",
             Level = EventLevel.Error)]
         public void WebModuleInitializationExceptionEvent(string excMessage, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                1, 
+                1,
                 excMessage ?? string.Empty,
                 this.ApplicationName);
         }
@@ -78,7 +77,7 @@
         public void HanderFailure(string exception, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                4, 
+                4,
                 exception ?? string.Empty,
                 this.ApplicationName);
         }
@@ -158,8 +157,8 @@
             string cookieValue, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                14, 
-                cookieValue ?? string.Empty, 
+                14,
+                cookieValue ?? string.Empty,
                 this.ApplicationName);
         }
 
@@ -168,11 +167,11 @@
             Message = "WebTelemetryInitializerLoaded at {0}",
             Level = EventLevel.Verbose)]
         public void WebTelemetryInitializerLoaded(
-            string typeName, 
+            string typeName,
             string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                16, 
+                16,
                 typeName ?? string.Empty,
                 this.ApplicationName);
         }
@@ -193,12 +192,12 @@
             Level = EventLevel.Error)]
         public void WebTelemetryInitializerFailure(
             string typeName,
-            string exception, 
+            string exception,
             string appDomainName = "Incorrect")
         {
             this.WriteEvent(
                 18,
-                typeName ?? string.Empty, 
+                typeName ?? string.Empty,
                 exception ?? string.Empty,
                 this.ApplicationName);
         }
@@ -379,12 +378,12 @@
             39,
             Message = "RequestTrackingTelemetryModule ChildRequestTrackingSuppressionModule Method: '{0}' Unknown Exception: {1}",
             Level = EventLevel.Error)]
-        public void ChildRequestUnknownException(string methodName, Exception ex, string appDomainName = "Incorrect")
+        public void ChildRequestUnknownException(string methodName, string exceptionMessage, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
                 39,
                 methodName,
-                ex.ToInvariantString(),
+                exceptionMessage,
                 this.ApplicationName);
         }
 
@@ -392,7 +391,7 @@
             40,
             Message = "RequestTrackingTelemetryModule: Request was not logged. Set EventLevel Verbose for more details.",
             Level = EventLevel.Informational)]
-        public void RequestTrackingTelemetryModule_RequestWasNotLogged_Informational(string appDomainName = "Incorrect")
+        public void RequestTrackingTelemetryModuleRequestWasNotLoggedInformational(string appDomainName = "Incorrect")
         {
             this.WriteEvent(
                 40,
@@ -403,7 +402,7 @@
             41,
             Message = "RequestTrackingTelemetryModule: Request was not logged. Request Id: '{0}' Reason: {1}",
             Level = EventLevel.Verbose)]
-        public void RequestTrackingTelemetryModule_RequestWasNotLogged_Verbose(string requestId, string reason, string appDomainName = "Incorrect")
+        public void RequestTrackingTelemetryModuleRequestWasNotLoggedVerbose(string requestId, string reason, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
                 41,

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -394,7 +394,9 @@
         {
             this.WriteEvent(
                 40,
-                numMaxActiveRequests.ToString(CultureInfo.InvariantCulture), timeoutSetting.ToString(CultureInfo.InvariantCulture), removedItems.ToString(CultureInfo.InvariantCulture),
+                numMaxActiveRequests.ToString(CultureInfo.InvariantCulture),
+                timeoutSetting.ToString(CultureInfo.InvariantCulture),
+                removedItems.ToString(CultureInfo.InvariantCulture),
                 this.ApplicationName);
         }
 

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -4,6 +4,7 @@
 #if NET45
     using System.Diagnostics.Tracing;
 #endif
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// ETW EventSource tracing class.
@@ -371,6 +372,43 @@
         {
             this.WriteEvent(
                 38,
+                this.ApplicationName);
+        }
+
+        [Event(
+            39,
+            Message = "RequestTrackingTelemetryModule ChildRequestTrackingSuppressionModule Method: '{0}' Unknown Exception: {1}",
+            Level = EventLevel.Error)]
+        public void ChildRequestUnknownException(string methodName, Exception ex, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                39,
+                methodName,
+                ex.ToInvariantString(),
+                this.ApplicationName);
+        }
+
+        [Event(
+            40,
+            Message = "RequestTrackingTelemetryModule: Request was not logged. Set EventLevel Verbose for more details.",
+            Level = EventLevel.Informational)]
+        public void RequestTrackingTelemetryModule_RequestWasNotLogged_Informational(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                40,
+                this.ApplicationName);
+        }
+
+        [Event(
+            41,
+            Message = "RequestTrackingTelemetryModule: Request was not logged. Request Id: '{0}' Reason: {1}",
+            Level = EventLevel.Verbose)]
+        public void RequestTrackingTelemetryModule_RequestWasNotLogged_Verbose(string requestId, string reason, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                41,
+                requestId,
+                reason,
                 this.ApplicationName);
         }
 

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -4,6 +4,7 @@
 #if NET45
     using System.Diagnostics.Tracing;
 #endif
+    using System.Globalization;
 
     /// <summary>
     /// ETW EventSource tracing class.
@@ -382,6 +383,18 @@
         {
             this.WriteEvent(
                 39,
+                this.ApplicationName);
+        }
+
+        [Event(
+            40,
+            Message = "RequestTrackingTelemetryModule ChildRequestTrackingSuppressionModule exceeded max number of '{0}' active requests. Timeout set to '{1}'. Clearing '{2}' items from dictionary.",
+            Level = EventLevel.Informational)]
+        public void ChildRequestTrackingClearingActiveRequests(int numMaxActiveRequests, int timeoutSetting, int removedItems, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                40,
+                numMaxActiveRequests.ToString(CultureInfo.InvariantCulture), timeoutSetting.ToString(CultureInfo.InvariantCulture), removedItems.ToString(CultureInfo.InvariantCulture),
                 this.ApplicationName);
         }
 

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -374,6 +374,17 @@
                 this.ApplicationName);
         }
 
+        [Event(
+            39,
+            Message = "RequestTrackingTelemetryModule ChildRequestTrackingSuppressionModule failed to remove request from ActiveRequests.",
+            Level = EventLevel.Warning)]
+        public void FailedToRemoveRequestFromActiveRequests(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                39,
+                this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -374,32 +374,7 @@
                 38,
                 this.ApplicationName);
         }
-
-        [Event(
-            39,
-            Message = "RequestTrackingTelemetryModule ChildRequestTrackingSuppressionModule failed to remove request from ActiveRequests.",
-            Level = EventLevel.Warning)]
-        public void FailedToRemoveRequestFromActiveRequests(string appDomainName = "Incorrect")
-        {
-            this.WriteEvent(
-                39,
-                this.ApplicationName);
-        }
-
-        [Event(
-            40,
-            Message = "RequestTrackingTelemetryModule ChildRequestTrackingSuppressionModule exceeded max number of '{0}' active requests. Timeout set to '{1}'. Clearing '{2}' items from dictionary.",
-            Level = EventLevel.Informational)]
-        public void ChildRequestTrackingClearingActiveRequests(int numMaxActiveRequests, int timeoutSetting, int removedItems, string appDomainName = "Incorrect")
-        {
-            this.WriteEvent(
-                40,
-                numMaxActiveRequests.ToString(CultureInfo.InvariantCulture),
-                timeoutSetting.ToString(CultureInfo.InvariantCulture),
-                removedItems.ToString(CultureInfo.InvariantCulture),
-                this.ApplicationName);
-        }
-
+        
         [NonEvent]
         private string GetApplicationName()
         {

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -442,7 +442,7 @@
             /// </summary>
             internal void OnBeginRequest_IdRequest(HttpContext context)
             {
-                if(context?.Request?.Headers == null)
+                if (context?.Request?.Headers == null)
                 {
                     return;
                 }
@@ -453,7 +453,7 @@
                 }
                 catch (Exception ex)
                 {
-                    WebEventSource.Log.ChildRequestUnknownException(nameof(OnBeginRequest_IdRequest), ex);
+                    WebEventSource.Log.ChildRequestUnknownException(nameof(this.OnBeginRequest_IdRequest), ex);
                 }
             }
 
@@ -467,7 +467,7 @@
             internal bool OnEndRequest_ShouldLog(HttpContext context)
             {
                 var headers = context?.Request?.Headers;
-                if(headers == null)
+                if (headers == null)
                 {
                     return false;
                 }
@@ -492,11 +492,10 @@
                     {
                         WebEventSource.Log.RequestTrackingTelemetryModule_RequestWasNotLogged_Verbose(rootRequestId, "Request id is null");
                     }
-                    
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
-                    WebEventSource.Log.ChildRequestUnknownException(nameof(OnEndRequest_ShouldLog), ex);
+                    WebEventSource.Log.ChildRequestUnknownException(nameof(this.OnEndRequest_ShouldLog), ex);
                 }
 
                 return false;

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -20,7 +20,7 @@
         private const string RequestIdHeader = "AppInsights-Request-Id";
 
         /// <summary>
-        /// Using this as a hashset of current active requests. The second value is ignored.
+        /// Using this as a hash-set of current active requests. The second value is ignored.
         /// </summary>
         private static ConcurrentDictionary<string, byte> activeRequests = new ConcurrentDictionary<string, byte>();
         

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -426,8 +426,6 @@
             internal ChildRequestTrackingSuppressionModule(int maxRequestsTracked = DEFAULTMAXVALUE)
             {
                 this.MAXSIZE = maxRequestsTracked > 0 ? maxRequestsTracked : DEFAULTMAXVALUE;
-
-                System.Diagnostics.Debug.WriteLine($"{nameof(RequestTrackingTelemetryModule)}.{nameof(ChildRequestTrackingSuppressionModule)} Initialized. {nameof(this.MAXSIZE)}:{this.MAXSIZE}");
             }
 
             /// <summary>

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -258,7 +258,7 @@
             }
 
             var requestTelemetry = context.GetRequestTelemetry();
-            
+
             if (string.IsNullOrEmpty(requestTelemetry.Context.InstrumentationKey))
             {
                 // Instrumentation key is probably empty, because the context has not yet had a chance to associate the requestTelemetry to the telemetry client yet.

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -247,7 +247,7 @@
             }
             else
             {
-                WebEventSource.Log.RequestTrackingTelemetryModule_RequestWasNotLogged_Informational();
+                WebEventSource.Log.RequestTrackingTelemetryModuleRequestWasNotLoggedInformational();
             }
         }
 
@@ -453,7 +453,7 @@
                 }
                 catch (Exception ex)
                 {
-                    WebEventSource.Log.ChildRequestUnknownException(nameof(this.OnBeginRequest_IdRequest), ex);
+                   WebEventSource.Log.ChildRequestUnknownException(nameof(this.OnBeginRequest_IdRequest), ex.ToInvariantString());
                 }
             }
 
@@ -485,17 +485,17 @@
                         }
                         else
                         {
-                            WebEventSource.Log.RequestTrackingTelemetryModule_RequestWasNotLogged_Verbose(rootRequestId, "Request is already known");
+                            WebEventSource.Log.RequestTrackingTelemetryModuleRequestWasNotLoggedVerbose(rootRequestId, "Request is already known");
                         }
                     }
                     else
                     {
-                        WebEventSource.Log.RequestTrackingTelemetryModule_RequestWasNotLogged_Verbose(rootRequestId, "Request id is null");
+                        WebEventSource.Log.RequestTrackingTelemetryModuleRequestWasNotLoggedVerbose(rootRequestId, "Request id is null");
                     }
                 }
                 catch (Exception ex)
                 {
-                    WebEventSource.Log.ChildRequestUnknownException(nameof(this.OnEndRequest_ShouldLog), ex);
+                    WebEventSource.Log.ChildRequestUnknownException(nameof(this.OnEndRequest_ShouldLog), ex.ToInvariantString());
                 }
 
                 return false;

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -41,7 +41,9 @@
         /// <param name="enableChildRequestsSuppression">Boolean flag to enable/disable child request suppression caused by <see cref="System.Web.Handlers.TransferRequestHandler" /></param>
         internal RequestTrackingTelemetryModule(bool enableChildRequestsSuppression)
         {
-            if (enableChildRequestsSuppression)
+            // Headers will be read-only in a classic iis pipeline
+            // Exception System.PlatformNotSupportedException: This operation requires IIS integrated pipeline mode.
+            if (HttpRuntime.UsingIntegratedPipeline && enableChildRequestsSuppression)
             {
                 this.childRequestTrackingSuppressionModule = new ChildRequestTrackingSuppressionModule();
             }
@@ -387,6 +389,7 @@
         /// Unit tests should disable the ChildRequestTrackingSuppressionModule.
         /// Unit test projects cannot create an [internal] IIS7WorkerRequest object.
         /// Without this object, we cannot modify the Request.Headers without throwing a PlatformNotSupportedException.
+        /// (Exception System.PlatformNotSupportedException: This operation requires IIS integrated pipeline mode.)
         /// Unit tests will have to initialize the RequestIdHeader.
         /// The second IF will ensure the id is added to the activeRequests.
         /// </remarks>

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -389,9 +389,13 @@
         /// Unit tests should disable the ChildRequestTrackingSuppressionModule.
         /// Unit test projects cannot create an [internal] IIS7WorkerRequest object.
         /// Without this object, we cannot modify the Request.Headers without throwing a PlatformNotSupportedException.
-        /// (Exception System.PlatformNotSupportedException: This operation requires IIS integrated pipeline mode.)
         /// Unit tests will have to initialize the RequestIdHeader.
         /// The second IF will ensure the id is added to the activeRequests.
+        /// </remarks>
+        /// <remarks>
+        /// IIS Classic Pipeline should disable the ChildRequestTrackingSuppressionModule.
+        /// Classic does not create IIS7WorkerRequest object and Headers will be read-only.
+        /// (Exception System.PlatformNotSupportedException: This operation requires IIS integrated pipeline mode.)
         /// </remarks>
         private class ChildRequestTrackingSuppressionModule
         {
@@ -439,7 +443,6 @@
                 {
                     if (!activeRequests.TryRemove(requestId, out byte value))
                     {
-                        // TODO: FAILED TO REMOVE KEY. CREATE LOG
                         WebEventSource.Log.FailedToRemoveRequestFromActiveRequests();
                     }
 

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/ApplicationInsights.config
@@ -26,7 +26,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/Aspx45/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/Aspx45/ApplicationInsights.config
@@ -28,7 +28,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/ApplicationInsights.config
@@ -27,7 +27,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/Wcf45Tests/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/Wcf45Tests/ApplicationInsights.config
@@ -30,7 +30,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/ApplicationInsights.config
@@ -31,7 +31,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/ApplicationInsights.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/ApplicationInsights.config
@@ -28,7 +28,6 @@
         
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
-        <Add>System.Web.Handlers.TransferRequestHandler</Add>
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
         <Add>System.Web.StaticFileHandler</Add>
         <Add>System.Web.Handlers.AssemblyResourceLoader</Add>


### PR DESCRIPTION
#175 

System.Web.Handlers.TransferRequestHandler
	This redirects extensionless requests to a controller (ex: site/home -> site/HomeController.cs)
	The redirection creates a "child" request of the original "parent" request.
	The child request will share the headers of the parent.

Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule
	Expected behavior: Tracks telemetry for individual request
	Bug: is not logging telemetry for 200 (successful) requests when - TransferRequestHandler is filtered
	Bug: without filter, logs 2 records for every 200 (successful) request

Sergey's suggested fix: attach id header to parent requests, and only log child request.
