### PR TITLE
Stabilizing QuickPulseServiceClient tests by adding a request processing sync

### DIFF
--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -1967,8 +1967,11 @@
             try
             {
                 ((IDisposable)this.listener).Dispose();
-                this.assertionSync?.Dispose();
-                this.assertionSync = null;
+                if (this.assertionSync != null)
+                {
+                    this.assertionSync.Dispose();
+                    this.assertionSync = null;
+                }
             }
             catch (Exception)
             {

--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -1967,7 +1967,8 @@
             try
             {
                 ((IDisposable)this.listener).Dispose();
-                Interlocked.Exchange(ref this.assertionSync, null)?.Dispose();
+                this.assertionSync?.Dispose();
+                this.assertionSync = null;
             }
             catch (Exception)
             {

--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -139,7 +139,7 @@
             }
             finally
             {
-                this.assertionSync = null;
+                Interlocked.Exchange(ref this.assertionSync, null)?.Dispose();
             }
         }
 
@@ -1967,6 +1967,7 @@
             try
             {
                 ((IDisposable)this.listener).Dispose();
+                Interlocked.Exchange(ref this.assertionSync, null)?.Dispose();
             }
             catch (Exception)
             {
@@ -2074,7 +2075,9 @@
             Task<bool>[] waitTasks = Enumerable.Range(0, requestCount).Select(_ => Task.Run(() => this.assertionSync.Wait(timeout))).ToArray();
             Task.WhenAll(waitTasks);
 
-            Assert.IsTrue(waitTasks.All(task => task.Result), $"Not all requests finished processing: expected {requestCount}, actual: {waitTasks.Count(task => task.Result)}");
+            Assert.IsTrue(
+                condition: waitTasks.All(task => task.Result), 
+                message: string.Format(CultureInfo.InvariantCulture, "Not all requests finished processing: expected {0}, actual: {1}", requestCount, waitTasks.Count(task => task.Result)));
         }
 
 #endregion

--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -1989,7 +1989,6 @@
             {
                 try
                 {
-
                     HttpListenerContext context = listener.GetContextAsync().GetAwaiter().GetResult();
 
                     var request = context.Request;

--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -8,6 +8,7 @@
     using System.Net;
     using System.Net.Http;
     using System.Runtime.Serialization.Json;
+    using System.Threading;
     using System.Threading.Tasks;
 
     using Microsoft.ApplicationInsights.Extensibility.Filtering;
@@ -57,6 +58,8 @@
         private bool emulateTimeout;
 
         private Random rand = new Random();
+
+        private SemaphoreSlim assertionSync;
 
         public QuickPulseServiceClientTests()
         {
@@ -120,6 +123,7 @@
 
             this.listener.Start();
 
+            this.assertionSync = new SemaphoreSlim(0);
             Task.Factory.StartNew(() => this.ProcessRequest(this.listener));
         }
 
@@ -132,6 +136,10 @@
             }
             catch
             {
+            }
+            finally
+            {
+                this.assertionSync = null;
             }
         }
 
@@ -149,6 +157,9 @@
             serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo);
             serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo);
             serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 3);
 
             // ASSERT
             Assert.AreEqual(3, this.pingCount);
@@ -215,6 +226,9 @@
                 string.Empty,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(true, sendMore);
@@ -287,6 +301,9 @@
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(3, this.samples.Count);
             Assert.IsTrue((timeProvider.UtcNow - this.samples[0].Item1).Duration() < TimeSpan.FromMilliseconds(1));
@@ -324,6 +341,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample1 }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(0.3333, this.samples[0].Item3.Metrics.Single(m => m.Name == @"\ApplicationInsights\Requests Succeeded/Sec").Value);
@@ -370,6 +390,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample1, sample2 }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(3, this.samples[0].Item3.Metrics.Single(m => m.Name == @"\ApplicationInsights\Request Duration").Weight);
@@ -441,6 +464,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual("Request1", ((RequestTelemetryDocument)this.samples[0].Item3.Documents[0]).Name);
             Assert.AreEqual("Prop1", ((RequestTelemetryDocument)this.samples[0].Item3.Documents[0]).Properties.First().Key);
