### PR TITLE
added available memory counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.6.0-beta4
 - [Update Microsoft.AspNet.TelemetryCorrelation package to 1.0.1: Fix endless loop when activity stack is broken](https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/issues/22)
 - [Fix: Failed HTTP outgoing requests are not tracked on .NET Core](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/780)
+- [Enable collection of Available Memory counter on Azure Web Apps](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/585)
 
 ## Version 2.6.0-beta3
 - [Ignore Deprecated events if running under netcore20](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/848)

--- a/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/WebAppPerformanceCollector/CounterFactory.cs
+++ b/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/WebAppPerformanceCollector/CounterFactory.cs
@@ -62,6 +62,8 @@
                                 "otherIoBytes",
                                 "otherIoBytes",
                                 AzureWebApEnvironmentVariables.App)));
+                case @"\Memory\Available Bytes":
+                    return new RawCounterGauge(reportAs, "availMemoryBytes", AzureWebApEnvironmentVariables.App);
 
                 ////$set = Get-Counter -ListSet "ASP.NET Applications"
                 ////$set.Paths


### PR DESCRIPTION
Fix Issue #585 .
Added Available memory counter that will be added to the Azure Web Apps in 3-4 weeks according to the Azure Web Apps team.

- [X] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [X] Changes in public surface reviewed
- [X] Design discussion issue #585
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [x] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.