### PR TITLE
Add Heartbeat feature http request e2e tests

### DIFF
--- a/Src/WindowsServer/WindowsServer.Shared.Tests/AzureInstanceMetadataEndToEndTests.cs
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/AzureInstanceMetadataEndToEndTests.cs
@@ -1,0 +1,134 @@
+namespace Microsoft.ApplicationInsights.WindowsServer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net.Http;
+    using System.Runtime.Serialization.Json;
+    using System.Text;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.WindowsServer.Implementation;
+    using Microsoft.ApplicationInsights.WindowsServer.Implementation.DataContracts;
+    using Microsoft.ApplicationInsights.WindowsServer.Mock;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Assert = Xunit.Assert;
+
+    [TestClass]
+    public class AzureInstanceMetadataEndToEndTests
+    {
+        private AzureInstanceComputeMetadata Data { get; set; }
+        private MemoryStream JsonStream;
+
+        public AzureInstanceMetadataEndToEndTests()
+        {
+            this.Data = new AzureInstanceComputeMetadata()
+            {
+                Location = "US-West",
+                Name = "test-vm01",
+                Offer = "D9_USWest",
+                OsType = "Linux",
+                PlacementGroupId = "placement-grp",
+                PlatformFaultDomain = "0",
+                PlatformUpdateDomain = "0",
+                Publisher = "Microsoft",
+                ResourceGroupName = "test.resource-group_01",
+                Sku = "Windows_10",
+                SubscriptionId = Guid.NewGuid().ToString(),
+                Tags = "thisTag;thatTag",
+                Version = "10.8a",
+                VmId = Guid.NewGuid().ToString(),
+                VmSize = "A8"
+            };
+
+            DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(AzureInstanceComputeMetadata));
+            this.JsonStream = new MemoryStream();
+            serializer.WriteObject(this.JsonStream, this.Data);
+        }
+
+        [TestMethod]
+        public void SpoofedResponseFromAzureIMSDoesntCrash()
+        {
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            string mockUri = "http://localhost:9922/";
+
+            using (new LocalServer(mockUri, (HttpListenerContext context) =>
+            {
+                HttpListenerResponse response = context.Response;
+
+                // Construct a response.
+                response.ContentEncoding = Encoding.UTF8;
+                // Get a response stream and write the response to it.
+                this.JsonStream.Position = 0;
+                response.ContentLength64 = (int)this.JsonStream.Length;
+                this.JsonStream.Position = 0;
+                context.Response.ContentType = "application/json";
+                this.JsonStream.WriteTo(context.Response.OutputStream);
+                context.Response.StatusCode = 200;
+            }))
+            {
+                var azIms = new AzureMetadataRequestor
+                {
+                    BaseAimsUri = mockUri
+                };
+
+                var azImsProps = new AzureComputeMetadataHeartbeatPropertyProvider();
+                var azureIMSData = azIms.GetAzureComputeMetadataAsync();
+                azureIMSData.Wait();
+
+                foreach (string fieldName in azImsProps.ExpectedAzureImsFields)
+                {
+                    string fieldValue = azureIMSData.Result.GetValueForField(fieldName);
+                    Assert.NotNull(fieldValue);
+                    Assert.Equal(fieldValue, this.Data.GetValueForField(fieldName));
+                }
+            }
+        }
+
+        class LocalServer : IDisposable
+        {
+            private readonly HttpListener listener;
+            private readonly CancellationTokenSource cts;
+
+            public LocalServer(string url, Action<HttpListenerContext> onRequest = null)
+            {
+                this.listener = new HttpListener();
+                this.listener.Prefixes.Add(url);
+                this.listener.Start();
+                this.cts = new CancellationTokenSource();
+
+                Task.Run(
+                    () =>
+                    {
+                        if (!this.cts.IsCancellationRequested)
+                        {
+                            HttpListenerContext context = this.listener.GetContext();
+                            if (onRequest != null)
+                            {
+                                onRequest(context);
+                            }
+                            else
+                            {
+                                context.Response.StatusCode = 200;
+                            }
+
+                            context.Response.OutputStream.Close();
+                            context.Response.Close();
+                        }
+                    },
+                    this.cts.Token);
+            }
+
+            public void Dispose()
+            {
+                this.cts.Cancel(false);
+                this.listener.Abort();
+                ((IDisposable)this.listener).Dispose();
+                this.cts.Dispose();
+            }
+        }
+
+    }
+}

