### PR TITLE
Clean up project references. 

### DIFF
--- a/Src/Common/Common.projitems
+++ b/Src/Common/Common.projitems
@@ -15,6 +15,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)ICorrelationIdLookupHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RequestResponseHeaders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CorrelationIdLookupHelper.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.6' ">
     <Compile Include="$(MSBuildThisFileDirectory)WebHeaderCollectionExtensions.cs" />
   </ItemGroup>
 </Project>

--- a/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
+++ b/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -49,35 +49,12 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
-    <Compile Include="..\Shared\Implementation\DiagnosticSourceListenerBase.cs">
-      <Link>DiagnosticSourceListenerBase.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Implementation\HttpCoreDiagnosticSourceListener.cs">
-      <Link>HttpCoreDiagnosticSourceListener.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Implementation\SqlClientDiagnosticSourceListener.cs">
-      <Link>SqlClientDiagnosticSourceListener.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Implementation\HttpHeadersUtilities.cs">
-      <Link>HttpHeadersUtilities.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Implementation\PropertyFetcher.cs">
-      <Link>PropertyFetcher.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Implementation\TelemetryDiagnosticSourceListener.cs">
-      <Link>TelemetryDiagnosticSourceListener.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\TestFramework\Net45\TestFramework.Net45.csproj">
       <Project>{1be54ee7-6627-4206-86dd-3d2c709a1500}</Project>
       <Name>TestFramework.Net45</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\..\Web\Web.Net45\Implementation\SdkVersionUtils.cs">
-      <Link>SdkVersionUtils.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\..\..\packages\Desktop.Analyzers.1.1.0\analyzers\dotnet\cs\Desktop.Analyzers.dll" />

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -10,10 +10,13 @@
     <Error Condition="!Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
   </Target>
 
+  <Import Project="..\..\Common\Common.projitems" Label="Shared" />
+
+  <Import Project="..\Shared\DependencyCollector.Shared.projitems" Label="Shared" />
+
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
 
   <PropertyGroup>
-    <Copyright>Copyright © Microsoft. All Rights Reserved.</Copyright>
     <VersionPrefix>2.5.0-beta1</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -29,40 +32,8 @@
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+	<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="..\Shared\DependencyTrackingTelemetryModule.cs" Link="DependencyTrackingTelemetryModule.cs" />
-    <Compile Include="..\Shared\HttpDependenciesParsingTelemetryInitializer.cs" Link="HttpDependenciesParsingTelemetryInitializer.cs" />
-    <Compile Include="..\Shared\Implementation\Operation\ObjectInstanceBasedOperationHolder.cs" Link="ObjectInstanceBasedOperationHolder.cs" />
-    <Compile Include="..\Shared\SanitizedHostList.cs" Link="SanitizedHostList.cs" />
-    <Compile Include="..\Shared\Implementation\DependencyCollectorEventSource.cs" Link="DependencyCollectorEventSource.cs" />
-    <Compile Include="..\Shared\Implementation\ApplicationInsightsUrlFilter.cs" Link="ApplicationInsightsUrlFilter.cs" />
-    <Compile Include="..\Shared\Implementation\RemoteDependencyConstants.cs" Link="RemoteDependencyConstants.cs" />
-    <Compile Include="..\Shared\Implementation\DiagnosticSourceListenerBase.cs" Link="DiagnosticSourceListenerBase.cs" />
-    <Compile Include="..\Shared\Implementation\TelemetryDiagnosticSourceListener.cs" Link="TelemetryDiagnosticSourceListener.cs" />
-    <Compile Include="..\Shared\Implementation\HttpCoreDiagnosticSourceListener.cs" Link="HttpCoreDiagnosticSourceListener.cs" />
-    <Compile Include="..\Shared\Implementation\SqlClientDiagnosticSourceListener.cs" Link="SqlClientDiagnosticSourceListener.cs" />
-    <Compile Include="..\Shared\Implementation\HttpHeadersUtilities.cs" Link="HttpHeadersUtilities.cs" />
-    <Compile Include="..\Shared\Implementation\PropertyFetcher.cs" Link="PropertyFetcher.cs" />
-    <Compile Include="..\Shared\Implementation\RDDSource.cs" Link="RDDSource.cs" />
-    <Compile Include="..\Shared\Implementation\HttpParsers\AzureBlobHttpParser.cs" Link="AzureBlobHttpParser.cs" />
-    <Compile Include="..\Shared\Implementation\HttpParsers\AzureIotHubHttpParser.cs" Link="AzureIotHubHttpParser.cs" />
-    <Compile Include="..\Shared\Implementation\HttpParsers\AzureQueueHttpParser.cs" Link="AzureQueueHttpParser.cs" />
-    <Compile Include="..\Shared\Implementation\HttpParsers\AzureServiceBusHttpParser.cs" Link="AzureServiceBusHttpParser.cs" />
-    <Compile Include="..\Shared\Implementation\HttpParsers\AzureTableHttpParser.cs" Link="AzureTableHttpParser.cs" />
-    <Compile Include="..\Shared\Implementation\HttpParsers\DocumentDbHttpParser.cs" Link="DocumentDbHttpParser.cs" />
-    <Compile Include="..\Shared\Implementation\HttpParsers\GenericServiceHttpParser.cs" Link="GenericServiceHttpParser.cs" />
-    <Compile Include="..\Shared\Implementation\HttpParsers\HttpParsingHelper.cs" Link="HttpParsingHelper.cs" />
-    <Compile Include="..\Shared\Implementation\AppMapCorrelationEventSource.cs" Link="Dependency\AppMapCorrelationEventSource.cs" />
-    <Compile Include="..\..\Common\CorrelationIdLookupHelper.cs" Link="CorrelationIdLookupHelper.cs" />
-    <Compile Include="..\..\Common\AppMapCorrelationEventSource.cs" Link="AppMapCorrelationEventSource.cs" />
-    <Compile Include="..\..\Common\ExceptionUtilities.cs" Link="ExceptionUtilities.cs" />
-    <Compile Include="..\..\Common\ICorrelationIdLookupHelper.cs" Link="ICorrelationIdLookupHelper.cs" />
-    <Compile Include="..\..\Common\RequestResponseHeaders.cs" Link="RequestResponseHeaders.cs" />
-    <Compile Include="..\..\Common\HeadersUtilities.cs" Link="HeadersUtilities.cs" />
-    <Compile Include="..\..\Web\Web.Net45\Implementation\SdkVersionUtils.cs" Link="SdkVersionUtils.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0-beta1" />

--- a/Src/DependencyCollector/Shared/DependencyCollector.Shared.projitems
+++ b/Src/DependencyCollector/Shared/DependencyCollector.Shared.projitems
@@ -12,45 +12,53 @@
     <Import_RootNamespace>Microsoft.ApplicationInsights.DependencyCollector</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)DependencyTrackingTelemetryModule.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpCoreDiagnosticSourceListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpDependenciesParsingTelemetryInitializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpHeadersUtilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ApplicationInsightsUrlFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\AppMapCorrelationEventSource.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ClientServerDependencyTracker.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\DependencyCollectorEventSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\DependencyTargetNameHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\DesktopDiagnosticSourceHttpProcessing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\DiagnosticSourceListenerBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpDesktopDiagnosticSourceListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureBlobHttpParser.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureQueueHttpParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureIotHubHttpParser.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureTableHttpParser.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureQueueHttpParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureServiceBusHttpParser.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\AzureTableHttpParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\DocumentDbHttpParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\GenericServiceHttpParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpParsers\HttpParsingHelper.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerSqlConnectionProcessing.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerSqlCommandProcessing.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\WebRequestDependencyTrackingHelpers.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\DependencyCollectorEventSource.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\RemoteDependencyConstants.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpDesktopDiagnosticSourceListener.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpDesktopDiagnosticSourceSubscriber.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\FrameworkHttpEventListener.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpProcessing.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\FrameworkHttpProcessing.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerHttpProcessing.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\Operation\CacheBasedOperationHolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\Operation\ObjectInstanceBasedOperationHolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\Operation\OperationWatch.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ApplicationInsightsUrlFilter.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerRuntimeInstrumentation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\RDDSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\RemoteDependencyConstants.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\SdkVersionUtils.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PropertyFetcher.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SanitizedHostList.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SqlClientDiagnosticSourceListener.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TelemetryDiagnosticSourceListener.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.6' ">
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ClientServerDependencyTracker.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\DependencyTableStore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\FrameworkHttpEventListener.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\FrameworkHttpProcessing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\FrameworkSqlEventListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\FrameworkSqlProcessing.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpDesktopDiagnosticSourceSubscriber.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\HttpProcessing.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\Operation\CacheBasedOperationHolder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerHttpProcessing.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerRuntimeInstrumentation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerSqlCommandProcessing.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerSqlConnectionProcessing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ProfilerSqlProcessingBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\RetryPolicy.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\DependencyTableStore.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\RDDSource.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)DependencyTrackingTelemetryModule.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)SanitizedHostList.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\WebRequestDependencyTrackingHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TelemetryExtensionsForDependencyCollector.cs" />
   </ItemGroup>
 </Project>

