### PR TITLE
add fxcop analyzer (help needed)

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -12,7 +12,8 @@
     <StyleCopEnabled>True</StyleCopEnabled>
     <StyleCopTreatErrorsAsWarnings>False</StyleCopTreatErrorsAsWarnings>
     <CodeAnalysisRuleSet>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'ApplicationInsightsSDKRules.ruleset'))\ApplicationInsightsSDKRules.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <!-- Need to disable WarningsAsErrors until all FxCop issues are fixed. -->
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
@@ -26,7 +27,8 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <RunCodeAnalysis>true</RunCodeAnalysis>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Need to disable WarningsAsErrors until all FxCop issues are fixed. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 

--- a/Src/Common/AppMapCorrelationEventSource.cs
+++ b/Src/Common/AppMapCorrelationEventSource.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Common
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
 #if NETSTANDARD1_6
     using System.Reflection;
@@ -11,6 +12,8 @@
     /// ETW EventSource tracing class.
     /// </summary>
     //// [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation")] - EVERY COMPONENT SHOULD DEFINE IT"S OWN NAME
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
+
     internal sealed partial class AppMapCorrelationEventSource : EventSource
     {
         public static readonly AppMapCorrelationEventSource Log = new AppMapCorrelationEventSource();

--- a/Src/Common/AppMapCorrelationEventSource.cs
+++ b/Src/Common/AppMapCorrelationEventSource.cs
@@ -13,7 +13,6 @@
     /// </summary>
     //// [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation")] - EVERY COMPONENT SHOULD DEFINE IT"S OWN NAME
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
-
     internal sealed partial class AppMapCorrelationEventSource : EventSource
     {
         public static readonly AppMapCorrelationEventSource Log = new AppMapCorrelationEventSource();

--- a/Src/DependencyCollector/Net45/packages.config
+++ b/Src/DependencyCollector/Net45/packages.config
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.8.0-beta1" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.6.1" targetFramework="net45" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -32,6 +32,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0-beta1" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
     using System.Globalization;
 #if NETSTANDARD1_6
@@ -12,6 +13,8 @@
     /// ETW EventSource tracing class.
     /// </summary>
     [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-DependencyCollector")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
+
     internal sealed class DependencyCollectorEventSource : EventSource
     {
         public static readonly DependencyCollectorEventSource Log = new DependencyCollectorEventSource();

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -14,7 +14,6 @@
     /// </summary>
     [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-DependencyCollector")]
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
-
     internal sealed class DependencyCollectorEventSource : EventSource
     {
         public static readonly DependencyCollectorEventSource Log = new DependencyCollectorEventSource();

--- a/Src/DependencyCollector/Shared/Implementation/Operation/ObjectInstanceBasedOperationHolder.cs
+++ b/Src/DependencyCollector/Shared/Implementation/Operation/ObjectInstanceBasedOperationHolder.cs
@@ -13,7 +13,7 @@
         {
             if (holderInstance == null)
             {
-                throw new ArgumentNullException("holderInstance");
+                throw new ArgumentNullException(nameof(holderInstance));
             }
 
             Tuple<DependencyTelemetry, bool> result = null;
@@ -29,7 +29,7 @@
         {
             if (holderInstance == null)
             {
-                throw new ArgumentNullException("holderInstance");
+                throw new ArgumentNullException(nameof(holderInstance));
             }
 
             return this.weakTableForCorrelation.Remove(holderInstance);
@@ -39,12 +39,12 @@
         {
             if (holderInstance == null)
             {
-                throw new ArgumentNullException("holderInstance");
+                throw new ArgumentNullException(nameof(holderInstance));
             }
 
             if (telemetryTuple == null)
             {
-                throw new ArgumentNullException("telemetryTuple");
+                throw new ArgumentNullException(nameof(telemetryTuple));
             }
 
             this.weakTableForCorrelation.Add(holderInstance, telemetryTuple);

--- a/Src/DependencyCollector/Shared/SanitizedHostList.cs
+++ b/Src/DependencyCollector/Shared/SanitizedHostList.cs
@@ -100,7 +100,7 @@
         {
             if (string.IsNullOrEmpty(hostName))
             {
-                throw new ArgumentNullException("hostName");
+                throw new ArgumentNullException(nameof(hostName));
             }
 
             if (!this.Contains(hostName))

--- a/Src/HostingStartup/HostingStartup.Net45/packages.config
+++ b/Src/HostingStartup/HostingStartup.Net45/packages.config
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.8.0-beta1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.6.1" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />

--- a/Src/PerformanceCollector/Net45/packages.config
+++ b/Src/PerformanceCollector/Net45/packages.config
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.8.0-beta1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.6.1" targetFramework="net45" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/PerformanceCollector/NetCore/Perf.NetCore.csproj
+++ b/Src/PerformanceCollector/NetCore/Perf.NetCore.csproj
@@ -29,6 +29,10 @@
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0-beta1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />

--- a/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCollectorEventSource.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCollectorEventSource.cs
@@ -1,10 +1,13 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
     using System.Reflection;
 
     [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
+
     internal sealed class PerformanceCollectorEventSource : EventSource
     {
         private static readonly PerformanceCollectorEventSource Logger = new PerformanceCollectorEventSource();

--- a/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCollectorEventSource.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCollectorEventSource.cs
@@ -7,7 +7,6 @@
 
     [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector")]
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
-
     internal sealed class PerformanceCollectorEventSource : EventSource
     {
         private static readonly PerformanceCollectorEventSource Logger = new PerformanceCollectorEventSource();

--- a/Src/PerformanceCollector/Perf.Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -7,7 +7,6 @@
 
     [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector-QuickPulse")]
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
-
     internal sealed class QuickPulseEventSource : EventSource
     {
         private static readonly QuickPulseEventSource Logger = new QuickPulseEventSource();

--- a/Src/PerformanceCollector/Perf.Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -1,10 +1,13 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
     using System.Reflection;
 
     [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector-QuickPulse")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
+
     internal sealed class QuickPulseEventSource : EventSource
     {
         private static readonly QuickPulseEventSource Logger = new QuickPulseEventSource();

--- a/Src/PerformanceCollector/Perf.Shared/PerformanceCollectorModule.cs
+++ b/Src/PerformanceCollector/Perf.Shared/PerformanceCollectorModule.cs
@@ -148,7 +148,7 @@
 
                         if (configuration == null)
                         {
-                            throw new ArgumentNullException("configuration");
+                            throw new ArgumentNullException(nameof(configuration));
                         }
 
                         if (!this.defaultCountersInitialized)

--- a/Src/Web/Web.Net45/packages.config
+++ b/Src/Web/Web.Net45/packages.config
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.8.0-beta1" targetFramework="net45" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.6.1" targetFramework="net45" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/WindowsServer/WindowsServer.Net45/packages.config
+++ b/Src/WindowsServer/WindowsServer.Net45/packages.config
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.8.0-beta1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.6.1" targetFramework="net45" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/WindowsServer/WindowsServer.NetCore/WindowsServer.NetCore.csproj
+++ b/Src/WindowsServer/WindowsServer.NetCore/WindowsServer.NetCore.csproj
@@ -29,6 +29,10 @@
 
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0-beta1" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />

--- a/Src/WindowsServer/WindowsServer.Shared/BuildInfoConfigComponentVersionTelemetryInitializer.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/BuildInfoConfigComponentVersionTelemetryInitializer.cs
@@ -30,7 +30,7 @@
         {
             if (telemetry == null)
             {
-                throw new ArgumentNullException("telemetry");
+                throw new ArgumentNullException(nameof(telemetry));
             }
 
             if (telemetry.Context != null && telemetry.Context.Component != null)

--- a/Src/WindowsServer/WindowsServer.Shared/Implementation/WindowsServerEventSource.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/Implementation/WindowsServerEventSource.cs
@@ -9,7 +9,6 @@
     /// </summary>
     [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-WindowsServer")]
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
-
     internal sealed class WindowsServerEventSource : EventSource
     {
         /// <summary>

--- a/Src/WindowsServer/WindowsServer.Shared/Implementation/WindowsServerEventSource.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/Implementation/WindowsServerEventSource.cs
@@ -1,12 +1,15 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.Implementation
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
 
     /// <summary>
     /// ETW EventSource tracing class.
     /// </summary>
     [EventSource(Name = "Microsoft-ApplicationInsights-Extensibility-WindowsServer")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
+
     internal sealed class WindowsServerEventSource : EventSource
     {
         /// <summary>


### PR DESCRIPTION
Add the FxCop Analyzer to Non-Test projects.

This analyzer identifies **SEVERAL** compiler errors. 
If you're bored one afternoon, feel free to pull this branch and fix a couple! :)

![dreamwork](https://user-images.githubusercontent.com/28785781/37181041-45284c68-22e0-11e8-8c5c-fc0322876351.jpg)
