### PR TITLE
add separate fetchers for rollback and commit message data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## Version 2.5.0
+- [Fix: System.InvalidCastException for SOL Dependency](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/782)
+
+
 ## Version 2.5.0-beta2
 - [Fix: When debugging netcoreapp2.0 in VS, http dependencies are tracked twice](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/723)
 - [Fix: DependencyCollector check if exits before add](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/724)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## Version 2.5.0
-- [Fix: System.InvalidCastException for SOL Dependency](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/782)
+- [Fix: System.InvalidCastException for SQL Dependency](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/782)
 
 
 ## Version 2.5.0-beta2

--- a/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
@@ -510,6 +510,7 @@ namespace Microsoft.ApplicationInsights.Tests
                 OperationId = operationId,
                 Operation = "Rollback",
                 IsolationLevel = IsolationLevel.Snapshot,
+                TransactionName = "testTransactionName",
                 Connection = sqlConnection,
                 Timestamp = 1000000L
             };


### PR DESCRIPTION
Fix issue #782  .

Short description of the fix:
SqlClient is including a TransactionName property in transaction rollback messages (but not in transaction commit messages). Added a separate “fetchers” for the rollback message data.

- [x] I ran all unit tests locally
- [x] CHANGELOG.md updated 


