### PR TITLE
Increasing QuickPulseServiceClient request processing timeout

### DIFF
--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -23,7 +23,7 @@
     {
         private const string ServiceEndpointPropertyName = "ServiceEndpoint";
 
-        private static readonly TimeSpan RequestProcessingTimeout = TimeSpan.FromSeconds(5.0);
+        private static readonly TimeSpan RequestProcessingTimeout = TimeSpan.FromSeconds(30.0);
 
         /// <summary>
         /// Tuple of (Timestamp, CollectionConfigurationETag, MonitoringDataPoint).

--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -23,6 +23,8 @@
     {
         private const string ServiceEndpointPropertyName = "ServiceEndpoint";
 
+        private static readonly TimeSpan RequestProcessingTimeout = TimeSpan.FromSeconds(5.0);
+
         /// <summary>
         /// Tuple of (Timestamp, CollectionConfigurationETag, MonitoringDataPoint).
         /// </summary>
@@ -2073,7 +2075,7 @@
 
         private void WaitForProcessing(int requestCount)
         {
-            TimeSpan timeout = TimeSpan.FromSeconds(5.0);
+            TimeSpan timeout = QuickPulseServiceClientTests.RequestProcessingTimeout;
 
             Task<bool>[] waitTasks = Enumerable.Range(0, requestCount).Select(_ => Task.Run(() => this.assertionSync.Wait(timeout))).ToArray();
             Task.WhenAll(waitTasks);


### PR DESCRIPTION
Short description of the fix: insignificant change to fix intermittent QuickPulseServiceClient test failures

- [x] I ran all unit tests locally
- [x] CHANGELOG.md updated or do not need to be updated
  - If not tell why: insignificant test change


For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] I ran [functional tests](https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md#functional-tests) locally.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR submitted from fork - mention one of committers to initiate the build for you.