--- a/Src/WindowsServer/WindowsServer.Shared.Tests/AzureInstanceMetadataEndToEndTests.cs
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/AzureInstanceMetadataEndToEndTests.cs
@@ -12,67 +12,38 @@ namespace Microsoft.ApplicationInsights.WindowsServer
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Assert = Xunit.Assert;
 
+    /// <summary>
+    /// Tests the heartbeat functionality through actual local-only Http calls to mimic
+    /// end to end functionality as closely as possible.
+    /// </summary>
     [TestClass]
     public class AzureInstanceMetadataEndToEndTests
     {
-        private MemoryStream jsonStream;
-
-        public AzureInstanceMetadataEndToEndTests()
-        {
-            this.TestComputeMetadata = new AzureInstanceComputeMetadata()
-            {
-                Location = "US-West",
-                Name = "test-vm01",
-                Offer = "D9_USWest",
-                OsType = "Linux",
-                PlacementGroupId = "placement-grp",
-                PlatformFaultDomain = "0",
-                PlatformUpdateDomain = "0",
-                Publisher = "Microsoft",
-                ResourceGroupName = "test.resource-group_01",
-                Sku = "Windows_10",
-                SubscriptionId = Guid.NewGuid().ToString(),
-                Tags = "thisTag;thatTag",
-                Version = "10.8a",
-                VmId = Guid.NewGuid().ToString(),
-                VmSize = "A8"
-            };
-
-            DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(AzureInstanceComputeMetadata));
-            this.jsonStream = new MemoryStream();
-            serializer.WriteObject(this.jsonStream, this.TestComputeMetadata);
-        }
-
-        private AzureInstanceComputeMetadata TestComputeMetadata { get; set; }
+        internal const string MockTestUri = "http://localhost:9922/";
 
         [TestMethod]
         public void SpoofedResponseFromAzureIMSDoesntCrash()
         {
             CancellationTokenSource cts = new CancellationTokenSource();
-
-            string mockUri = "http://localhost:9922/";
+            var testMetadata = this.GetTestMetadata();
 
             using (new AzureInstanceMetadataServiceMock(
-                mockUri, 
+                AzureInstanceMetadataEndToEndTests.MockTestUri, 
                 (HttpListenerContext context) =>
             {
                 HttpListenerResponse response = context.Response;
-
-                // Construct a response.
-                response.ContentEncoding = Encoding.UTF8;
-
-                // Get a response stream and write the response to it.
-                this.jsonStream.Position = 0;
-                response.ContentLength64 = (int)this.jsonStream.Length;
-                this.jsonStream.Position = 0;
-                context.Response.ContentType = "application/json";
-                this.jsonStream.WriteTo(context.Response.OutputStream);
                 context.Response.StatusCode = 200;
+
+                response.ContentEncoding = Encoding.UTF8;
+                var jsonStream = this.GetTestMetadataStream(testMetadata);
+                response.ContentLength64 = (int)jsonStream.Length;
+                context.Response.ContentType = "application/json";
+                jsonStream.WriteTo(context.Response.OutputStream);
             }))
             {
                 var azureIms = new AzureMetadataRequestor
                 {
-                    BaseAimsUri = mockUri
+                    BaseAimsUri = AzureInstanceMetadataEndToEndTests.MockTestUri
                 };
 
                 var azureImsProps = new AzureComputeMetadataHeartbeatPropertyProvider();
@@ -83,7 +54,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer
                 {
                     string fieldValue = azureIMSData.Result.GetValueForField(fieldName);
                     Assert.NotNull(fieldValue);
-                    Assert.Equal(fieldValue, this.TestComputeMetadata.GetValueForField(fieldName));
+                    Assert.Equal(fieldValue, testMetadata.GetValueForField(fieldName));
                 }
             }
         }
