### PR TITLE
Added more tests in dep collection functionals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Dependency Collector functional tests fail with messages like "Assert.AreEqual f
 	Alternate workaround if you have previously run the tests successfully atleast once - execute the ```dockercleanup.ps1``` from repository root to cleanup any containers from prior runs.
 
 The test code intentionally does not clean up the containers it spun up. This is to enable fast re-runs of the tests. If the WebApp code is changed, then Docker-Compose will detect it, and re-build the container.
-If you want to do clean up all the containers created by the test, execute the ```dockercleanup.ps1``` from repository root.
+If you want to do clean up all the containers created by the test, execute the ```dockercleanup.ps1``` from repository root. This is typically required if tests were aborted in the middle of a run for some reason.
 
 ## Debugging the functional tests.
 It is important to note that since the test application is deployed as a separate process/container, debugging the tests itself will not help debug the application code. A debugger need to be attached

--- a/Test/E2ETests/E2ETests/Test452Base.cs
+++ b/Test/E2ETests/E2ETests/Test452Base.cs
@@ -477,7 +477,7 @@ namespace E2ETests
         }
 
 
-        public void TestSqlDependency(string expectedPrefix, string appname, string path, bool success = true, bool storedProc = false)
+        public void TestSqlDependency(string expectedPrefix, string appname, string path, string expectedData, bool success = true)
         {
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
@@ -487,15 +487,8 @@ namespace E2ETests
                 expectedDependencyTelemetry.ResultCode = "208";
             }
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            if(storedProc)
-            {
-                expectedDependencyTelemetry.Data = TestConstants.WebAppStoredProcedureNameToSql;
-            }
-            else
-            {
-                expectedDependencyTelemetry.Data = (success) ? TestConstants.WebAppFullQueryToSqlSuccess : TestConstants.WebAppFullQueryToSqlException;
-            }
-
+            expectedDependencyTelemetry.Data = expectedData;
+            
             ValidateBasicDependency(Apps[appname].ipAddress, path, expectedDependencyTelemetry,
                 Apps[appname].ikey, 1, expectedPrefix);
         }

--- a/Test/E2ETests/E2ETests/Test452Base.cs
+++ b/Test/E2ETests/E2ETests/Test452Base.cs
@@ -230,6 +230,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = successExpected;
             expectedDependencyTelemetry.ResultCode = resultCodeExpected;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = (successExpected) ? TestConstants.WebAppUrlToWebApiSuccess : TestConstants.WebAppUrlToWebApiException;
 
             ValidateBasicDependency(Apps[appname].ipAddress, path, expectedDependencyTelemetry,
                 Apps[appname].ikey, 1, expectedPrefix);
@@ -246,6 +248,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.ResultCode = "200";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiSuccess;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=httpasynchttpclient", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -256,6 +260,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiSuccess;
 
             // 204 as the webapi does not return anything
             expectedDependencyTelemetry.ResultCode = "204";
@@ -270,6 +276,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "500";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiException;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=httpfailedwithexception", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -280,7 +288,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = false;
-
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToInvalidHost;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToInvalidHost;
             // Failed at DNS means status code not collected
             //expectedDependencyTelemetry.ResultCode = "200";
 
@@ -294,6 +303,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.ResultCode = "200";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiSuccess;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=httpasync1", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -305,6 +316,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "500";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiException;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=failedhttpasync1", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -316,6 +329,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.ResultCode = "200";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiSuccess;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=httpasync2", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -327,6 +342,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "500";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiException;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=failedhttpasync2", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -338,6 +355,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.ResultCode = "200";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiSuccess;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=httpasync3", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -349,6 +368,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "500";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiException;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=failedhttpasync3", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -360,6 +381,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.ResultCode = "200";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiSuccess;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=httpasync4", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -371,6 +394,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "500";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiException;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=failedhttpasync4", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -382,7 +407,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.ResultCode = "200";
-
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiSuccess;
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=httpasyncawait1", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
         }
@@ -393,6 +419,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "500";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToWebApi;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppUrlToWebApiException;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=failedhttpasyncawait1", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -405,7 +433,8 @@ namespace E2ETests
             // Expected type is http instead of AzureTable as type is based on the target url which
             // will be a local url in case of emulator.
             expectedDependencyTelemetry.Type = "Http";
-            expectedDependencyTelemetry.Success = true;            
+            expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetToEmulatorTable;            
 
             // 2 dependency item is expected.
             // 1 from creating table, and 1 from writing data to it.
