### PR TITLE
Add more context into ActivityIsNull logging

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -248,7 +248,7 @@
 
         [Event(
             23,
-            Message = "Current Activity is null",
+            Message = "Current Activity is null for event = '{0}'",
             Level = EventLevel.Error)]
         public void CurrentActivityIsNull(string diagnosticsSourceEventName, string appDomainName = "Incorrect")
         {

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -250,9 +250,9 @@
             23,
             Message = "Current Activity is null",
             Level = EventLevel.Error)]
-        public void CurrentActivityIsNull(string appDomainName = "Incorrect")
+        public void CurrentActivityIsNull(string diagnosticsSourceEventName, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(23, this.ApplicationName);
+            this.WriteEvent(23, diagnosticsSourceEventName, this.ApplicationName);
         }
 
         [Event(

--- a/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
@@ -150,18 +150,18 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
             public void OnNext(KeyValuePair<string, object> evnt)
             {
-                Activity currentActivity = Activity.Current;
-                if (currentActivity == null)
-                {
-                    DependencyCollectorEventSource.Log.CurrentActivityIsNull();
-                    return;
-                }
-
                 // while we provide IsEnabled callback during subscription, it does not gurantee events will not be fired
                 // In case of multiple subscribers, it's enough for one to reply true to IsEnabled.
                 // I.e. check for if activity is not disabled and particular handler wants to receive the event.
                 if (this.telemetryDiagnosticSourceListener.IsActivityEnabled(evnt.Key, this.Context) && this.eventHandler.IsEventEnabled(evnt.Key, null, null))
                 {
+                    Activity currentActivity = Activity.Current;
+                    if (currentActivity == null)
+                    {
+                        DependencyCollectorEventSource.Log.CurrentActivityIsNull(evnt.Key);
+                        return;
+                    }
+
                     DependencyCollectorEventSource.Log.TelemetryDiagnosticSourceListenerEvent(evnt.Key, currentActivity.Id);
 
                     try


### PR DESCRIPTION
Fix issue #799 

A couple of cases where `AI (Internal): Current Activity is null`  may be valid and do not indicate any issue. It is also useless and confusing:
1. HTTP call to AI backed fires exception (times out or experience any network issues), the Exception event is ignored, but before that, Activity is checked for null and `AI (Internal): Current Activity is null` is written.

2. Custom activity for generic diagnostic listener is not enabled and some DS event happens - Activity will be null

So this change moves check for null Activity after check for an event being enabled thus removing unnecessary logging.

In case an event is enabled, we definitely must have Activity.Current, so this message from now on indicates that there is actually a problem, so I've added a bit more context to the log - DS event name.

- [x] I ran all unit tests locally
- [ ] CHANGELOG.md updated or do not need to be updated
  - If not tell why: 
Change affects internal logging only, nothing changes for the customer
