### PR TITLE
bug fix. check if exists before add

### DIFF
--- a/Src/Common/Common.projitems
+++ b/Src/Common/Common.projitems
@@ -10,11 +10,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AppMapCorrelationEventSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ConditionalWeakTableExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CorrelationIdLookupHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HeadersUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ICorrelationIdLookupHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RequestResponseHeaders.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)CorrelationIdLookupHelper.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.6' ">
     <Compile Include="$(MSBuildThisFileDirectory)WebHeaderCollectionExtensions.cs" />

--- a/Src/Common/ConditionalWeakTableExtensions.cs
+++ b/Src/Common/ConditionalWeakTableExtensions.cs
@@ -1,0 +1,21 @@
+﻿namespace Microsoft.ApplicationInsights.Common
+{
+    using System.Runtime.CompilerServices;
+
+    /// <summary>
+    /// Extension methods for the ConditionalWeakTable class.
+    /// </summary>
+    public static class ConditionalWeakTableExtensions
+    {
+        /// <summary>
+        /// Check if a key exists before adding the key/value pair.
+        /// </summary>
+        public static void AddIfNotExists<TKey, TValue>(this ConditionalWeakTable<TKey, TValue> conditionalWeakTable, TKey key, TValue value) where TKey : class where TValue : class
+        {
+            if (!conditionalWeakTable.TryGetValue(key, out TValue testValue))
+            {
+                conditionalWeakTable.Add(key, value);
+            }
+        }
+    }
+}

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
@@ -122,6 +122,12 @@ namespace Microsoft.ApplicationInsights.Tests
         /// Very second request does not throw an exception.
         /// Verify that telemetry is collected for both requests.
         /// </summary>
+        /// <remarks>
+        /// IGNORE
+        /// THE FOLLOWING ASSERTS ARE EXPECTED TO PASS, BUT CURRENTLY FAIL DUE TO A KNOWN ISSUE: #724 
+        /// Because two identical requests were sent, whichever completes first will remove the request from pending telemetry.
+        /// </remarks>
+        [Ignore]
         [TestMethod]
         public void VerifyOnRequestWithDuplicateRequestCreatesValidTelemetry()
         {

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
@@ -104,6 +104,70 @@ namespace Microsoft.ApplicationInsights.Tests
         }
 
         /// <summary>
+        /// Very second request does not throw an exception.
+        /// </summary>
+        [TestMethod]
+        public void VerifyOnRequestWithSameDoesNotThrowException()
+        {
+            Guid loggingRequestId = Guid.NewGuid();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, RequestUrlWithScheme);
+
+            this.listener.OnRequest(request, loggingRequestId);
+            this.listener.OnRequest(request, loggingRequestId);
+        }
+
+        /// <summary>
+        /// Scenario: Assume a retry request after first request fails.
+        /// Very second request does not throw an exception.
+        /// Verify that telemetry is collected for both requests.
+        /// </summary>
+        [TestMethod]
+        public void VerifyOnRequestWithDuplicateRequestCreatesValidTelemetry()
+        {
+            Guid loggingRequestId = Guid.NewGuid();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, RequestUrlWithScheme);
+
+            // first request, expected to fail
+            this.listener.OnRequest(request, loggingRequestId);
+
+            // second request (BEFORE HANDLING FIRST RESPONSE), expected to pass 
+            this.listener.OnRequest(request, loggingRequestId);
+
+            IOperationHolder<DependencyTelemetry> dependency;
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.AreEqual(0, this.sentTelemetry.Count);
+
+            // first request fails
+            HttpResponseMessage response1 = new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = request
+            };
+
+            this.listener.OnResponse(response1, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.AreEqual(1, this.sentTelemetry.Count);
+            Assert.AreEqual(false, ((DependencyTelemetry)this.sentTelemetry.Last()).Success); // first request fails
+
+            Assert.Inconclusive();
+
+            // THE FOLLOWING ASSERTS ARE EXPECTED TO PASS, BUT CURRENTLY FAIL DUE TO A KNOWN ISSUE: #724 
+            // Because two identical requests were sent, whichever completes first will remove the request from pending telemetry.
+
+            // second request is success
+            HttpResponseMessage response2 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                RequestMessage = request
+            };
+
+            this.listener.OnResponse(response2, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.AreEqual(2, this.sentTelemetry.Count);
+            Assert.AreEqual(true, ((DependencyTelemetry)this.sentTelemetry.Last()).Success); // second request is success
+        }
+
+        /// <summary>
         /// Call OnRequest() with uri that is in the excluded domain list.
         /// </summary>
         [TestMethod]

--- a/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
@@ -379,7 +379,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 dependency.Telemetry.Target = requestUri.Host;
                 dependency.Telemetry.Type = RemoteDependencyConstants.HTTP;
                 dependency.Telemetry.Data = requestUri.OriginalString;
-                this.pendingTelemetry.Add(request, dependency);
+                this.pendingTelemetry.AddIfNotExists(request, dependency);
 
                 this.InjectRequestHeaders(request, dependency.Telemetry.Context.InstrumentationKey, true);
             }


### PR DESCRIPTION
#724 
Bug fix for the add if not exists scenario. SDK should not throw an exception.
Enhancement to track both requests will be discussed at a later date.