@@ -420,7 +449,8 @@ namespace E2ETests
             // Expected type is http instead of AzureTable as type is based on the target url which
             // will be a local url in case of emulator.
             expectedDependencyTelemetry.Type = "Http";
-            expectedDependencyTelemetry.Success = true;            
+            expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetToEmulatorQueue;            
 
             // 2 dependency item is expected.
             // 1 from creating queue, and 1 from writing data to it.
@@ -435,7 +465,8 @@ namespace E2ETests
             // Expected type is http instead of AzureTable as type is based on the target url which
             // will be a local url in case of emulator.
             expectedDependencyTelemetry.Type = "Http";
-            expectedDependencyTelemetry.Success = true;            
+            expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetToEmulatorBlob;            
 
             // 2 dependency item is expected.
             // 1 from creating table, and 1 from writing data to it.
@@ -455,6 +486,8 @@ namespace E2ETests
             {
                 expectedDependencyTelemetry.ResultCode = "208";
             }
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (success) ? TestConstants.WebAppFullQueryToSqlSuccess : TestConstants.WebAppFullQueryToSqlException;
 
             ValidateBasicDependency(Apps[appname].ipAddress, path, expectedDependencyTelemetry,
                 Apps[appname].ikey, 1, expectedPrefix);
@@ -465,6 +498,9 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteReaderAsync&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -476,6 +512,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;            
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteReaderAsync&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -486,6 +524,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader0&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -497,6 +537,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader0&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -507,6 +549,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader1&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -518,6 +562,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader1&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -528,6 +574,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader2&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -539,6 +587,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader2&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -549,6 +599,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader3&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -560,6 +612,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader3&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -570,6 +624,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteReader1&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -581,6 +637,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteReader1&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -591,6 +649,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteReader1&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -602,6 +662,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteReader1&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -612,6 +674,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteScalarAsync&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -623,6 +687,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteScalarAsync&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -633,6 +699,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteScalar&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -644,6 +712,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteScalar&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -654,6 +724,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteNonQuery&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -665,6 +737,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteNonQuery&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -675,6 +749,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteNonQueryAsync&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -686,6 +762,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteNonQueryAsync&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -696,6 +774,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteNonQuery0&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -707,6 +787,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteNonQuery0&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -717,6 +799,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteNonQuery2&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -728,6 +812,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteNonQuery2&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -738,6 +824,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccessXML : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteXmlReaderAsync&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -749,6 +837,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteXmlReaderAsync&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -759,6 +849,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccessXML : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteXmlReader&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -770,6 +862,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteXmlReader&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -780,6 +874,8 @@ namespace E2ETests
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccessXML : string.Empty;            
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteXmlReader&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -791,6 +887,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteXmlReader&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -1020,6 +1118,17 @@ namespace E2ETests
                 Assert.AreEqual(expectedDependencyTelemetry.ResultCode, actualDependencyTelemetry.data.baseData.resultCode);
             }
 
+            //Assert.AreEqual(verb + " " + expectedUrl.AbsolutePath, actualDependencyTelemetry.data.baseData.name);
+            if (!string.IsNullOrEmpty(expectedDependencyTelemetry.Target))
+            {
+                Assert.AreEqual(expectedDependencyTelemetry.Target, actualDependencyTelemetry.data.baseData.target);
+            }
+
+            if (!string.IsNullOrEmpty(expectedDependencyTelemetry.Data))
+            {
+                Assert.AreEqual(expectedDependencyTelemetry.Data, actualDependencyTelemetry.data.baseData.data);
+            }
+            
             var depTime = TimeSpan.Parse(actualDependencyTelemetry.data.baseData.duration, CultureInfo.InvariantCulture);            
             if (expectedDependencyTelemetry.Success.HasValue)
             {

--- a/Test/E2ETests/E2ETests/Test452Base.cs
+++ b/Test/E2ETests/E2ETests/Test452Base.cs
@@ -477,7 +477,7 @@ namespace E2ETests
         }
 
 
-        public void TestSqlDependency(string expectedPrefix, string appname, string path, bool success = true)
+        public void TestSqlDependency(string expectedPrefix, string appname, string path, bool success = true, bool storedProc = false)
         {
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
@@ -487,7 +487,14 @@ namespace E2ETests
                 expectedDependencyTelemetry.ResultCode = "208";
             }
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (success) ? TestConstants.WebAppFullQueryToSqlSuccess : TestConstants.WebAppFullQueryToSqlException;
+            if(storedProc)
+            {
+                expectedDependencyTelemetry.Data = TestConstants.WebAppStoredProcedureNameToSql;
+            }
+            else
+            {
+                expectedDependencyTelemetry.Data = (success) ? TestConstants.WebAppFullQueryToSqlSuccess : TestConstants.WebAppFullQueryToSqlException;
+            }
 
             ValidateBasicDependency(Apps[appname].ipAddress, path, expectedDependencyTelemetry,
                 Apps[appname].ikey, 1, expectedPrefix);
