### PR TITLE
fix synthetic user agent null check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.5.0-beta2
 - [Track requests and dependencies from ServiceBus .NET Client 2.1.0](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/740)
 - [Fix for REST API Request filter bug](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/175)
+- [Fix for SyntheticUserAgentTelemetryInitializer null check](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/750)
 
 ## Version 2.5.0-beta1
 - Removed `net40` targets from all packages. Use the version 2.4 of SDK if your application is still compiled with the framework 4.0.

--- a/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
+++ b/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
@@ -59,9 +59,9 @@
                     else
                     {
                         var request = platformContext.GetRequest();
-                        string userAgent = request.UserAgent;
-                        if (request != null && !string.IsNullOrEmpty(userAgent))
-                        {
+                        string userAgent = request?.UserAgent;
+                        if (!string.IsNullOrEmpty(userAgent))
+                        { 
                             // We expect customers to configure telemetry initializer before they add it to active configuration
                             // So we will not protect filterPatterns array with locks (to improve perf)                            
                             for (int i = 0; i < this.filterPatterns.Length; i++)


### PR DESCRIPTION
Fix issue #750 .

Short description of the fix:
Performing a null check before reading variable.

- [x] I ran all unit tests locally
- [x] CHANGELOG.md updated 
