### PR TITLE
Fix flaky test: Checking number or RequestTelemetry items sent

### DIFF
--- a/Test/Web/FunctionalTests/FunctionalTests/TestsRequestTelemetryFw45AspxIntegratedWebSecurityOn.cs
+++ b/Test/Web/FunctionalTests/FunctionalTests/TestsRequestTelemetryFw45AspxIntegratedWebSecurityOn.cs
@@ -9,6 +9,7 @@ namespace Functional
 {
     using System.Diagnostics;
     using System.IO;
+    using System.Linq;
     using System.Net;
 
     using Helpers;
@@ -96,9 +97,9 @@ namespace Functional
 
             //// Validating telemetry results
             const int TimeToListenToEvents = 15000;
-            var items = Listener.ReceiveAllItemsDuringTime(TimeToListenToEvents);
+            var items = Listener.ReceiveAllItemsDuringTime(TimeToListenToEvents).Where(i => i is AI.TelemetryItem<AI.RequestData>);
 
-            Assert.AreEqual(1, items.Length, "Unexpected count of events received: expected 1 request");
+            Assert.AreEqual(1, items.Count(), "Unexpected count of request events received: expected 1 request");
         }
     }
 }


### PR DESCRIPTION
Fixing `TestCustomSecuirtyDenyAllRequestCollecting` functional test

During test run https://mseng.visualstudio.com/AppInsights/_build/index?buildId=4700089&_a=summary
it got Metric in addition to Request and failed because it expects just one item.

Changed the test to check number of request telemetry items received.

```
=>
Item received: {"name":"Microsoft.ApplicationInsights.fafa4b1003d34bb098f4364f0bdf5df8.Request","time":"2017-12-19T01:20:49.3977085Z","iKey":"fafa4b10-03d3-4bb0-98f4-364f0bdf5df8","tags":{"ai.cloud.roleInstance":"AI-WEBSDK-TEST1.redmond.corp.microsoft.com","ai.operation.id":"/eg3KT1eOSA=","ai.operation.name":"GET /SyncWebForm.aspx","ai.internal.sdkVersion":"web:2.5.0-36493","ai.internal.nodeName":"AI-WEBSDK-TEST1.redmond.corp.microsoft.com"},"data":{"baseType":"RequestData","baseData":{"ver":2,"id":"|/eg3KT1eOSA=.5dac3e46_","name":"GET /SyncWebForm.aspx","duration":"00:00:00.0736778","success":true,"responseCode":"401","url":"http://localhost:31337/SyncWebForm.aspx","properties":{"_MS.ProcessedByMetricExtractors":"(Name:'Requests', Ver:'1.0')"}}}}
<=
......
Item received: {"name":"Microsoft.ApplicationInsights.fafa4b1003d34bb098f4364f0bdf5df8.Metric","time":"2017-12-19T01:20:01.0097077Z","iKey":"fafa4b10-03d3-4bb0-98f4-364f0bdf5df8","tags":{"ai.cloud.roleInstance":"AI-WEBSDK-TEST1.redmond.corp.microsoft.com","ai.internal.sdkVersion":"m-agg:2.5.0-44811"},"data":{"baseType":"MetricData","baseData":{"ver":2,"metrics":[{"name":"Server response time","kind":"Aggregation","value":73.6778,"count":1,"min":73.6778,"max":73.6778,"stdDev":0}],"properties":{"_MS.MetricId":"requests/duration","_MS.IsAutocollected":"True","_MS.AggregationIntervalMs":"11987","Request.Success":"True"}}}}
<=
```