@@ -93,35 +64,30 @@ namespace Microsoft.ApplicationInsights.WindowsServer
         {
             CancellationTokenSource cts = new CancellationTokenSource();
 
-            string mockUri = "http://localhost:9922/";
-
             using (new AzureInstanceMetadataServiceMock(
-                mockUri, 
+                AzureInstanceMetadataEndToEndTests.MockTestUri, 
                 (HttpListenerContext context) =>
             {
                 HttpListenerResponse response = context.Response;
+                context.Response.StatusCode = 200;
 
                 // Construct a response just like in the positive test but triple it.
                 response.ContentEncoding = Encoding.UTF8;
 
                 // Get a response stream and write the response to it.
-                this.jsonStream.Position = 0;
-                response.ContentLength64 = 3 * (int)this.jsonStream.Length;
-                this.jsonStream.Position = 0;
+                var jsonStream = this.GetTestMetadataStream();
+                response.ContentLength64 = 3 * (int)jsonStream.Length;
                 context.Response.ContentType = "application/json";
-
-                this.jsonStream.WriteTo(context.Response.OutputStream);
-                this.jsonStream.Position = 0;
-                this.jsonStream.WriteTo(context.Response.OutputStream);
-                this.jsonStream.Position = 0;
-                this.jsonStream.WriteTo(context.Response.OutputStream);
-
-                context.Response.StatusCode = 200;
+                jsonStream.WriteTo(context.Response.OutputStream);
+                jsonStream.Position = 0;
+                jsonStream.WriteTo(context.Response.OutputStream);
+                jsonStream.Position = 0;
+                jsonStream.WriteTo(context.Response.OutputStream);
             }))
             {
                 var azureIms = new AzureMetadataRequestor
                 {
-                    BaseAimsUri = mockUri
+                    BaseAimsUri = AzureInstanceMetadataEndToEndTests.MockTestUri
                 };
 
                 var azureIMSData = azureIms.GetAzureComputeMetadataAsync();
@@ -136,35 +102,29 @@ namespace Microsoft.ApplicationInsights.WindowsServer
         {
             CancellationTokenSource cts = new CancellationTokenSource();
 
-            string mockUri = "http://localhost:9922/";
-
             using (new AzureInstanceMetadataServiceMock(
-                mockUri, 
+                AzureInstanceMetadataEndToEndTests.MockTestUri, 
                 (HttpListenerContext context) =>
             {
                 HttpListenerResponse response = context.Response;
+                context.Response.StatusCode = 200;
 
-                var malformedData = this.TestComputeMetadata;
+                // make it a malicious-ish response...
+                var malformedData = this.GetTestMetadata();
                 malformedData.Name = "Not allowed for VM names";
                 malformedData.ResourceGroupName = "Not allowed for resource group name";
                 malformedData.SubscriptionId = "Definitely-not-a GUID up here";
-                var serializer = new DataContractJsonSerializer(typeof(AzureInstanceComputeMetadata));
-                var malformedJsonStream = new MemoryStream();
-                serializer.WriteObject(malformedJsonStream, malformedData);
+                var malformedJsonStream = this.GetTestMetadataStream(malformedData);
 
-                // Construct a response just like in the positive test but triple it.
                 response.ContentEncoding = Encoding.UTF8;
-
-                // Get a response stream and write the response to it.
                 response.ContentLength64 = (int)malformedJsonStream.Length;
                 context.Response.ContentType = "application/json";
                 malformedJsonStream.WriteTo(context.Response.OutputStream);
-                context.Response.StatusCode = 200;
             }))
             {
                 var azureIms = new AzureMetadataRequestor
                 {
-                    BaseAimsUri = mockUri
+                    BaseAimsUri = AzureInstanceMetadataEndToEndTests.MockTestUri
                 };
 
                 var azureImsProps = new AzureComputeMetadataHeartbeatPropertyProvider(azureIms);
@@ -183,32 +143,26 @@ namespace Microsoft.ApplicationInsights.WindowsServer
         {
             CancellationTokenSource cts = new CancellationTokenSource();
 
-            string mockUri = "http://localhost:9922/";
-
             using (new AzureInstanceMetadataServiceMock(
-                mockUri, 
+                AzureInstanceMetadataEndToEndTests.MockTestUri, 
                 (HttpListenerContext context) =>
             {
                 // wait for longer than the request timeout
                 System.Threading.Thread.Sleep(TimeSpan.FromSeconds(5));
 
                 HttpListenerResponse response = context.Response;
-
-                // Construct a response just like in the positive test but triple it.
-                response.ContentEncoding = Encoding.UTF8;
-
-                // Get a response stream and write the response to it.
-                this.jsonStream.Position = 0;
-                response.ContentLength64 = (int)this.jsonStream.Length;
-                context.Response.ContentType = "application/json";
-                this.jsonStream.WriteTo(context.Response.OutputStream);
-
                 context.Response.StatusCode = 200;
+
+                response.ContentEncoding = Encoding.UTF8;
+                var jsonStream = this.GetTestMetadataStream();
+                response.ContentLength64 = (int)jsonStream.Length;
+                context.Response.ContentType = "application/json";
+                jsonStream.WriteTo(context.Response.OutputStream);
             }))
             {
                 var azureIms = new AzureMetadataRequestor
                 {
-                    BaseAimsUri = mockUri,
+                    BaseAimsUri = AzureInstanceMetadataEndToEndTests.MockTestUri,
                     AzureImsRequestTimeout = TimeSpan.FromSeconds(1)
                 };
 
@@ -224,18 +178,17 @@ namespace Microsoft.ApplicationInsights.WindowsServer
         {
             CancellationTokenSource cts = new CancellationTokenSource();
 
-            string mockUri = "http://localhost:9922/";
-
             using (new AzureInstanceMetadataServiceMock(
-                mockUri, 
+                AzureInstanceMetadataEndToEndTests.MockTestUri, 
                 (HttpListenerContext context) =>
             {
+                // don't send anything in content at all, or the context defaults to 200 OK
                 context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
             }))
             {
                 var azureIms = new AzureMetadataRequestor
                 {
-                    BaseAimsUri = mockUri
+                    BaseAimsUri = AzureInstanceMetadataEndToEndTests.MockTestUri
                 };
 
                 var azureIMSData = azureIms.GetAzureComputeMetadataAsync();
@@ -243,6 +196,52 @@ namespace Microsoft.ApplicationInsights.WindowsServer
 
                 Assert.Null(azureIMSData.Result);
             }
+        }
+
+        /// <summary>
+        /// Return a memory stream adequate for testing.
+        /// </summary>
+        /// <param name="inst">An Azure instance metadata compute object.</param>
+        /// <returns>Azure Instance Compute Metadata as a JSON-encoded MemoryStream.</returns>
+        private MemoryStream GetTestMetadataStream(AzureInstanceComputeMetadata inst = null)
+        {
+            if (inst == null)
+            {
+                inst = this.GetTestMetadata();
+            }
+
+            DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(AzureInstanceComputeMetadata));
+
+            MemoryStream jsonStream = new MemoryStream();
+            serializer.WriteObject(jsonStream, inst);
+
+            return jsonStream;
+        }
+
+        /// <summary>
+        /// Creates test data for heartbeat e2e.
+        /// </summary>
+        /// <returns>An Azure Instance Metadata Compute object suitable for use in testing.</returns>
+        private AzureInstanceComputeMetadata GetTestMetadata()
+        {
+            return new AzureInstanceComputeMetadata()
+            {
+                Location = "US-West",
+                Name = "test-vm01",
+                Offer = "D9_USWest",
+                OsType = "Linux",
+                PlacementGroupId = "placement-grp",
+                PlatformFaultDomain = "0",
+                PlatformUpdateDomain = "0",
+                Publisher = "Microsoft",
+                ResourceGroupName = "test.resource-group_01",
+                Sku = "Windows_10",
+                SubscriptionId = Guid.NewGuid().ToString(),
+                Tags = "thisTag;thatTag",
+                Version = "10.8a",
+                VmId = Guid.NewGuid().ToString(),
+                VmSize = "A8"
+            };
         }
     }
 }

--- a/Src/WindowsServer/WindowsServer.Shared.Tests/Mock/AzureInstanceMetadataServiceMock.cs
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/Mock/AzureInstanceMetadataServiceMock.cs
@@ -5,7 +5,7 @@
     using System.Threading;
     using System.Threading.Tasks;
 
-    class AzureInstanceMetadataServiceMock : IDisposable
+    internal class AzureInstanceMetadataServiceMock : IDisposable
     {
         private readonly HttpListener listener;
         private readonly CancellationTokenSource cts;

--- a/Src/WindowsServer/WindowsServer.Shared.Tests/Mock/AzureInstanceMetadataServiceMock.cs
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/Mock/AzureInstanceMetadataServiceMock.cs
@@ -1,0 +1,50 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.Mock
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class AzureInstanceMetadataServiceMock : IDisposable
+    {
+        private readonly HttpListener listener;
+        private readonly CancellationTokenSource cts;
+
+        public AzureInstanceMetadataServiceMock(string url, Action<HttpListenerContext> onRequest = null)
+        {
+            this.listener = new HttpListener();
+            this.listener.Prefixes.Add(url);
+            this.listener.Start();
+            this.cts = new CancellationTokenSource();
+
+            Task.Run(
+                () =>
+                {
+                    if (!this.cts.IsCancellationRequested)
+                    {
+                        HttpListenerContext context = this.listener.GetContext();
+                        if (onRequest != null)
+                        {
+                            onRequest(context);
+                        }
+                        else
+                        {
+                            context.Response.StatusCode = 200;
+                        }
+
+                        context.Response.OutputStream.Close();
+                        context.Response.Close();
+                    }
+                },
+                this.cts.Token);
+        }
+
+        public void Dispose()
+        {
+            this.cts.Cancel(false);
+            this.listener.Abort();
+            ((IDisposable)this.listener).Dispose();
+            this.cts.Dispose();
+        }
+    }
+}

--- a/Src/WindowsServer/WindowsServer.Shared.Tests/WindowsServer.Shared.Tests.projitems
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/WindowsServer.Shared.Tests.projitems
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WindowsServerEventSourceTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FirstChanceExceptionStatisticsTelemetryModuleTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mock\AzureInstanceMetadataRequestMock.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mock\AzureInstanceMetadataServiceMock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mock\HeartbeatProviderMock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UnhandledExceptionTelemetryModuleTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UnobservedExceptionTelemetryModuleTest.cs" />

--- a/Src/WindowsServer/WindowsServer.Shared.Tests/WindowsServer.Shared.Tests.projitems
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/WindowsServer.Shared.Tests.projitems
@@ -12,6 +12,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Azure\Emulation\Microsoft.WindowsAzure.ServiceRuntime.dll" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AzureInstanceMetadataEndToEndTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AzureWebAppRoleEnvironmentTelemetryInitializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AzureInstanceMetadataTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AzureRoleEnvironmentTelemetryInitializerTest.cs" />


### PR DESCRIPTION
Fix for issue #832
Add new automated end to end tests for the new heartbeat feature in the WindowsServer SDK.

- [x] I ran Unit Tests locally.
- [x] Changes in public surface reviewed
   - no public API changes