@@ -504,6 +530,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample1, sample2 }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.IsTrue(this.samples[0].Item3.GlobalDocumentQuotaReached);
             Assert.IsFalse(this.samples[1].Item3.GlobalDocumentQuotaReached);
@@ -528,6 +557,9 @@
             CollectionConfigurationInfo configurationInfo;
             bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.IsTrue(response.Value);
         }
@@ -550,6 +582,9 @@
             this.pingResponse = r => { r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString()); };
             CollectionConfigurationInfo configurationInfo;
             bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.IsFalse(response.Value);
@@ -574,6 +609,9 @@
             CollectionConfigurationInfo configurationInfo;
             bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.IsNull(response);
         }
@@ -596,6 +634,9 @@
             this.pingResponse = r => { };
             CollectionConfigurationInfo configurationInfo;
             bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.IsNull(response);
@@ -626,6 +667,9 @@
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.IsTrue(response.Value);
         }
@@ -654,6 +698,9 @@
                 string.Empty,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.IsFalse(response.Value);
@@ -684,6 +731,9 @@
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.IsNull(response);
         }
@@ -713,6 +763,9 @@
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.IsNull(response);
         }
@@ -737,6 +790,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.pingCount);
@@ -768,6 +824,9 @@
                 string.Empty,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.submitCount);
@@ -806,6 +865,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping("ikey", now, "ETag1", string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.IsNull(configurationInfo);
@@ -852,6 +914,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.IsNull(configurationInfo);
         }
@@ -890,6 +955,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping("ikey", now, "ETag1", string.Empty, out configurationInfo);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.IsNotNull(configurationInfo, "configurationInfo should not be null.");
             Assert.AreEqual("ETag2", configurationInfo.ETag);
@@ -899,8 +967,6 @@
         [TestMethod]
         public void QuickPulseServiceClientReadsCollectionConfigurationFromPostWhenETagIsDifferent()
         {
-            // TODO: Stabilize test for NetCore
-#if !NETCORE
             // ARRANGE
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
@@ -939,11 +1005,13 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.IsNotNull(configurationInfo, "configurationInfo should not be null.");
             Assert.AreEqual("ETag2", configurationInfo.ETag);
             Assert.AreEqual("Id1", configurationInfo.Metrics.Single().Id);
-#endif
         }
 
         [TestMethod]
@@ -975,6 +1043,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping("ikey", now, "ETag2", string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.IsNull(configurationInfo);
@@ -1016,6 +1087,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag2", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.IsNull(configurationInfo);
@@ -1081,6 +1155,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             MetricPoint metric1 = this.samples.Single().Item3.Metrics.Single(m => m.Name == "Metric1");
             MetricPoint metric2 = this.samples.Single().Item3.Metrics.Single(m => m.Name == "Metric2");
@@ -1109,6 +1186,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.pings.Count);
@@ -1142,6 +1222,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(instanceName, this.samples[0].Item3.Instance);
@@ -1165,6 +1248,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.pings.Count);
@@ -1198,6 +1284,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(streamId, this.samples[0].Item3.StreamId);
@@ -1221,6 +1310,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.pings.Count);
@@ -1254,6 +1346,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(machineName, this.samples[0].Item3.MachineName);
@@ -1276,6 +1371,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.pings.Count);
@@ -1308,6 +1406,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(4, this.samples[0].Item3.InvariantVersion);
@@ -1331,6 +1432,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping(Guid.NewGuid().ToString(), timeProvider.UtcNow, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.pings.Count);
@@ -1366,6 +1470,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(timeProvider.UtcNow.Ticks, this.samples[0].Item1.Ticks);
@@ -1390,6 +1497,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.pingCount);
@@ -1422,6 +1532,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(version, this.samples[0].Item3.Version);
@@ -1447,6 +1560,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping("some ikey", now, string.Empty, authApiKey, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.pingCount);
@@ -1479,6 +1595,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, authApiKey, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(authApiKey, this.lastAuthApiKey);
@@ -1510,6 +1629,9 @@
 
             // received the proper headers, now re-submit them
             serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 2);
 
             // ASSERT
             Assert.AreEqual(2, this.pingCount);
