### PR TITLE
Fix Service Bus .NET Client version in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 2.5.0-beta2
 - [Fix: When debugging netcoreapp2.0 in VS, http dependencies are tracked twice](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/723)
 - [Fix: DependencyCollector check if exits before add](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/724)
-- [Track requests and dependencies from ServiceBus .NET Client (Microsoft.Azure.ServiceBus 2.1.0](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/740)
+- [Track requests and dependencies from ServiceBus .NET Client (Microsoft.Azure.ServiceBus 3.0.0](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/740)
 - [Fix: REST API Request filter bug](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/175)
 - [Fix: SyntheticUserAgentTelemetryInitializer null check](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/750)
 - [Track dependencies from EventHubs .NET Client (Microsoft.Azure.EventHubs 1.1.0)](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/753)


### PR DESCRIPTION
Service Bus .NET client 3.0.0 was released on the last week. It has diagnosticsource instrumentation.
However, CHANGELOG mentions version 2.1.0.

This change just fixes the version.