### PR TITLE
Fix 503 WCF test that sometimes fails because of intermediate request

### DIFF
--- a/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
+++ b/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
@@ -114,11 +114,15 @@
             client.TrackTrace(trace);
 
             this.aspNetDiagnosticsSource.ReportRestoredActivity(restoredActivity);
-            Assert.AreEqual(2, this.sendItems.Count);
-            var requestRestoredTelemetry = (RequestTelemetry)this.sendItems.SingleOrDefault(i => i is RequestTelemetry);
+            Assert.AreEqual(1, this.sendItems.Count);
+
+            restoredActivity.Stop();
+            this.aspNetDiagnosticsSource.StopLostActivity(activity);
+
+            Assert.AreEqual(3, this.sendItems.Count);
+            var requestRestoredTelemetry = (RequestTelemetry)this.sendItems[1];
             Assert.IsNotNull(requestRestoredTelemetry);
 
-            this.aspNetDiagnosticsSource.StopActivity();
             Assert.AreEqual(3, this.sendItems.Count);
 
             var requestTelemetry = (RequestTelemetry)this.sendItems[2];

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -429,8 +429,8 @@
             var restoredActivity = new Activity("dummy").SetParentId(originalRequest.Id).Start();
 
             module.TrackIntermediateRequest(context, restoredActivity);
-
-            Assert.Equal(1, this.sentTelemetry.Count);
+            module.OnEndRequest(context);
+            Assert.Equal(2, this.sentTelemetry.Count);
             Assert.True(this.sentTelemetry.TryDequeue(out RequestTelemetry intermediateRequest));
 
             Assert.Equal(originalRequest.Id, intermediateRequest.Context.Operation.ParentId);


### PR DESCRIPTION
After merging #898 I found that some Web Func testsfail sometimes in external, hosted build. 

It happens with WCF app tests because intermediate request is sometimes tracked for non-reported handlers.

To fix it, I started tracking intermediate request together with 'main' request. I.e. intermediate requests would never be reported for non-tracked handlers. After ~15 hosted test runs, all web func tests pass.
It should also reduce the noise for users. 

- [x] I ran Unit Tests locally.
