### PR TITLE
Add monitor to keep track of current value of App Services env vars

### DIFF
--- a/Src/WindowsServer/WindowsServer.Shared.Tests/AppServiceEnvVarMonitorTests.cs
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/AppServiceEnvVarMonitorTests.cs
@@ -1,0 +1,117 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Runtime.Serialization.Json;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.WindowsServer.Implementation;
+    using Microsoft.ApplicationInsights.WindowsServer.Implementation.DataContracts;
+    using Microsoft.ApplicationInsights.WindowsServer.Mock;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Assert = Xunit.Assert;
+
+    [TestClass]
+    public class AppServiceEnvVarMonitorTests
+    {
+        // used to clean up the environment variables after we've run this test
+        static private Dictionary<string, string> environmentInitialState;
+
+        [ClassInitialize]
+        static public void InitializeTests(TestContext context)
+        {
+            environmentInitialState = GetCurrentAppServiceEnvironmentVariableValues(false);
+        }
+
+        [ClassCleanup]
+        static public void CleanupTests()
+        {
+            foreach (var kvp in environmentInitialState)
+            {
+                Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+            }
+
+            environmentInitialState = null;
+        }
+
+        [TestMethod]
+        public void ConfirmIntervalCheckEnforced()
+        {
+            var envVars = GetCurrentAppServiceEnvironmentVariableValues();
+
+            foreach (var kvp in envVars)
+            {
+                string val = string.Empty;
+                AppServiceEnvVarMonitor.GetUpdatedEnvironmentVariable(kvp.Key, ref val);
+                // set the value to something new
+                Environment.SetEnvironmentVariable(kvp.Key, string.Concat("UPDATED-", val, "-UPDATED"));
+            }
+
+            // set the next-check time to a value that won't get hit
+            AppServiceEnvVarMonitor.NextCheckTime = DateTime.MaxValue;
+
+            // ensure the current values are indeed different
+            var currentEnvVars = GetCurrentAppServiceEnvironmentVariableValues();
+
+            // ensure the values are cached and aren't getting re-read at this time
+            foreach (var kvp in envVars)
+            {
+                string cachedVal = string.Empty;
+                AppServiceEnvVarMonitor.GetUpdatedEnvironmentVariable(kvp.Key, ref cachedVal);
+                Assert.Equal(kvp.Value, cachedVal, StringComparer.Ordinal);
+                Assert.NotEqual(cachedVal, currentEnvVars[kvp.Key], StringComparer.Ordinal);
+            }
+        }
+
+        [TestMethod]
+        public void ConfirmUpdatedEnvironmentIsCaptured()
+        {
+            var envVars = GetCurrentAppServiceEnvironmentVariableValues();
+
+            foreach (var kvp in envVars)
+            {
+                string val = string.Empty;
+                AppServiceEnvVarMonitor.GetUpdatedEnvironmentVariable(kvp.Key, ref val);
+                // set the value to something new
+                Environment.SetEnvironmentVariable(kvp.Key, string.Concat("UPDATED-", val, "-UPDATED"));
+            }
+
+            // set the next-check time to a value that will re-read the values immediately
+            AppServiceEnvVarMonitor.NextCheckTime = DateTime.MinValue;
+
+            // ensure the current values are indeed different
+            var currentEnvVars = GetCurrentAppServiceEnvironmentVariableValues();
+
+            // ensure the values are re-read
+            foreach (var kvp in envVars)
+            {
+                string cachedVal = string.Empty;
+                AppServiceEnvVarMonitor.GetUpdatedEnvironmentVariable(kvp.Key, ref cachedVal);
+                Assert.Equal(currentEnvVars[kvp.Key], cachedVal, StringComparer.Ordinal);
+                Assert.NotEqual(cachedVal, kvp.Value, StringComparer.Ordinal);
+            }
+        }
+
+        static private Dictionary<string,string> GetCurrentAppServiceEnvironmentVariableValues(bool supplyValue = true)
+        {
+            int testValueCount = 0;
+            Dictionary<string, string> envVars = new Dictionary<string, string>();
+
+            foreach (var kvp in AppServiceEnvVarMonitor.CheckedValues)
+            {
+                string envVar = Environment.GetEnvironmentVariable(kvp.Key);
+                if (supplyValue && string.IsNullOrEmpty(envVar))
+                {
+                    envVar = $"{testValueCount}_Stand-inValue_{testValueCount}";
+                    testValueCount++;
+                    Environment.SetEnvironmentVariable(kvp.Key, envVar);
+                }
+                envVars.Add(kvp.Key, envVar);
+            }
+
+            return envVars;
+        }
+    }
+}

--- a/Src/WindowsServer/WindowsServer.Shared.Tests/WindowsServer.Shared.Tests.projitems
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/WindowsServer.Shared.Tests.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Microsoft.ApplicationInsights.WindowsServer</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AppServiceEnvVarMonitorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AzureInstanceMetadataEndToEndTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AzureWebAppRoleEnvironmentTelemetryInitializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AzureInstanceMetadataTests.cs" />

