### PR TITLE
test fix for intermittent tests

### DIFF
--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -891,6 +891,7 @@
             serviceClient.Ping("ikey", now, "ETag1", string.Empty, out configurationInfo);
 
             // ASSERT
+            Assert.IsNotNull(configurationInfo, "configurationInfo should not be null.");
             Assert.AreEqual("ETag2", configurationInfo.ETag);
             Assert.AreEqual("Id1", configurationInfo.Metrics.Single().Id);
         }
@@ -939,6 +940,7 @@
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
             // ASSERT
+            Assert.IsNotNull(configurationInfo, "configurationInfo should not be null.");
             Assert.AreEqual("ETag2", configurationInfo.ETag);
             Assert.AreEqual("Id1", configurationInfo.Metrics.Single().Id);
 #endif

--- a/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpListenerObservable.cs
+++ b/Test/DependencyCollector/FunctionalTests/FuncTest/Helpers/HttpListenerObservable.cs
@@ -42,7 +42,7 @@
 
             if (!this.listener.IsListening)
             {
-                Trace.TraceInformation("Starting listener");
+                Trace.TraceInformation($"{DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss")} Starting listener");
                 this.listener.Start();
             }
 
@@ -51,7 +51,7 @@
 
         public void Stop()
         {
-            Trace.TraceInformation("Stopping listener");
+            Trace.TraceInformation($"{DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss")} Stopping listener");
             listener.Stop();
         }
 

--- a/Test/DependencyCollector/FunctionalTests/TestApps/Aspx451/ExternalCalls.aspx.cs
+++ b/Test/DependencyCollector/FunctionalTests/TestApps/Aspx451/ExternalCalls.aspx.cs
@@ -69,14 +69,10 @@ namespace Aspx451
             var success = true;
             bool.TryParse(Request.QueryString["success"], out success);
             string sqlQueryTouse = (success == true) ? ValidSqlQueryToApmDatabase : InvalidSqlQueryToApmDatabase;
-            var count = 1;
-            try
+
+            if (!int.TryParse(countStr, NumberStyles.Integer, CultureInfo.CurrentCulture, out int count))
             {
-                count = int.Parse(countStr, CultureInfo.CurrentCulture);
-            }
-            catch (Exception)
-            {
-                // Dont care about this           
+                count = 1;
             }
 
             this.lblRequestedAction.Text = "Requested Action:" + type;


### PR DESCRIPTION
Replacing try/catch with try parse should remove some noise from the test logs.
Adding Assert.IsNotNull will help confirm if test is failing or if module is failing.
Adding timestamp to listener log will help investigate if tests stop before next test starts.