@@ -894,7 +901,17 @@ namespace E2ETests
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
         }
 
+        public void TestSqlDependencyStoredProcedureName(string expectedPrefix)
+        {
+            var expectedDependencyTelemetry = new DependencyTelemetry();
+            expectedDependencyTelemetry.Type = "SQL";
+            expectedDependencyTelemetry.Success = true;            
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
+            expectedDependencyTelemetry.Data = TestConstants.WebAppStoredProcedureNameToSql;
 
+            ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteReaderStoredProcedureAsync&storedProcedureName=GetTopTenMessages", expectedDependencyTelemetry,
+                Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
+        }
 
         private async Task ValidateXComponentWebAppToWebApi(string sourceInstanceIp, string targetInstanceIp, string sourcePath,
             RequestTelemetry expectedRequestTelemetrySource,

--- a/Test/E2ETests/E2ETests/net462/Test452OnNet462.cs
+++ b/Test/E2ETests/E2ETests/net462/Test452OnNet462.cs
@@ -410,7 +410,14 @@ namespace E2ETests.Net462
         public void Test452OnNet462_SqlDependencySqlCommandExecuteXmlReaderFailed()
         {
             base.TestSqlDependencySqlCommandExecuteXmlReaderFailed(VersionPrefixSql);
-        }       
+        }
+
+        [TestMethod]
+        [TestCategory("Net452OnNet462")]
+        public void Test452OnNet462_SqlDependencyStoredProcedure()
+        {
+            base.TestSqlDependencyStoredProcedureName(VersionPrefixSql);
+        }
 
         [ClassCleanup]
         public static void MyClassCleanup()

--- a/Test/E2ETests/E2ETests/net462SM/Test452OnNet462SM.cs
+++ b/Test/E2ETests/E2ETests/net462SM/Test452OnNet462SM.cs
@@ -417,6 +417,15 @@ namespace E2ETests.Net462SMSM
             base.TestSqlDependencySqlCommandExecuteXmlReaderFailed(VersionPrefixSql);
         }
 
