### PR TITLE
Detect issue with POST/PUT/PATCH requests correlation  and report in event source actionable event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version 2.7.0-beta1
+- [Send UserActionable event about correlation issue with HTTP request with body when .NET 4.7.1 is not installed](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/903)
 - [Added support to collect Perf Counters for .NET Core Apps if running inside Azure WebApps](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/889)
 - [Opt-in legacy correlation headers (x-ms-request-id and x-ms-request-root-id) extraction and injection](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/887)
 - [Fix: Correlation is not working for POST requests](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/898) when .NET 4.7.1 runtime is installed.

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -479,7 +479,7 @@
         [Event(49,
             Keywords = Keywords.Diagnostics | Keywords.UserActionable,
             Message = ".NET 4.7.1 is not installed, correlation for HTTP requests with body is not possible",
-            Level = EventLevel.Warning)]
+            Level = EventLevel.Error)]
         public void CorrelationIssueIsDetectedForRequestWithBody(string appDomainName = "Incorrect")
         {
             this.WriteEvent(

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -476,6 +476,17 @@
             this.WriteEvent(48, diagnosticsSourceEventName, this.ApplicationName);
         }
 
+        [Event(49,
+            Keywords = Keywords.Diagnostics | Keywords.UserActionable,
+            Message = ".NET 4.7.1 is not installed, correlation for HTTP requests with body is not possible",
+            Level = EventLevel.Warning)]
+        public void CorrelationIssueIsDetectedForRequestWithBody(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                49,
+                this.ApplicationName);
+        }
+
         [NonEvent]
         private string GetApplicationName()
         {


### PR DESCRIPTION
See #797.

We have fixed the issue with #898 for users that have .NET 4.7.1 installed (all Azure WebApp users).
Azure Cloud Services do not have 4.7.1 by default.

For users that do not have 4.7.1 we recommend installing .NET 4.7.1 (without retargeting the app) or follow workaround mentioned in the #797.

We also want to see how many users are affected by the issue, so we detect it and ~~set heartbeat property~~ [**Updated**] send user actionable event source event.

We'll see if need to notify users in UI based on the number of affected users. For now, we just ensuring data is there.

<Short description of the fix.>

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