--- a/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
@@ -1,0 +1,615 @@
+namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+    internal class HttpCoreDiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
+    {
+        private const string DependencyErrorPropertyKey = "Error";
+        private const string HttpOutEventName = "System.Net.Http.HttpRequestOut";
+        private const string HttpOutStartEventName = "System.Net.Http.HttpRequestOut.Start";
+        private const string HttpOutStopEventName = "System.Net.Http.HttpRequestOut.Stop";
+        private const string HttpExceptionEventName = "System.Net.Http.Exception";
+        private const string DeprecatedRequestEventName = "System.Net.Http.Request";
+        private const string DeprecatedResponseEventName = "System.Net.Http.Response";
+
+        private readonly IEnumerable<string> correlationDomainExclusionList;
+        private readonly ApplicationInsightsUrlFilter applicationInsightsUrlFilter;
+        private readonly bool setComponentCorrelationHttpHeaders;
+        private readonly ICorrelationIdLookupHelper correlationIdLookupHelper;
+        private readonly TelemetryClient client;
+        private readonly TelemetryConfiguration configuration;
+        private readonly HttpCoreDiagnosticSourceSubscriber subscriber;
+        #region fetchers
+
+        private readonly PropertyFetcher startRequestFetcher = new PropertyFetcher("Request");
+        private readonly PropertyFetcher stopRequestFetcher = new PropertyFetcher("Request");
+        private readonly PropertyFetcher exceptionRequestFetcher = new PropertyFetcher("Request");
+        private readonly PropertyFetcher exceptionFetcher = new PropertyFetcher("Exception");
+        private readonly PropertyFetcher stopResponseFetcher = new PropertyFetcher("Response");
+        private readonly PropertyFetcher stopRequestStatusFetcher = new PropertyFetcher("RequestTaskStatus");
+        private readonly PropertyFetcher deprecatedRequestFetcher = new PropertyFetcher("Request");
+        private readonly PropertyFetcher deprecatedResponseFetcher = new PropertyFetcher("Response");
+        private readonly PropertyFetcher deprecatedRequestGuidFetcher = new PropertyFetcher("LoggingRequestId");
+        private readonly PropertyFetcher deprecatedResponseGuidFetcher = new PropertyFetcher("LoggingRequestId");
+
+        #endregion
+
+        private readonly ConditionalWeakTable<HttpRequestMessage, IOperationHolder<DependencyTelemetry>> pendingTelemetry = 
+            new ConditionalWeakTable<HttpRequestMessage, IOperationHolder<DependencyTelemetry>>();
+
+        private readonly ConcurrentDictionary<string, Exception> pendingExceptions =
+            new ConcurrentDictionary<string, Exception>();
+
+        public HttpCoreDiagnosticSourceListener(
+            TelemetryConfiguration configuration,
+            string effectiveProfileQueryEndpoint,
+            bool setComponentCorrelationHttpHeaders,
+            IEnumerable<string> correlationDomainExclusionList,
+            ICorrelationIdLookupHelper correlationIdLookupHelper)
+        {
+            this.client = new TelemetryClient(configuration);
+            this.client.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceCore + ":");
+
+            this.configuration = configuration;
+            this.applicationInsightsUrlFilter = new ApplicationInsightsUrlFilter(configuration);
+            this.setComponentCorrelationHttpHeaders = setComponentCorrelationHttpHeaders;
+            this.correlationIdLookupHelper = correlationIdLookupHelper ?? new CorrelationIdLookupHelper(effectiveProfileQueryEndpoint);
+            this.correlationDomainExclusionList = correlationDomainExclusionList ?? Enumerable.Empty<string>();
+
+            this.subscriber = new HttpCoreDiagnosticSourceSubscriber(this, this.applicationInsightsUrlFilter);
+        }
+
+        /// <summary>
+        /// Get the DependencyTelemetry objects that are still waiting for a response from the dependency. This will most likely only be used for testing purposes.
+        /// </summary>
+        internal ConditionalWeakTable<HttpRequestMessage, IOperationHolder<DependencyTelemetry>> PendingDependencyTelemetry => this.pendingTelemetry;
+
+        /// <summary>
+        /// Notifies the observer that the provider has finished sending push-based notifications.
+        /// <seealso cref="IObserver{T}.OnCompleted()"/>
+        /// </summary>
+        public void OnCompleted()
+        {
+        }
+
+        /// <summary>
+        /// Notifies the observer that the provider has experienced an error condition.
+        /// <seealso cref="IObserver{T}.OnError(Exception)"/>
+        /// </summary>
+        /// <param name="error">An object that provides additional information about the error.</param>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <summary>
+        /// Provides the observer with new data.
+        /// <seealso cref="IObserver{T}.OnNext(T)"/>
+        /// </summary>
+        /// <param name="evnt">The current notification information.</param>
+        public void OnNext(KeyValuePair<string, object> evnt)
+        {
+            const string ErrorTemplateTypeCast = "Event {0}: cannot cast {1} to expected type {2}";
+            const string ErrorTemplateValueParse = "Event {0}: cannot parse '{1}' as type {2}";
+
+            try
+            {
+                switch (evnt.Key)
+                {
+                    case HttpOutStartEventName:
+                        {
+                            var request = this.startRequestFetcher.Fetch(evnt.Value) as HttpRequestMessage;
+
+                            if (request == null)
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateTypeCast, evnt.Key, "request", "HttpRequestMessage");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else
+                            {
+                                this.OnActivityStart(request);
+                            }
+
+                            break;
+                        }
+
+                    case HttpOutStopEventName:
+                        {
+                            var response = this.stopResponseFetcher.Fetch(evnt.Value) as HttpResponseMessage;
+                            var request = this.stopRequestFetcher.Fetch(evnt.Value) as HttpRequestMessage;
+                            var requestTaskStatusString = this.stopRequestStatusFetcher.Fetch(evnt.Value).ToString();
+                            TaskStatus requestTaskStatus;
+
+                            if (response == null)
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateTypeCast, evnt.Key, "response", "HttpResponseMessage");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else if (request == null)
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateTypeCast, evnt.Key, "request", "HttpRequestMessage");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else if (!Enum.TryParse(requestTaskStatusString, out requestTaskStatus))
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateValueParse, evnt.Key, requestTaskStatusString, "TaskStatus");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else
+                            {
+                                this.OnActivityStop(response, request, requestTaskStatus);
+                            }
+
+                            break;
+                        }
+
+                    case HttpExceptionEventName:
+                        {
+                            var exception = this.exceptionFetcher.Fetch(evnt.Value) as Exception;
+                            var request = this.exceptionRequestFetcher.Fetch(evnt.Value) as HttpRequestMessage;
+
+                            if (exception == null)
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateTypeCast, evnt.Key, "exception", "Exception");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else if (request == null)
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateTypeCast, evnt.Key, "request", "HttpRequestMessage");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else
+                            {
+                                this.OnException(exception, request);
+                            }
+
+                            break;
+                        }
+
+                    case DeprecatedRequestEventName:
+                        {
+                            var request = this.deprecatedRequestFetcher.Fetch(evnt.Value) as HttpRequestMessage;
+                            var loggingRequestIdString = this.deprecatedRequestGuidFetcher.Fetch(evnt.Value).ToString();
+                            Guid loggingRequestId;
+
+                            if (request == null)
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateTypeCast, evnt.Key, "request", "HttpRequestMessage");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else if (!Guid.TryParse(loggingRequestIdString, out loggingRequestId))
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateValueParse, evnt.Key, loggingRequestIdString, "Guid");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else
+                            {
+                                this.OnRequest(request, loggingRequestId);
+                            }
+
+                            break;
+                        }
+
+                    case DeprecatedResponseEventName:
+                        {
+                            var response = this.deprecatedResponseFetcher.Fetch(evnt.Value) as HttpResponseMessage;
+                            var loggingRequestIdString = this.deprecatedResponseGuidFetcher.Fetch(evnt.Value).ToString();
+                            Guid loggingRequestId;
+
+                            if (response == null)
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateTypeCast, evnt.Key, "response", "HttpResponseMessage");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else if (!Guid.TryParse(loggingRequestIdString, out loggingRequestId))
+                            {
+                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateValueParse, evnt.Key, loggingRequestIdString, "Guid");
+                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
+                            }
+                            else
+                            {
+                                this.OnResponse(response, loggingRequestId);
+                            }
+
+                            break;
+                        }
+                }
+            }
+            catch (Exception ex)
+            {
+                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(ExceptionUtilities.GetExceptionDetailString(ex));
+            }
+        }
+
+        public void Dispose()
+        {
+            if (this.subscriber != null)
+            {
+                this.subscriber.Dispose();
+            }
+        }
+
+        //// netcoreapp 2.0 event
+
+        /// <summary>
+        /// Handler for Exception event, it is sent when request processing cause an exception (e.g. because of DNS or network issues)
+        /// Stop event will be sent anyway with null response.
+        /// </summary>
+        internal void OnException(Exception exception, HttpRequestMessage request)
+        {
+            Activity currentActivity = Activity.Current;
+            if (currentActivity == null)
+            {
+                DependencyCollectorEventSource.Log.CurrentActivityIsNull();
+                return;
+            }
+
+            DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerException(currentActivity.Id);
+
+            // Even though we have the IsEnabled filter, to reject ApplicationInsights URLs before any events are fired,
+            // Exceptions are special and fired even if request instrumentation is disabled.
+            if (!this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
+            {
+                this.pendingExceptions.TryAdd(currentActivity.Id, exception);
+                this.client.TrackException(exception);
+            }
+        }
+
+        //// netcoreapp 2.0 event
+
+        /// <summary>
+        /// Handler for Activity start event (outgoing request is about to be sent).
+        /// </summary>
+        internal void OnActivityStart(HttpRequestMessage request)
+        {
+            var currentActivity = Activity.Current;
+            if (currentActivity == null)
+            {
+                DependencyCollectorEventSource.Log.CurrentActivityIsNull();
+                return;
+            }
+
+            DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerStart(currentActivity.Id);
+
+            // Even though we have the IsEnabled filter to reject ApplicationInsights URLs before any events are fired, if there
+            // are multiple subscribers and one subscriber returns true to IsEnabled then all subscribers will receive the event.
+            if (!this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
+            {
+                this.InjectRequestHeaders(request, this.configuration.InstrumentationKey);
+            }
+        }
+
+        //// netcoreapp 2.0 event
+
+        /// <summary>
+        /// Handler for Activity stop event (response is received for the outgoing request).
+        /// </summary>
+        internal void OnActivityStop(HttpResponseMessage response, HttpRequestMessage request, TaskStatus requestTaskStatus)
+        {
+            Activity currentActivity = Activity.Current;
+            if (currentActivity == null)
+            {
+                DependencyCollectorEventSource.Log.CurrentActivityIsNull();
+                return;
+            }
+
+            DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerStop(currentActivity.Id);
+
+            // Even though we have the IsEnabled filter to reject ApplicationInsights URLs before any events are fired, if there
+            // are multiple subscribers and one subscriber returns true to IsEnabled then all subscribers will receive the event.
+            if (this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
+            {
+                return;
+            }
+
+            Uri requestUri = request.RequestUri;
+            var resourceName = request.Method.Method + " " + requestUri.AbsolutePath;
+
+            DependencyTelemetry telemetry = new DependencyTelemetry();
+
+            // properly fill dependency telemetry operation context: OperationCorrelationTelemetryInitializer initializes child telemetry
+            telemetry.Context.Operation.Id = currentActivity.RootId;
+            telemetry.Context.Operation.ParentId = currentActivity.ParentId;
+            telemetry.Id = currentActivity.Id;
+            foreach (var item in currentActivity.Baggage)
+            {
+                if (!telemetry.Context.Properties.ContainsKey(item.Key))
+                {
+                    telemetry.Context.Properties[item.Key] = item.Value;
+                }
+            }
+            
+            this.client.Initialize(telemetry);
+
+            telemetry.Timestamp = currentActivity.StartTimeUtc;
+            telemetry.Name = resourceName;
+            telemetry.Target = requestUri.Host;
+            telemetry.Type = RemoteDependencyConstants.HTTP;
+            telemetry.Data = requestUri.OriginalString;
+            telemetry.Duration = currentActivity.Duration;
+            if (response != null)
+            {
+                this.ParseResponse(response, telemetry);
+            }
+            else
+            {
+                Exception exception;
+                if (this.pendingExceptions.TryRemove(currentActivity.Id, out exception))
+                {
+                    telemetry.Context.Properties[DependencyErrorPropertyKey] = exception.GetBaseException().Message;
+                }
+
+                telemetry.ResultCode = requestTaskStatus.ToString();
+                telemetry.Success = false;
+            }
+
+            this.client.Track(telemetry);
+        }
+
+        //// netcoreapp1.1 and prior event. See https://github.com/dotnet/corefx/blob/release/1.0.0-rc2/src/Common/src/System/Net/Http/HttpHandlerDiagnosticListenerExtensions.cs.
+
+        /// <summary>
+        /// Diagnostic event handler method for 'System.Net.Http.Request' event.
+        /// </summary>
+        internal void OnRequest(HttpRequestMessage request, Guid loggingRequestId)
+        {
+            if (request != null && request.RequestUri != null &&
+                !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri))
+            {
+                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerRequest(loggingRequestId);
+
+                Uri requestUri = request.RequestUri;
+                var resourceName = request.Method.Method + " " + requestUri.AbsolutePath;
+
+                var dependency = this.client.StartOperation<DependencyTelemetry>(resourceName);
+                dependency.Telemetry.Target = requestUri.Host;
+                dependency.Telemetry.Type = RemoteDependencyConstants.HTTP;
+                dependency.Telemetry.Data = requestUri.OriginalString;
+                this.pendingTelemetry.Add(request, dependency);
+
+                this.InjectRequestHeaders(request, dependency.Telemetry.Context.InstrumentationKey, true);
+            }
+        }
+
+        //// netcoreapp1.1 and prior event. See https://github.com/dotnet/corefx/blob/release/1.0.0-rc2/src/Common/src/System/Net/Http/HttpHandlerDiagnosticListenerExtensions.cs.
+
+        /// <summary>
+        /// Diagnostic event handler method for 'System.Net.Http.Response' event.
+        /// This event will be fired only if response was received (and not called for faulted or canceled requests).
+        /// </summary>
+        internal void OnResponse(HttpResponseMessage response, Guid loggingRequestId)
+        {
+            if (response != null)
+            {
+                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerResponse(loggingRequestId);
+                var request = response.RequestMessage;
+                IOperationHolder<DependencyTelemetry> dependency;
+                if (request != null && this.pendingTelemetry.TryGetValue(request, out dependency))
+                {
+                    this.ParseResponse(response, dependency.Telemetry);
+                    this.client.StopOperation(dependency);
+                    this.pendingTelemetry.Remove(request);
+                }
+            }
+        }
+
+        private void InjectRequestHeaders(HttpRequestMessage request, string instrumentationKey, bool isLegacyEvent = false)
+        {
+            try
+            {
+                var currentActivity = Activity.Current;
+
+                HttpRequestHeaders requestHeaders = request.Headers;
+                if (requestHeaders != null && this.setComponentCorrelationHttpHeaders && !this.correlationDomainExclusionList.Contains(request.RequestUri.Host))
+                {
+                    try
+                    {
+                        if (!string.IsNullOrEmpty(instrumentationKey) && !HttpHeadersUtilities.ContainsRequestContextKeyValue(requestHeaders, RequestResponseHeaders.RequestContextCorrelationSourceKey))
+                        {
+                            string sourceApplicationId;
+                            if (this.correlationIdLookupHelper.TryGetXComponentCorrelationId(instrumentationKey, out sourceApplicationId))
+                            {
+                                HttpHeadersUtilities.SetRequestContextKeyValue(requestHeaders, RequestResponseHeaders.RequestContextCorrelationSourceKey, sourceApplicationId);
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        AppMapCorrelationEventSource.Log.UnknownError(ExceptionUtilities.GetExceptionDetailString(e));
+                    }
+
+                    // Add the root ID
+                    string rootId = currentActivity.RootId;
+                    if (!string.IsNullOrEmpty(rootId) &&
+                        !requestHeaders.Contains(RequestResponseHeaders.StandardRootIdHeader))
+                    {
+                        requestHeaders.Add(RequestResponseHeaders.StandardRootIdHeader, rootId);
+                    }
+
+                    // Add the parent ID
+                    string parentId = currentActivity.Id;
+                    if (!string.IsNullOrEmpty(parentId) &&
+                        !requestHeaders.Contains(RequestResponseHeaders.StandardParentIdHeader))
+                    {
+                        requestHeaders.Add(RequestResponseHeaders.StandardParentIdHeader, parentId);
+                        if (isLegacyEvent)
+                        {
+                            requestHeaders.Add(RequestResponseHeaders.RequestIdHeader, parentId);
+                        }
+                    }
+
+                    if (isLegacyEvent)
+                    {
+                        // we expect baggage to be empty or contain a few items
+                        using (IEnumerator<KeyValuePair<string, string>> e = currentActivity.Baggage.GetEnumerator())
+                        {
+                            if (e.MoveNext())
+                            {
+                                var baggage = new List<string>();
+                                do
+                                {
+                                    KeyValuePair<string, string> item = e.Current;
+                                    baggage.Add(new NameValueHeaderValue(item.Key, item.Value).ToString());
+                                }
+                                while (e.MoveNext());
+                                request.Headers.Add(RequestResponseHeaders.CorrelationContextHeader, baggage);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                AppMapCorrelationEventSource.Log.UnknownError(ExceptionUtilities.GetExceptionDetailString(e));
+            }
+        }
+
+        private void ParseResponse(HttpResponseMessage response, DependencyTelemetry telemetry)
+        {
+            try
+            {
+                string targetApplicationId = HttpHeadersUtilities.GetRequestContextKeyValue(response.Headers, RequestResponseHeaders.RequestContextCorrelationTargetKey);
+                if (!string.IsNullOrEmpty(targetApplicationId) && !string.IsNullOrEmpty(telemetry.Context.InstrumentationKey))
+                {
+                    // We only add the cross component correlation key if the key does not represent the current component.
+                    string sourceApplicationId;
+                    if (this.correlationIdLookupHelper.TryGetXComponentCorrelationId(telemetry.Context.InstrumentationKey, out sourceApplicationId) &&
+                        targetApplicationId != sourceApplicationId)
+                    {
+                        telemetry.Type = RemoteDependencyConstants.AI;
+                        telemetry.Target += " | " + targetApplicationId;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                AppMapCorrelationEventSource.Log.UnknownError(ExceptionUtilities.GetExceptionDetailString(e));
+            }
+
+            int statusCode = (int)response.StatusCode;
+            telemetry.ResultCode = (statusCode > 0) ? statusCode.ToString(CultureInfo.InvariantCulture) : string.Empty;
+            telemetry.Success = (statusCode > 0) && (statusCode < 400);
+        }
+
+        /// <summary>
+        /// Diagnostic listener implementation that listens for events specific to outgoing dependency requests.
+        /// </summary>
+        private class HttpCoreDiagnosticSourceSubscriber : IObserver<DiagnosticListener>, IDisposable
+        {
+            private readonly HttpCoreDiagnosticSourceListener httpDiagnosticListener;
+            private readonly IDisposable listenerSubscription;
+            private readonly ApplicationInsightsUrlFilter applicationInsightsUrlFilter;
+            private readonly bool isNetCore20HttpClient;
+
+            private IDisposable eventSubscription;
+
+            internal HttpCoreDiagnosticSourceSubscriber(HttpCoreDiagnosticSourceListener listener, ApplicationInsightsUrlFilter applicationInsightsUrlFilter)
+            {
+                this.httpDiagnosticListener = listener;
+                this.applicationInsightsUrlFilter = applicationInsightsUrlFilter;
+
+                var httpClientVersion = typeof(HttpClient).GetTypeInfo().Assembly.GetName().Version;
+                this.isNetCore20HttpClient = httpClientVersion.CompareTo(new Version(4, 2)) >= 0;
+
+                try
+                {
+                    this.listenerSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+                }
+                catch (Exception ex)
+                {
+                    DependencyCollectorEventSource.Log.HttpCoreDiagnosticSubscriberFailedToSubscribe(ex.ToInvariantString());
+                }
+            }
+
+            /// <summary>
+            /// This method gets called once for each existing DiagnosticListener when this
+            /// DiagnosticListener is added to the list of DiagnosticListeners
+            /// (<see cref="System.Diagnostics.DiagnosticListener.AllListeners"/>). This method will
+            /// also be called for each subsequent DiagnosticListener that is added to the list of
+            /// DiagnosticListeners.
+            /// <seealso cref="IObserver{T}.OnNext(T)"/>
+            /// </summary>
+            /// <param name="value">The DiagnosticListener that exists when this listener was added to
+            /// the list, or a DiagnosticListener that got added after this listener was added.</param>
+            public void OnNext(DiagnosticListener value)
+            {
+                if (value != null)
+                {
+                    // Comes from https://github.com/dotnet/corefx/blob/master/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs#L12
+                    if (value.Name == "HttpHandlerDiagnosticListener")
+                    {
+                        this.eventSubscription = value.Subscribe(
+                            this.httpDiagnosticListener,
+                            (evnt, r, _) =>
+                            {
+                                if (isNetCore20HttpClient)
+                                {
+                                    if (evnt == HttpExceptionEventName)
+                                    {
+                                        return true;
+                                    }
+
+                                    if (!evnt.StartsWith(HttpOutEventName, StringComparison.Ordinal))
+                                    {
+                                        return false;
+                                    }
+
+                                    if (evnt == HttpOutEventName && r != null)
+                                    {
+                                        var request = (HttpRequestMessage)r;
+                                        return !this.applicationInsightsUrlFilter.IsApplicationInsightsUrl(request.RequestUri);
+                                    }
+                                }
+
+                                return true;
+                            });
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Notifies the observer that the provider has finished sending push-based notifications.
+            /// <seealso cref="IObserver{T}.OnCompleted()"/>
+            /// </summary>
+            public void OnCompleted()
+            {
+            }
+
+            /// <summary>
+            /// Notifies the observer that the provider has experienced an error condition.
+            /// <seealso cref="IObserver{T}.OnError(Exception)"/>
+            /// </summary>
+            /// <param name="error">An object that provides additional information about the error.</param>
+            public void OnError(Exception error)
+            {
+            }
+
+            public void Dispose()
+            {
+                if (this.eventSubscription != null)
+                {
+                    this.eventSubscription.Dispose();
+                }
+
+                if (this.listenerSubscription != null)
+                {
+                    this.listenerSubscription.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/Src/DependencyCollector/Shared/HttpHeadersUtilities.cs
+++ b/Src/DependencyCollector/Shared/HttpHeadersUtilities.cs
@@ -1,0 +1,60 @@
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http.Headers;
+    using Microsoft.ApplicationInsights.Common;
+
+    internal static class HttpHeadersUtilities
+    {
+        internal static IEnumerable<string> GetHeaderValues(HttpHeaders headers, string headerName)
+        {
+            IEnumerable<string> result;
+            if (headers == null || !headers.TryGetValues(headerName, out result))
+            {
+                result = Enumerable.Empty<string>();
+            }
+
+            return result;
+        }
+
+        internal static string GetHeaderKeyValue(HttpHeaders headers, string headerName, string keyName)
+        {
+            IEnumerable<string> headerValues = GetHeaderValues(headers, headerName);
+            return HeadersUtilities.GetHeaderKeyValue(headerValues, keyName);
+        }
+
+        internal static string GetRequestContextKeyValue(HttpHeaders headers, string keyName)
+        {
+            return GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName);
+        }
+
+        internal static bool ContainsHeaderKeyValue(HttpHeaders headers, string headerName, string keyName)
+        {
+            return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, headerName, keyName));
+        }
+
+        internal static bool ContainsRequestContextKeyValue(HttpHeaders headers, string keyName)
+        {
+            return ContainsHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName);
+        }
+
+        internal static void SetRequestContextKeyValue(HttpHeaders headers, string keyName, string keyValue)
+        {
+            SetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName, keyValue);
+        }
+
+        internal static void SetHeaderKeyValue(HttpHeaders headers, string headerName, string keyName, string keyValue)
+        {
+            if (headers == null)
+            {
+                throw new ArgumentNullException(nameof(headers));
+            }
+
+            IEnumerable<string> headerValues = GetHeaderValues(headers, headerName);
+            headers.Remove(headerName);
+            headers.Add(headerName, HeadersUtilities.UpdateHeaderWithKeyValue(headerValues, keyName, keyValue));
+        }
+    }
+}

--- a/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DesktopDiagnosticSourceHttpProcessing.cs
@@ -7,7 +7,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.Web.Implementation;
 
     /// <summary>
     /// Concrete class with all processing logic to generate RDD data from the callbacks received from HttpDesktopDiagnosticSourceListener.

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkHttpProcessing.cs
@@ -8,7 +8,6 @@
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Web.Implementation;
 
     /// <summary>
     /// Concrete class with all processing logic to generate RDD data from the callbacks received from FrameworkHttpEventListener.

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkSqlProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkSqlProcessing.cs
@@ -6,7 +6,6 @@
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Web.Implementation;
 
     internal sealed class FrameworkSqlProcessing
     {

--- a/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
@@ -13,7 +13,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Web.Implementation;
 
     /// <summary>
     /// Concrete class with all processing logic to generate RDD data from the callbacks

--- a/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
@@ -13,7 +13,6 @@
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Web.Implementation;
 
     /// <summary>
     /// Concrete class with all processing logic to generate RDD data from the callbacks

--- a/Src/DependencyCollector/Shared/Implementation/ProfilerSqlProcessingBase.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ProfilerSqlProcessingBase.cs
@@ -8,7 +8,6 @@
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Web.Implementation;
 
     /// <summary>
     /// Base class with all processing logic to generate dependencies from the callbacks received from Profiler instrumentation for SQL.    

--- a/Src/DependencyCollector/Shared/Implementation/SdkVersionUtils.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SdkVersionUtils.cs
@@ -1,0 +1,35 @@
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+#if NETCORE
+    using System.Collections.Generic;
+#endif
+
+    internal class SdkVersionUtils
+    {
+        internal static string GetSdkVersion(string versionPrefix)
+        {
+            // Since dependencySource is no longer set, sdk version is prepended with information which can identify whether RDD was collected by profiler/framework
+            // For directly using TrackDependency(), version will be simply what is set by core
+            Type sdkVersionUtilsType = typeof(SdkVersionUtils);
+
+#if NETCORE
+            IEnumerable<Attribute> assemblyCustomAttributes = sdkVersionUtilsType.GetTypeInfo().Assembly.GetCustomAttributes();
+#else
+            object[] assemblyCustomAttributes = sdkVersionUtilsType.Assembly.GetCustomAttributes(false);
+#endif
+            string versionStr = assemblyCustomAttributes
+                    .OfType<AssemblyFileVersionAttribute>()
+                    .First()
+                    .Version;
+
+            Version version = new Version(versionStr);
+
+            string postfix = version.Revision.ToString(CultureInfo.InvariantCulture);
+            return (versionPrefix ?? string.Empty) + version.ToString(3) + "-" + postfix;
+        }
+    }
+}

--- a/Src/DependencyCollector/Shared/PropertyFetcher.cs
+++ b/Src/DependencyCollector/Shared/PropertyFetcher.cs
@@ -1,0 +1,76 @@
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Reflection;
+
+    /// <summary>
+    /// Efficient implementation of fetching properties of anonymous types with reflection.
+    /// </summary>
+    internal class PropertyFetcher
+    {
+        private readonly string propertyName;
+        private PropertyFetch innerFetcher;
+
+        public PropertyFetcher(string propertyName)
+        {
+            this.propertyName = propertyName;
+        }
+
+        public object Fetch(object obj)
+        {
+            if (this.innerFetcher == null)
+            {
+                this.innerFetcher = PropertyFetch.FetcherForProperty(obj.GetType().GetTypeInfo().GetDeclaredProperty(this.propertyName));
+            }
+
+            return this.innerFetcher?.Fetch(obj);
+        }
+
+        // see https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+        private class PropertyFetch
+        {
+            /// <summary>
+            /// Create a property fetcher from a .NET Reflection PropertyInfo class that
+            /// represents a property of a particular type.  
+            /// </summary>
+            public static PropertyFetch FetcherForProperty(PropertyInfo propertyInfo)
+            {
+                if (propertyInfo == null)
+                {
+                    // returns null on any fetch.
+                    return new PropertyFetch();
+                }
+
+                var typedPropertyFetcher = typeof(TypedFetchProperty<,>);
+                var instantiatedTypedPropertyFetcher = typedPropertyFetcher.GetTypeInfo().MakeGenericType(
+                    propertyInfo.DeclaringType, propertyInfo.PropertyType);
+                return (PropertyFetch)Activator.CreateInstance(instantiatedTypedPropertyFetcher, propertyInfo);
+            }
+
+            /// <summary>
+            /// Given an object, fetch the property that this propertyFetch represents. 
+            /// </summary>
+            public virtual object Fetch(object obj)
+            {
+                return null;
+            }
+
+            private class TypedFetchProperty<TObject, TProperty> : PropertyFetch
+            {
+                private readonly Func<TObject, TProperty> propertyFetch;
+
+                public TypedFetchProperty(PropertyInfo property)
+                {
+                    this.propertyFetch =
+                        (Func<TObject, TProperty>)
+                        property.GetMethod.CreateDelegate(typeof(Func<TObject, TProperty>));
+                }
+
+                public override object Fetch(object obj)
+                {
+                    return this.propertyFetch((TObject)obj);
+                }
+            }
+        }
+    }
+}

--- a/Src/DependencyCollector/Shared/SqlClientDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/SqlClientDiagnosticSourceListener.cs
@@ -1,0 +1,564 @@
+namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.Diagnostics;
+    using System.Globalization;
+
+    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+    internal class SqlClientDiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
+    {
+        // Event ids defined at: https://github.com/dotnet/corefx/blob/master/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+        public const string DiagnosticListenerName = "SqlClientDiagnosticListener";
+
+        public const string SqlBeforeExecuteCommand = SqlClientPrefix + "WriteCommandBefore";
+        public const string SqlAfterExecuteCommand = SqlClientPrefix + "WriteCommandAfter";
+        public const string SqlErrorExecuteCommand = SqlClientPrefix + "WriteCommandError";
+        
+        public const string SqlBeforeOpenConnection = SqlClientPrefix + "WriteConnectionOpenBefore";
+        public const string SqlAfterOpenConnection = SqlClientPrefix + "WriteConnectionOpenAfter";
+        public const string SqlErrorOpenConnection = SqlClientPrefix + "WriteConnectionOpenError";
+
+        public const string SqlBeforeCloseConnection = SqlClientPrefix + "WriteConnectionCloseBefore";
+        public const string SqlAfterCloseConnection = SqlClientPrefix + "WriteConnectionCloseAfter";
+        public const string SqlErrorCloseConnection = SqlClientPrefix + "WriteConnectionCloseError";
+
+        public const string SqlBeforeCommitTransaction = SqlClientPrefix + "WriteTransactionCommitBefore";
+        public const string SqlAfterCommitTransaction = SqlClientPrefix + "WriteTransactionCommitAfter";
+        public const string SqlErrorCommitTransaction = SqlClientPrefix + "WriteTransactionCommitError";
+
+        public const string SqlBeforeRollbackTransaction = SqlClientPrefix + "WriteTransactionRollbackBefore";
+        public const string SqlAfterRollbackTransaction = SqlClientPrefix + "WriteTransactionRollbackAfter";
+        public const string SqlErrorRollbackTransaction = SqlClientPrefix + "WriteTransactionRollbackError";
+
+        private const string SqlClientPrefix = "System.Data.SqlClient.";
+
+        private readonly TelemetryClient client;
+        private readonly SqlClientDiagnosticSourceSubscriber subscriber;
+
+        private readonly ObjectInstanceBasedOperationHolder operationHolder = new ObjectInstanceBasedOperationHolder();
+
+        public SqlClientDiagnosticSourceListener(TelemetryConfiguration configuration)
+        {
+            this.client = new TelemetryClient(configuration);
+            this.client.Context.GetInternalContext().SdkVersion =
+                SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceCore + ":");
+
+            this.subscriber = new SqlClientDiagnosticSourceSubscriber(this);
+        }
+
+        public void Dispose()
+        {
+            if (this.subscriber != null)
+            {
+                this.subscriber.Dispose();
+            }
+        }
+        
+        void IObserver<KeyValuePair<string, object>>.OnCompleted()
+        {
+        }
+
+        void IObserver<KeyValuePair<string, object>>.OnError(Exception error)
+        {
+        }
+
+        void IObserver<KeyValuePair<string, object>>.OnNext(KeyValuePair<string, object> evnt)
+        {
+            try
+            {
+                switch (evnt.Key)
+                {
+                    case SqlBeforeExecuteCommand:
+                    {
+                        var operationId = (Guid)CommandBefore.OperationId.Fetch(evnt.Value);
+
+                        DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                        var command = (SqlCommand)CommandBefore.Command.Fetch(evnt.Value);
+
+                        if (this.operationHolder.Get(command) == null)
+                        {
+                            var dependencyName = string.Empty;
+                            var target = string.Empty;
+
+                            if (command.Connection != null)
+                            {
+                                target = string.Join(" | ", command.Connection.DataSource, command.Connection.Database);
+
+                                var commandName = command.CommandType == CommandType.StoredProcedure
+                                    ? command.CommandText
+                                    : string.Empty;
+
+                                dependencyName = string.IsNullOrEmpty(commandName)
+                                    ? string.Join(" | ", command.Connection.DataSource, command.Connection.Database)
+                                    : string.Join(" | ", command.Connection.DataSource, command.Connection.Database, commandName);
+                            }
+
+                            var timestamp = CommandBefore.Timestamp.Fetch(evnt.Value) as long?
+                                        ?? Stopwatch.GetTimestamp(); // TODO corefx#20748 - timestamp missing from event data
+
+                            var telemetry = new DependencyTelemetry()
+                            {
+                                Id = operationId.ToString("N"),
+                                Name = dependencyName,
+                                Type = RemoteDependencyConstants.SQL,
+                                Target = target,
+                                Data = command.CommandText,
+                                Success = true
+                            };
+                            
+                            InitializeTelemetry(telemetry, operationId, timestamp);
+
+                            this.operationHolder.Store(command, Tuple.Create(telemetry, /* isCustomCreated: */ false));
+                        }
+                        else
+                        {
+                            DependencyCollectorEventSource.Log.TrackingAnExistingTelemetryItemVerbose();
+                        }
+
+                        break;
+                    }
+
+                    case SqlAfterExecuteCommand:
+                    {
+                        var operationId = (Guid)CommandAfter.OperationId.Fetch(evnt.Value);
+
+                        DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                        var command = (SqlCommand)CommandAfter.Command.Fetch(evnt.Value);
+                        var tuple = this.operationHolder.Get(command);
+
+                        if (tuple != null)
+                        {
+                            this.operationHolder.Remove(command);
+
+                            var telemetry = tuple.Item1;
+
+                            var timestamp = (long)CommandAfter.Timestamp.Fetch(evnt.Value);
+
+                            telemetry.Stop(timestamp);
+
+                            this.client.Track(telemetry);
+                        }
+                        else
+                        {
+                            DependencyCollectorEventSource.Log.EndCallbackWithNoBegin(operationId.ToString("N"));
+                        }
+
+                        break;
+                    }
+
+                    case SqlErrorExecuteCommand:
+                    {
+                        var operationId = (Guid)CommandError.OperationId.Fetch(evnt.Value);
+
+                        DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                        var command = (SqlCommand)CommandError.Command.Fetch(evnt.Value);
+                        var tuple = this.operationHolder.Get(command);
+
+                        if (tuple != null)
+                        {
+                            this.operationHolder.Remove(command);
+
+                            var telemetry = tuple.Item1;
+
+                            var timestamp = (long)CommandError.Timestamp.Fetch(evnt.Value);
+
+                            telemetry.Stop(timestamp);
+
+                            var exception = (Exception)CommandError.Exception.Fetch(evnt.Value);
+
+                            ConfigureExceptionTelemetry(telemetry, exception);
+
+                            this.client.Track(telemetry);
+                        }
+                        else
+                        {
+                            DependencyCollectorEventSource.Log.EndCallbackWithNoBegin(operationId.ToString("N"));
+                        }
+
+                        break;
+                    }
+                    
+                    case SqlBeforeOpenConnection:
+                    {
+                        var operationId = (Guid)ConnectionBefore.OperationId.Fetch(evnt.Value);
+
+                        DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+                    
+                        var connection = (SqlConnection)ConnectionBefore.Connection.Fetch(evnt.Value);
+
+                        if (this.operationHolder.Get(connection) == null)
+                        {
+                            var operation = (string)ConnectionBefore.Operation.Fetch(evnt.Value);
+                            var timestamp = (long)ConnectionBefore.Timestamp.Fetch(evnt.Value);
+
+                            var telemetry = new DependencyTelemetry()
+                            {
+                                Id = operationId.ToString("N"),
+                                Name = string.Join(" | ", connection.DataSource, connection.Database, operation),
+                                Type = RemoteDependencyConstants.SQL,
+                                Target = string.Join(" | ", connection.DataSource, connection.Database),
+                                Data = operation,
+                                Success = true
+                            };
+                        
+                            InitializeTelemetry(telemetry, operationId, timestamp);
+
+                            this.operationHolder.Store(connection, Tuple.Create(telemetry, /* isCustomCreated: */ false));
+                        }
+                        else
+                        {
+                            DependencyCollectorEventSource.Log.TrackingAnExistingTelemetryItemVerbose();
+                        }
+
+                        break;
+                    }
+
+                    case SqlAfterOpenConnection:
+                    {
+                        var operationId = (Guid)ConnectionAfter.OperationId.Fetch(evnt.Value);
+
+                        DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                        var connection = (SqlConnection)ConnectionAfter.Connection.Fetch(evnt.Value);
+                        var tuple = this.operationHolder.Get(connection);
+
+                        if (tuple != null)
+                        {
+                            this.operationHolder.Remove(connection);
+                        }
+                        else
+                        {
+                            DependencyCollectorEventSource.Log.EndCallbackWithNoBegin(operationId.ToString("N"));
+                        }
+
+                        break;
+                    }
+
+                    case SqlErrorOpenConnection:
+                    {
+                        var operationId = (Guid)ConnectionError.OperationId.Fetch(evnt.Value);
+
+                        DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                        var connection = (SqlConnection)ConnectionError.Connection.Fetch(evnt.Value);
+                        var tuple = this.operationHolder.Get(connection);
+
+                        if (tuple != null)
+                        {
+                            this.operationHolder.Remove(connection);
+
+                            var telemetry = tuple.Item1;
+
+                            var timestamp = (long)ConnectionError.Timestamp.Fetch(evnt.Value);
+
+                            telemetry.Stop(timestamp);
+
+                            var exception = (Exception)ConnectionError.Exception.Fetch(evnt.Value);
+
+                            ConfigureExceptionTelemetry(telemetry, exception);
+
+                            this.client.Track(telemetry);
+                        }
+                        else
+                        {
+                            DependencyCollectorEventSource.Log.EndCallbackWithNoBegin(operationId.ToString("N"));
+                        }
+
+                        break;
+                    }
+
+                    case SqlBeforeCommitTransaction:
+                    case SqlBeforeRollbackTransaction:
+                    {
+                        var operationId = (Guid)TransactionBefore.OperationId.Fetch(evnt.Value);
+
+                        DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                        var connection = (SqlConnection)TransactionBefore.Connection.Fetch(evnt.Value);
+
+                        if (this.operationHolder.Get(connection) == null)
+                        {
+                            var operation = (string)TransactionBefore.Operation.Fetch(evnt.Value);
+                            var timestamp = (long)TransactionBefore.Timestamp.Fetch(evnt.Value);
+                            var isolationLevel = (IsolationLevel)TransactionBefore.IsolationLevel.Fetch(evnt.Value);
+
+                            var telemetry = new DependencyTelemetry()
+                            {
+                                Id = operationId.ToString("N"),
+                                Name = string.Join(" | ", connection.DataSource, connection.Database, operation, isolationLevel),
+                                Type = RemoteDependencyConstants.SQL,
+                                Target = string.Join(" | ", connection.DataSource, connection.Database),
+                                Data = operation,
+                                Success = true
+                            };
+
+                            InitializeTelemetry(telemetry, operationId, timestamp);
+
+                            this.operationHolder.Store(connection, Tuple.Create(telemetry, /* isCustomCreated: */ false));
+                        }
+                        else
+                        {
+                            DependencyCollectorEventSource.Log.TrackingAnExistingTelemetryItemVerbose();
+                        }
+
+                        break;
+                    }
+
+                    case SqlAfterCommitTransaction:
+                    case SqlAfterRollbackTransaction:
+                    {
+                        var operationId = (Guid)TransactionAfter.OperationId.Fetch(evnt.Value);
+
+                        DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                        var connection = (SqlConnection)TransactionAfter.Connection.Fetch(evnt.Value);
+                        var tuple = this.operationHolder.Get(connection);
+
+                        if (tuple != null)
+                        {
+                            this.operationHolder.Remove(connection);
+
+                            var telemetry = tuple.Item1;
+
+                            var timestamp = (long)TransactionAfter.Timestamp.Fetch(evnt.Value);
+
+                            telemetry.Stop(timestamp);
+
+                            this.client.Track(telemetry);
+                        }
+                        else
+                        {
+                            DependencyCollectorEventSource.Log.EndCallbackWithNoBegin(operationId.ToString("N"));
+                        }
+
+                        break;
+                    }
+
+                    case SqlErrorCommitTransaction:
+                    case SqlErrorRollbackTransaction:
+                    {
+                        var operationId = (Guid)TransactionError.OperationId.Fetch(evnt.Value);
+
+                        DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
+
+                        var connection = (SqlConnection)TransactionError.Connection.Fetch(evnt.Value);
+                        var tuple = this.operationHolder.Get(connection);
+
+                        if (tuple != null)
+                        {
+                            this.operationHolder.Remove(connection);
+
+                            var telemetry = tuple.Item1;
+
+                            var timestamp = (long)TransactionError.Timestamp.Fetch(evnt.Value);
+
+                            telemetry.Stop(timestamp);
+
+                            var exception = (Exception)TransactionError.Exception.Fetch(evnt.Value);
+
+                            ConfigureExceptionTelemetry(telemetry, exception);
+
+                            this.client.Track(telemetry);
+                        }
+                        else
+                        {
+                            DependencyCollectorEventSource.Log.EndCallbackWithNoBegin(operationId.ToString("N"));
+                        }
+
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                DependencyCollectorEventSource.Log
+                    .SqlClientDiagnosticSourceListenerOnNextFailed(ExceptionUtilities.GetExceptionDetailString(ex));
+            }
+        }
+
+        private static void InitializeTelemetry(DependencyTelemetry telemetry, Guid operationId, long timestamp)
+        {
+            telemetry.Start(timestamp);
+
+            var activity = Activity.Current;
+
+            if (activity != null)
+            {
+                telemetry.Context.Operation.Id = activity.RootId;
+                telemetry.Context.Operation.ParentId = activity.ParentId;
+
+                foreach (var item in activity.Baggage)
+                {
+                    if (!telemetry.Context.Properties.ContainsKey(item.Key))
+                    {
+                        telemetry.Context.Properties[item.Key] = item.Value;
+                    }
+                }
+            }
+            else
+            {
+                telemetry.Context.Operation.Id = operationId.ToString("N");
+            }
+        }
+
+        private static void ConfigureExceptionTelemetry(DependencyTelemetry telemetry, Exception exception)
+        {
+            telemetry.Success = false;
+            telemetry.Properties["Exception"] = exception.ToInvariantString();
+
+            var sqlException = exception as SqlException;
+
+            if (sqlException != null)
+            {
+                telemetry.ResultCode = sqlException.Number.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        #region Fetchers
+
+        // Fetchers for execute command before event
+        private static class CommandBefore
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Command = new PropertyFetcher(nameof(Command));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for execute command after event
+        private static class CommandAfter
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Command = new PropertyFetcher(nameof(Command));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for execute command error event
+        private static class CommandError
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Command = new PropertyFetcher(nameof(Command));
+            public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for connection open/close before events
+        private static class ConnectionBefore
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for connection open/close after events
+        private static class ConnectionAfter
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+        }
+
+        // Fetchers for connection open/close error events
+        private static class ConnectionError
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for transaction commit/rollback before events
+        private static class TransactionBefore
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
+            public static readonly PropertyFetcher IsolationLevel = new PropertyFetcher(nameof(IsolationLevel));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for transaction commit/rollback after events
+        private static class TransactionAfter
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        // Fetchers for transaction commit/rollback error events
+        private static class TransactionError
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        #endregion
+
+        private sealed class SqlClientDiagnosticSourceSubscriber : IObserver<DiagnosticListener>, IDisposable
+        {
+            private readonly SqlClientDiagnosticSourceListener sqlDiagnosticListener;
+            private readonly IDisposable listenerSubscription;
+
+            private IDisposable eventSubscription;
+
+            internal SqlClientDiagnosticSourceSubscriber(SqlClientDiagnosticSourceListener listener)
+            {
+                this.sqlDiagnosticListener = listener;
+
+                try
+                {
+                    this.listenerSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+                }
+                catch (Exception ex)
+                {
+                    DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberFailedToSubscribe(ex.ToInvariantString());
+                }
+            }
+
+            public void OnNext(DiagnosticListener value)
+            {
+                if (value != null)
+                {
+                    if (value.Name == DiagnosticListenerName)
+                    {
+                        this.eventSubscription = value.Subscribe(this.sqlDiagnosticListener);
+                    }
+                }
+            }
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void Dispose()
+            {
+                if (this.eventSubscription != null)
+                {
+                    this.eventSubscription.Dispose();
+                }
+
+                if (this.listenerSubscription != null)
+                {
+                    this.listenerSubscription.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/Src/DependencyCollector/Shared/TelemetryDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/TelemetryDiagnosticSourceListener.cs
@@ -1,0 +1,255 @@
+namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
+    internal class TelemetryDiagnosticSourceListener : DiagnosticSourceListenerBase<HashSet<string>>
+    {
+        internal const string ActivityStartNameSuffix = ".Start";
+        internal const string ActivityStopNameSuffix = ".Stop";
+
+        private readonly HashSet<string> includedDiagnosticSources 
+            = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly Dictionary<string, HashSet<string>> includedDiagnosticSourceActivities 
+            = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        public TelemetryDiagnosticSourceListener(TelemetryConfiguration configuration, ICollection<string> includeDiagnosticSourceActivities) 
+            : base(configuration)
+        {
+            this.Client.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceListener + ":");
+            this.PrepareInclusionLists(includeDiagnosticSourceActivities);
+        }
+
+        internal override bool IsSourceEnabled(DiagnosticListener value)
+        {
+            return this.includedDiagnosticSources.Contains(value.Name);
+        }
+
+        internal override bool IsEventEnabled(string evnt, object input1, object input2, DiagnosticListener diagnosticListener, HashSet<string> context)
+        {
+            return this.IsActivityIncluded(evnt, context)
+                && !evnt.EndsWith(ActivityStartNameSuffix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal bool IsActivityIncluded(string activityName, HashSet<string> includedActivities)
+        {
+            // if no list of included activities then all are included
+            return includedActivities == null || includedActivities.Contains(activityName);
+        }
+
+        internal override void HandleEvent(KeyValuePair<string, object> evnt, DiagnosticListener diagnosticListener, HashSet<string> context)
+        {
+            if (!this.IsActivityIncluded(evnt.Key, context)
+                || !evnt.Key.EndsWith(ActivityStopNameSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            Activity currentActivity = Activity.Current;
+            if (currentActivity == null)
+            {
+                DependencyCollectorEventSource.Log.CurrentActivityIsNull();
+                return;
+            }
+
+            DependencyCollectorEventSource.Log.TelemetryDiagnosticSourceListenerActivityStopped(currentActivity.Id, currentActivity.OperationName);
+
+            // extensibility point - can chain more telemetry extraction methods here
+            ITelemetry telemetry = this.ExtractDependencyTelemetry(diagnosticListener, currentActivity);
+            if (telemetry == null)
+            {
+                return;
+            }
+
+            // properly fill dependency telemetry operation context
+            telemetry.Context.Operation.Id = currentActivity.RootId;
+            telemetry.Context.Operation.ParentId = currentActivity.ParentId;
+            telemetry.Timestamp = currentActivity.StartTimeUtc;
+
+            telemetry.Context.Properties["DiagnosticSource"] = diagnosticListener.Name;
+            telemetry.Context.Properties["Activity"] = currentActivity.OperationName;
+
+            this.Client.Track(telemetry);
+        }
+
+        internal DependencyTelemetry ExtractDependencyTelemetry(DiagnosticListener diagnosticListener, Activity currentActivity)
+        {
+            DependencyTelemetry telemetry = new DependencyTelemetry();
+
+            telemetry.Id = currentActivity.Id;
+            telemetry.Duration = currentActivity.Duration;
+            telemetry.Name = currentActivity.OperationName;
+
+            Uri requestUri = null;
+            string component = null;
+            string queryStatement = null;
+            string httpMethodWithSpace = string.Empty;
+            string httpUrl = null;
+            string peerAddress = null;
+            string peerService = null;
+
+            foreach (KeyValuePair<string, string> tag in currentActivity.Tags)
+            {
+                // interpret Tags as defined by OpenTracing conventions
+                // https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+                switch (tag.Key)
+                {
+                    case "component":
+                        {
+                            component = tag.Value;
+                            break;
+                        }
+
+                    case "db.statement":
+                        {
+                            queryStatement = tag.Value;
+                            break;
+                        }
+
+                    case "error":
+                        {
+                            bool failed;
+                            if (bool.TryParse(tag.Value, out failed))
+                            {
+                                telemetry.Success = !failed;
+                                continue; // skip Properties
+                            }
+
+                            break;
+                        }
+
+                    case "http.status_code":
+                        {
+                            telemetry.ResultCode = tag.Value;
+                            continue; // skip Properties
+                        }
+
+                    case "http.method":
+                        {
+                            httpMethodWithSpace = tag.Value + " ";
+                            break;
+                        }
+
+                    case "http.url":
+                        {
+                            httpUrl = tag.Value;
+                            if (Uri.TryCreate(tag.Value, UriKind.RelativeOrAbsolute, out requestUri))
+                            {
+                                continue; // skip Properties
+                            }
+
+                            break;
+                        }
+
+                    case "peer.address":
+                        {
+                            peerAddress = tag.Value;
+                            break;
+                        }
+
+                    case "peer.hostname":
+                        {
+                            telemetry.Target = tag.Value;
+                            continue; // skip Properties
+                        }
+
+                    case "peer.service":
+                        {
+                            peerService = tag.Value;
+                            break;
+                        }
+                }
+
+                // if more than one tag with the same name is specified, the first one wins
+                // TODO verify if still needed once https://github.com/Microsoft/ApplicationInsights-dotnet/issues/562 is resolved 
+                if (!telemetry.Context.Properties.ContainsKey(tag.Key))
+                {
+                    telemetry.Context.Properties.Add(tag);
+                }
+            }
+
+            if (string.IsNullOrEmpty(telemetry.Type))
+            {
+                telemetry.Type = peerService ?? component ?? diagnosticListener.Name;
+            }
+
+            if (string.IsNullOrEmpty(telemetry.Target))
+            {
+                // 'peer.address' can be not user-friendly, thus use only if nothing else specified
+                telemetry.Target = requestUri?.Host ?? peerAddress;
+            }
+
+            if (string.IsNullOrEmpty(telemetry.Name))
+            {
+                telemetry.Name = currentActivity.OperationName;
+            }
+
+            if (string.IsNullOrEmpty(telemetry.Data))
+            {
+                telemetry.Data = queryStatement ?? requestUri?.OriginalString ?? httpUrl;
+            }
+
+            return telemetry;
+        }
+
+        protected override HashSet<string> GetListenerContext(DiagnosticListener diagnosticListener)
+        {
+            HashSet<string> includedActivities;
+            if (!this.includedDiagnosticSourceActivities.TryGetValue(diagnosticListener.Name, out includedActivities))
+            {
+                return null;
+            }
+
+            return includedActivities;
+        }
+
+        private void PrepareInclusionLists(ICollection<string> includeDiagnosticSourceActivities)
+        {
+            if (includeDiagnosticSourceActivities == null)
+            {
+                return;
+            }
+
+            foreach (string inclusion in includeDiagnosticSourceActivities)
+            {
+                if (string.IsNullOrWhiteSpace(inclusion))
+                {
+                    continue;
+                }
+
+                // each individual inclusion can specify
+                // 1) the name of Diagnostic Source 
+                //    - in that case the whole source is included
+                //    - e.g. "System.Net.Http"
+                // 2) the names of Diagnostic Source and Activity separated by ':' 
+                //   - in that case only the activity is enabled from given source
+                //   - e.g. ""
+                string[] tokens = inclusion.Split(':');
+
+                // the Diagnostic Source is included (even if only certain activities are enabled)
+                this.includedDiagnosticSources.Add(tokens[0]);
+
+                if (tokens.Length > 1)
+                {
+                    // only certain Activity from the Diagnostic Source is included
+                    HashSet<string> includedActivities;
+                    if (!this.includedDiagnosticSourceActivities.TryGetValue(tokens[0], out includedActivities))
+                    {
+                        includedActivities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        this.includedDiagnosticSourceActivities[tokens[0]] = includedActivities;
+                    }
+
+                    // include activity and activity Stop events
+                    includedActivities.Add(tokens[1]);
+                    includedActivities.Add(tokens[1] + ActivityStopNameSuffix);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Moving all files to DependencyCollector.Shared and Common projects.
No new files were added to this project!
These files were already in the directory, but not referenced by the project.

New45 and NetCore include both Shared and Common instead of including individual files.
Shared and Common will now conditionally exclude files per framework.