+        [TestMethod]
+        [TestCategory("Net452OnNet462SM")]
+        public void Test452OnNet462SM_SqlDependencyStoredProcedure()
+        {
+            base.TestSqlDependencyStoredProcedureName(VersionPrefixSql);
+        }
+
+        
+
         [ClassCleanup]
         public static void MyClassCleanup()
         {

--- a/Test/E2ETests/E2ETests/netcore20/TestCore20OnNetCore20.cs
+++ b/Test/E2ETests/E2ETests/netcore20/TestCore20OnNetCore20.cs
@@ -124,7 +124,7 @@ namespace E2ETests.netcore20
         [TestCategory("Core20")]
         public void TestCore20OnNetCore20_SqlCommandExecuteReaderStoredProcedureAsync()
         {
-            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteReaderStoredProcedureAsync&storedProcedureName=GetTopTenMessages&success=true", true);
+            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteReaderStoredProcedureAsync&storedProcedureName=GetTopTenMessages&success=true", true, true);
         }
 
         [ClassCleanup]

--- a/Test/E2ETests/E2ETests/netcore20/TestCore20OnNetCore20.cs
+++ b/Test/E2ETests/E2ETests/netcore20/TestCore20OnNetCore20.cs
@@ -81,50 +81,57 @@ namespace E2ETests.netcore20
         [TestMethod]
         [TestCategory("Core20")]
         public void TestCore20OnNetCore20_SqlExecuteReaderAsync()
-        {
-            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteReaderAsync&success=true");
+        {            
+            var dataExpected = TestConstants.WebAppFullQueryToSqlSuccess;
+            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteReaderAsync&success=true", dataExpected);
         }
 
         [TestMethod]
         [TestCategory("Core20")]
         public void TestCore20OnNetCore20_SqlExecuteScalarAsync()
         {
-            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteScalarAsync&success=true");
+            var dataExpected = TestConstants.WebAppFullQueryToSqlSuccess;
+            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteScalarAsync&success=true", dataExpected);
         }
 
         [TestMethod]
         [TestCategory("Core20")]
         public void TestCore20OnNetCore20_SqlExecuteNonQueryAsync()
         {
-            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteNonQueryAsync&success=true");
+            var dataExpected = TestConstants.WebAppFullQueryToSqlSuccess;
+            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteNonQueryAsync&success=true", dataExpected);
         }
 
         [TestMethod]
         [TestCategory("Core20")]
         public void TestCore20OnNetCore20_SqlExecuteXmlReaderAsync()
         {
-            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteXmlReaderAsync&success=true");
+            var dataExpected = TestConstants.WebAppFullQueryToSqlSuccessXML;
+            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteXmlReaderAsync&success=true", dataExpected);
         }
 
         [TestMethod]
         [TestCategory("Core20")]
         public void TestCore20OnNetCore20_SqlCommandExecuteScalarAsync()
         {
-            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=SqlCommandExecuteScalar&success=true");
+            var dataExpected = TestConstants.WebAppFullQueryCountToSqlSuccess;
+            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=SqlCommandExecuteScalar&success=true", dataExpected);
         }
 
         [TestMethod]
         [TestCategory("Core20")]
         public void TestCore20OnNetCore20_SqlCommandExecuteScalarFailedAsync()
         {
-            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=SqlCommandExecuteScalar&success=false", false);
+            var dataExpected = TestConstants.WebAppFullQueryToSqlException;
+            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=SqlCommandExecuteScalar&success=false", dataExpected, false);
         }
 
         [TestMethod]
         [TestCategory("Core20")]
         public void TestCore20OnNetCore20_SqlCommandExecuteReaderStoredProcedureAsync()
         {
-            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteReaderStoredProcedureAsync&storedProcedureName=GetTopTenMessages&success=true", true, true);
+            var dataExpected = TestConstants.WebAppStoredProcedureNameToSql;
+            base.TestSqlDependency(VersionPrefixSql, AppNameBeingTested, "/external/calls?type=ExecuteReaderStoredProcedureAsync&storedProcedureName=GetTopTenMessages&success=true", dataExpected);
         }
 
         [ClassCleanup]

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/Dependencies.aspx.cs
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/Dependencies.aspx.cs
@@ -24,8 +24,7 @@ namespace E2ETestApp
         public const string InvalidAccountConnectionString = @"Server =sql-server;User Id = sa; Password=thisiswrong";
         public const string InvalidServerConnectionString = @"Server =sql-server-dontexist;User Id = sa; Password=MSDNm4g4z!n4";
         private string SqlQuerySuccess = "WAITFOR DELAY '00:00:00:007';select * from dbo.Messages";
-        private string SqlQueryError = "WAITFOR DELAY '00:00:00:007';SELECT name FROM master.dbo.sysdatabasesunknown";
-        private string SqlStoredProcedureName = "WAITFOR DELAY '00:00:00:007';SELECT name FROM master.dbo.sysdatabases";
+        private string SqlQueryError = "WAITFOR DELAY '00:00:00:007';SELECT name FROM master.dbo.sysdatabasesunknown";        
         public static string EndPointAddressFormat = "http://{0}/api/Data/PushItem";
 
         private const string UrlTestWebApiGetCallTemplate = "http://{0}:80/api/values";

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/Dependencies.aspx.cs
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/Dependencies.aspx.cs
@@ -191,8 +191,14 @@ namespace E2ETestApp
                                         ? SqlQuerySuccess
                                         : SqlQueryError);
                         break;
-                    case "ExecuteReaderStoredProcedureAsync":
-                        SqlCommandHelper.ExecuteReaderAsync(LocalDbConnectionString, SqlStoredProcedureName, CommandType.StoredProcedure);
+                    case "ExecuteReaderStoredProcedureAsync":                        
+                        string storedProcedureName = "GetTopTenMessages";
+                        try
+                        {
+                            storedProcedureName = Request.QueryString["storedProcedureName"];
+                        }
+                        catch (Exception) { }
+                        SqlCommandHelper.ExecuteReaderAsync(LocalDbConnectionString, storedProcedureName, CommandType.StoredProcedure);
                         break;
                     case "TestExecuteReaderTwice":
                         SqlCommandHelper.TestExecuteReaderTwice(LocalDbConnectionString, (success == true)

--- a/Test/E2ETests/TestApps/NetCore20/E2ETestAppCore20/Controllers/ExternalCallsController.cs
+++ b/Test/E2ETests/TestApps/NetCore20/E2ETestAppCore20/Controllers/ExternalCallsController.cs
@@ -44,7 +44,7 @@ namespace E2ETestAppCore20.Controllers
         /// <summary>
         /// Invalid SQL Query.
         /// </summary> 
-        private const string InvalidSqlQueryToApmDatabase = "SELECT TOP 2 * FROM apm.[Database1212121]";
+        private const string InvalidSqlQueryToApmDatabase = "WAITFOR DELAY '00:00:00:007';SELECT name FROM master.dbo.sysdatabasesunknown";
 
         /// <summary>
         /// Label used to identify the query being executed.

--- a/Test/E2ETests/TestConstants/TestConstants.cs
+++ b/Test/E2ETests/TestConstants/TestConstants.cs
@@ -35,5 +35,19 @@ namespace TestUtils.TestConstants
         public const string WebApiFlushPath = "/api/values";
         public const string IngestionFlushPath = "/api/Data/HealthCheck?name=cijo";
 
+        public const string WebAppTargetNameToWebApi = "e2etestwebapi";
+        public const string WebAppTargetNameToInvalidHost = "abcdefzzzzeeeeadadad.com";
+        public const string WebAppUrlToInvalidHost = "http://abcdefzzzzeeeeadadad.com";        
+        public const string WebAppUrlToWebApiSuccess = "http://e2etestwebapi:80/api/values";
+        public const string WebAppUrlToWebApiException = "http://e2etestwebapi:80/api/values/999";
+
+        public const string WebAppTargetNameToSql = "sql-server | dependencytest";
+        public const string WebAppFullQueryToSqlException = "WAITFOR DELAY '00:00:00:007';SELECT name FROM master.dbo.sysdatabasesunknown";
+        public const string WebAppFullQueryToSqlSuccess = "WAITFOR DELAY '00:00:00:007';select * from dbo.Messages";
+        public const string WebAppFullQueryToSqlSuccessXML = "WAITFOR DELAY '00:00:00:007';select * from dbo.Messages FOR XML AUTO";        
+
+        public const string WebAppTargetToEmulatorBlob = "e2etests_azureemulator_1:10000";
+        public const string WebAppTargetToEmulatorQueue = "e2etests_azureemulator_1:10001";
+        public const string WebAppTargetToEmulatorTable = "e2etests_azureemulator_1:10002";        
     }
 }

