### PR TITLE
fix for "project system has encountered an error"

### DIFF
--- a/Src/TestFramework/Shared/TestFramework.Shared.shproj
+++ b/Src/TestFramework/Shared/TestFramework.Shared.shproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
-    <ProjectGuid>9718F051-147F-4F5F-9FF3-C92.5.0-beta1-build19420EFCF7</ProjectGuid>
+     <ProjectGuid>9718F051-147F-4F5F-9FF3-C926430EFCF7</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/Src/TestFramework/Shared/TestFramework.Shared.shproj
+++ b/Src/TestFramework/Shared/TestFramework.Shared.shproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
-     <ProjectGuid>9718F051-147F-4F5F-9FF3-C926430EFCF7</ProjectGuid>
+    <ProjectGuid>9718F051-147F-4F5F-9FF3-C926430EFCF7</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />


### PR DESCRIPTION
Visual Studio would display this error every time we open the project:

> Visual Studio project system has encountered a non-fatal error.
> The project system has encountered an error.
> Guid should contain 32 digits with 4 dashes.