### PR TITLE
Add parameters to disable/enable strong name validation scripts

### DIFF
--- a/disablestrongnamevalidation.ps1
+++ b/disablestrongnamevalidation.ps1
@@ -1,3 +1,12 @@
-& "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\x64\sn.exe" -Vr *,31bf3856ad364e35
-& "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\sn.exe" -Vr *,31bf3856ad364e35
+Param(
+	[Parameter(Mandatory=$false)]
+	[String]
+	$SnPath=$(Join-Path -Path $Env:WindowsSDK_ExecutablePath_x86 -ChildPath "sn.exe"),
+	[Parameter(Mandatory=$false)]
+	[String]
+	$SnPathx64=$(Join-Path -Path $Env:WindowsSDK_ExecutablePath_x64 -ChildPath "sn.exe")
+)
+
+& $SnPathx64 -Vr *,31bf3856ad364e35
+& $SnPath -Vr *,31bf3856ad364e35
 # running both the above as a hack which is known to work. Its not clear why both are needed.

--- a/enablestrongnamevalidation.ps1
+++ b/enablestrongnamevalidation.ps1
@@ -1,3 +1,12 @@
-& "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\x64\sn.exe" -Vu *,31bf3856ad364e35
-& "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\sn.exe" -Vu *,31bf3856ad364e35
+Param(
+	[Parameter(Mandatory=$false)]
+	[String]
+	$SnPath=$(Join-Path -Path $Env:WindowsSDK_ExecutablePath_x86 -ChildPath "sn.exe"),
+	[Parameter(Mandatory=$false)]
+	[String]
+	$SnPathx64=$(Join-Path -Path $Env:WindowsSDK_ExecutablePath_x64 -ChildPath "sn.exe")
+)
+
+& $SnPathx64 -Vu *,31bf3856ad364e35
+& $SnPath -Vu *,31bf3856ad364e35
 # running both the above as a hack which is known to work. Its not clear why both are needed.


### PR DESCRIPTION
Script-only fix: Allow scripts to work on machines without a specific .NET windows SDK version.

The scripts previously assume .NET 4.6.2 is installed on a machine. Mine has 4.6.1, and 4.7. Instead of assuming this, use the environment to drive any assumptions and allow for them to be overridden as parameters.