### PR TITLE
Allow null response in .NET Core DiagnosticSource and fix functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version 2.6.0-beta3
+- [Fix: Failed HTTP outgoing requests are not tracked on .NET Core](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/780)
 - [Ignore Deprecated events if running under netcore20](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/848)
 - [Implement unhandled exception auto-tracking (500 requests) for MVC 5 and WebAPI 2 applications.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/847)
 - [Enable .NET Core platform in WindowsServer SDK. This enables the following modules in .NET Standard applications:](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/854)

--- a/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
@@ -139,12 +139,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                             var requestTaskStatusString = this.stopRequestStatusFetcher.Fetch(evnt.Value).ToString();
                             TaskStatus requestTaskStatus;
 
-                            if (response == null)
-                            {
-                                var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateTypeCast, evnt.Key, "response", "HttpResponseMessage");
-                                DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);
-                            }
-                            else if (request == null)
+                            if (request == null)
                             {
                                 var error = string.Format(CultureInfo.InvariantCulture, ErrorTemplateTypeCast, evnt.Key, "request", "HttpRequestMessage");
                                 DependencyCollectorEventSource.Log.HttpCoreDiagnosticSourceListenerOnNextFailed(error);

--- a/Test/E2ETests/E2ETests/netcore20/TestCore20OnNetCore20.cs
+++ b/Test/E2ETests/E2ETests/netcore20/TestCore20OnNetCore20.cs
@@ -72,11 +72,17 @@ namespace E2ETests.netcore20
 
         [TestMethod]
         [TestCategory("Core20")]
-        public void TestCore20OnNetCore20_FailedHttpDependency()
+        public void TestCore20OnNetCore20_500HttpDependency()
         {
-            base.TestHttpDependency(VersionPrefix, AppNameBeingTested, "/external/calls?type=failedhttp", "500", false);
+            base.TestHttpDependency(VersionPrefix, AppNameBeingTested, "/external/calls?type=http500", "500", false);
         }
 
+        [TestMethod]
+        [TestCategory("Core20")]
+        public void TestCore20OnNetCore20_ExceptionHttpDependency()
+        {
+            base.TestHttpDependency(VersionPrefix, AppNameBeingTested, "/external/calls?type=httpexception", null, false);
+        }
 
         [TestMethod]
         [TestCategory("Core20")]


### PR DESCRIPTION
Fix Issue #780.
<Short description of the fix.>

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.