--- a/Test/E2ETests/TestConstants/TestConstants.cs
+++ b/Test/E2ETests/TestConstants/TestConstants.cs
@@ -44,6 +44,7 @@ namespace TestUtils.TestConstants
         public const string WebAppTargetNameToSql = "sql-server | dependencytest";
         public const string WebAppFullQueryToSqlException = "WAITFOR DELAY '00:00:00:007';SELECT name FROM master.dbo.sysdatabasesunknown";
         public const string WebAppFullQueryToSqlSuccess = "WAITFOR DELAY '00:00:00:007';select * from dbo.Messages";
+        public const string WebAppStoredProcedureNameToSql = "GetTopTenMessages";
         public const string WebAppFullQueryToSqlSuccessXML = "WAITFOR DELAY '00:00:00:007';select * from dbo.Messages FOR XML AUTO";        
 
         public const string WebAppTargetToEmulatorBlob = "e2etests_azureemulator_1:10000";

--- a/Test/E2ETests/TestConstants/TestConstants.cs
+++ b/Test/E2ETests/TestConstants/TestConstants.cs
@@ -44,6 +44,7 @@ namespace TestUtils.TestConstants
         public const string WebAppTargetNameToSql = "sql-server | dependencytest";
         public const string WebAppFullQueryToSqlException = "WAITFOR DELAY '00:00:00:007';SELECT name FROM master.dbo.sysdatabasesunknown";
         public const string WebAppFullQueryToSqlSuccess = "WAITFOR DELAY '00:00:00:007';select * from dbo.Messages";
+        public const string WebAppFullQueryCountToSqlSuccess = "WAITFOR DELAY '00:00:00:007';select count(*) from dbo.Messages";        
         public const string WebAppStoredProcedureNameToSql = "GetTopTenMessages";
         public const string WebAppFullQueryToSqlSuccessXML = "WAITFOR DELAY '00:00:00:007';select * from dbo.Messages FOR XML AUTO";        
 


### PR DESCRIPTION
No code change. Added more tests in dep tests functional. This was left out when moving to new infra

Short description of the fix:

- [x] I ran all unit tests locally
- [x] CHANGELOG.md updated or do not need to be updated
  - If not tell why: 


For significant contributions please make sure you have completed the following items:

- [x] Changes in public surface reviewed
- [x] I ran [functional tests](https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md#functional-tests) locally.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR submitted from fork - mention one of committers to initiate the build for you.