--- a/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
@@ -1,8 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer
 {
     using System;
-    using System.Threading;
-
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -18,9 +16,6 @@
 
         /// <summary>Predefined suffix for Azure Web App Hostname.</summary>
         private const string WebAppSuffix = ".azurewebsites.net";
-
-        private string nodeName;
-        private string roleName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureWebAppRoleEnvironmentTelemetryInitializer" /> class.
@@ -38,8 +33,7 @@
         {
             if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
             {
-                string name = LazyInitializer.EnsureInitialized(ref this.roleName, this.GetRoleName);
-                telemetry.Context.Cloud.RoleName = name;
+                telemetry.Context.Cloud.RoleName = this.GetRoleName();
             }
 
             if (string.IsNullOrEmpty(telemetry.Context.GetInternalContext().NodeName))
@@ -61,8 +55,9 @@
 
         private string GetNodeName()
         {
-            AppServiceEnvVarMonitor.GetUpdatedEnvironmentVariable(WebAppHostNameEnvironmentVariable, ref this.nodeName);
-            return this.nodeName;
+            string nodeName = string.Empty;
+            AppServiceEnvVarMonitor.GetUpdatedEnvironmentVariable(WebAppHostNameEnvironmentVariable, ref nodeName);
+            return nodeName;
         }
     }
 }

--- a/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
@@ -44,8 +44,7 @@
 
             if (string.IsNullOrEmpty(telemetry.Context.GetInternalContext().NodeName))
             {
-                string name = LazyInitializer.EnsureInitialized(ref this.nodeName, this.GetNodeName);                
-                telemetry.Context.GetInternalContext().NodeName = name;
+                telemetry.Context.GetInternalContext().NodeName = this.GetNodeName();
             }
         }
 
@@ -62,7 +61,8 @@
 
         private string GetNodeName()
         {
-            return Environment.GetEnvironmentVariable(WebAppHostNameEnvironmentVariable) ?? string.Empty;
+            AppServiceEnvVarMonitor.GetUpdatedEnvironmentVariable(WebAppHostNameEnvironmentVariable, ref this.nodeName);
+            return this.nodeName;
         }
     }
 }

--- a/Src/WindowsServer/WindowsServer.Shared/Implementation/AppServiceEnvVarMonitor.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/Implementation/AppServiceEnvVarMonitor.cs
@@ -11,7 +11,7 @@
     internal static class AppServiceEnvVarMonitor
     {
         // Environment variables tracked by this monitor. (internal to allow tests to modify them)
-        internal static Dictionary<string, string> CheckedValues = new Dictionary<string, string>()
+        internal static readonly Dictionary<string, string> CheckedValues = new Dictionary<string, string>()
         {
             { "WEBSITE_SITE_NAME", string.Empty },
             { "WEBSITE_HOME_STAMPNAME", string.Empty },

--- a/Src/WindowsServer/WindowsServer.Shared/Implementation/AppServiceEnvVarMonitor.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/Implementation/AppServiceEnvVarMonitor.cs
@@ -1,0 +1,57 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Utility to monitor the value of environment variables which may change 
+    /// during the run of an application. Checks the environment variables 
+    /// intermittently.
+    /// </summary>
+    internal static class AppServiceEnvVarMonitor
+    {
+        internal static TimeSpan CheckInterval = TimeSpan.FromSeconds(30);
+        internal static DateTime LastCheckTime = DateTime.MinValue;
+
+        /// <summary>
+        /// Environment variables tracked by this monitor.
+        /// </summary>
+        internal static Dictionary<string, string> CheckedValues = new Dictionary<string, string>()
+        {
+            { "WEBSITE_SITE_NAME", string.Empty },
+            { "WEBSITE_HOME_STAMPNAME", string.Empty },
+            {  "WEBSITE_HOSTNAME", string.Empty }
+        };
+
+        /// <summary>
+        /// Get the latest value assigned to an environment variable.
+        /// </summary>
+        /// <param name="envVarName">Name of the environment variable to acquire.</param>
+        /// <param name="value">Value of the environment variable (updated within the update interval).</param>
+        public static void GetUpdatedEnvironmentVariable(string envVarName, ref string value)
+        {
+            if (!string.IsNullOrEmpty(envVarName))
+            {
+                CheckVariablesIntermittent();
+                CheckedValues.TryGetValue(envVarName, out value);
+            }
+        }
+
+        /// <summary>
+        /// Simply update the stored environment variables if the last time we 
+        /// checked from now is greater than the check interval.
+        /// </summary>
+        private static void CheckVariablesIntermittent()
+        {
+            DateTime checkTime = DateTime.Now;
+            if (checkTime - LastCheckTime > CheckInterval)
+            {
+                LastCheckTime = checkTime;
+                foreach (var kvp in CheckedValues)
+                {
+                    CheckedValues[kvp.Key] = Environment.GetEnvironmentVariable(kvp.Key);
+                }
+            }
+        }
+    }
+}

--- a/Src/WindowsServer/WindowsServer.Shared/WindowsServer.Shared.projitems
+++ b/Src/WindowsServer/WindowsServer.Shared/WindowsServer.Shared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)BuildInfoConfigComponentVersionTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeveloperModeWithDebuggerAttachedTelemetryModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DomainNameRoleInstanceTelemetryInitializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\AppServiceEnvVarMonitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\AzureComputeMetadataHeartbeatPropertyProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\AzureMetadataRequestor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\DataContracts\AzureInstanceComputeMetadata.cs" />


### PR DESCRIPTION
Corrects aspects of issue #868, further to PR #869.

Use to keep the value of WEBSITE_SITE_NAME and other App Services values current during runtime, as these values can change when swapping App Service applications from one slot to the next.

- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.

Initial PR to bring discussion on the fix, and get some feedback before pushing to Heartbeat update as well.