@@ -1554,6 +1676,9 @@
             // received the proper headers, now re-submit them
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 2);
+
             // ASSERT
             Assert.AreEqual(2, this.samples.Count);
             Assert.AreEqual("x-ms-qps-auth-app-id1", this.lastOpaqueAuthHeaderValues["x-ms-qps-auth-app-id"]);
@@ -1588,6 +1713,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
             serviceClient.Ping(string.Empty, now, "ETag1", string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual("ETag1", this.samples.Single().Item2);
@@ -1638,6 +1766,9 @@
                 out configurationInfo,
                 collectionConfigurationErrors);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(2, this.samples.Single().Item3.CollectionConfigurationErrors.Length);
 
@@ -1680,6 +1811,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(ikey, this.samples[0].Item3.InstrumentationKey);
@@ -1711,6 +1845,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.IsTrue(this.samples[0].Item3.IsWebApp);
@@ -1741,6 +1878,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
@@ -1774,6 +1914,9 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
@@ -1811,6 +1954,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
 
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.IsTrue(this.samples[0].Item3.TopCpuDataAccessDenied);
@@ -1836,19 +1982,22 @@
 
             while (listener.IsListening)
             {
-                HttpListenerContext context = listener.GetContextAsync().GetAwaiter().GetResult();
-
-                var request = context.Request;
-
-                this.lastAuthApiKey = context.Request.Headers[QuickPulseConstants.XMsQpsAuthApiKeyHeaderName];
-                foreach (var headerName in QuickPulseConstants.XMsQpsAuthOpaqueHeaderNames)
+                try
                 {
-                    this.lastOpaqueAuthHeaderValues[headerName] = context.Request.Headers[headerName];
-                }
 
-                switch (request.Url.LocalPath)
-                {
-                    case "/ping":
+                    HttpListenerContext context = listener.GetContextAsync().GetAwaiter().GetResult();
+
+                    var request = context.Request;
+
+                    this.lastAuthApiKey = context.Request.Headers[QuickPulseConstants.XMsQpsAuthApiKeyHeaderName];
+                    foreach (var headerName in QuickPulseConstants.XMsQpsAuthOpaqueHeaderNames)
+                    {
+                        this.lastOpaqueAuthHeaderValues[headerName] = context.Request.Headers[headerName];
+                    }
+
+                    switch (request.Url.LocalPath)
+                    {
+                        case "/ping":
                         {
                             this.pingCount++;
 
@@ -1883,8 +2032,8 @@
                             this.lastVersion = dataPoint.Version;
                         }
 
-                        break;
-                    case "/post":
+                            break;
+                        case "/post":
                         {
                             this.submitCount++;
 
@@ -1901,16 +2050,31 @@
                                     dp => Tuple.Create(new DateTimeOffset(transmissionTime, TimeSpan.Zero), collectionConfigurationETag, dp)));
                         }
 
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException("Unknown request: " + request.Url.LocalPath);
-                }
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException("Unknown request: " + request.Url.LocalPath);
+                    }
 
-                if (!this.emulateTimeout)
+                    if (!this.emulateTimeout)
+                    {
+                        context.Response.Close();
+                    }
+                }
+                finally
                 {
-                    context.Response.Close();
+                    this.assertionSync.Release();
                 }
             }
+        }
+
+        private void WaitForProcessing(int requestCount)
+        {
+            TimeSpan timeout = TimeSpan.FromSeconds(5.0);
+
+            Task<bool>[] waitTasks = Enumerable.Range(0, requestCount).Select(_ => Task.Run(() => this.assertionSync.Wait(timeout))).ToArray();
+            Task.WhenAll(waitTasks);
+
+            Assert.IsTrue(waitTasks.All(task => task.Result), $"Not all requests finished processing: expected {requestCount}, actual: {waitTasks.Count(task => task.Result)}");
         }
 
 #endregion


### PR DESCRIPTION
Fix for intermittently failing QuickPulseServiceClient tests, no issue#, not a significant contribution

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
- [x] Ran atleast all unit tests locally
- [ ] Ran functional tests locally if making major changes.
- [x] The PR will trigger build, unit test, and functional tests automatically. If you are non-Microsoft employee, please
mention any committers to help trigger build.
