### PR TITLE
Fix dependency tracking if non-zero length response was cached by PropertyFetcher before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Added support to collect Perf Counters for .NET Core Apps if running inside Azure WebApps](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/889)
 - [Opt-in legacy correlation headers (x-ms-request-id and x-ms-request-root-id) extraction and injection](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/887)
 - [Fix: Correlation is not working for POST requests](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/898) when .NET 4.7.1 runtime is installed.
+- [Fix: Tracking mixed HTTP responses with and without content](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/919)
 
 ## Version 2.6.0-beta4
 - [Remove CorrelationIdLookupHelper. Use TelemetryConfiguration.ApplicationIdProvider instead.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/880) With this change you can update URL to query application ID from which enables environments with reverse proxy configuration to access Application Insights ednpoints.

--- a/Src/DependencyCollector/Net45.Tests/DependencyTrackingTelemetryModuleHttpTest.cs
+++ b/Src/DependencyCollector/Net45.Tests/DependencyTrackingTelemetryModuleHttpTest.cs
@@ -96,7 +96,14 @@
         [Timeout(5000)]
         public async Task TestZeroContentResponseDiagnosticSource()
         {
-            await this.TestCollectionHttpClientSucessfulResponse(LocalhostUrlDiagSource, 200, 0);
+            await this.TestCollectionHttpClientSuccessfulResponse(LocalhostUrlDiagSource, 200, 0);
+        }
+
+        [TestMethod]
+        [Timeout(500000)]
+        public async Task TestZeroAndNonZeroContentResponseDiagnosticSource()
+        {
+            await this.TestZeroContentResponseAfterNonZeroResponse(LocalhostUrlDiagSource, 200);
         }
 
         [TestMethod]
@@ -379,7 +386,7 @@
             }
         }
 
-        private async Task TestCollectionHttpClientSucessfulResponse(string url, int statusCode, int contentLength, bool injectLegacyHeaders = false)
+        private async Task TestCollectionHttpClientSuccessfulResponse(string url, int statusCode, int contentLength, bool injectLegacyHeaders = false)
         {
             using (this.CreateDependencyTrackingModule(true))
             {
@@ -406,6 +413,62 @@
                 }
 
                 this.ValidateTelemetry(true, this.sentTelemetry.Single(), new Uri(url), null, statusCode >= 200 && statusCode < 300, statusCode.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        private async Task TestZeroContentResponseAfterNonZeroResponse(string url, int statusCode)
+        {
+            using (this.CreateDependencyTrackingModule(true))
+            {
+                using (HttpClient client = new HttpClient())
+                {
+                    using (new LocalServer(
+                        url,
+                        context =>
+                        {
+                            context.Response.ContentLength64 = 1;
+                            context.Response.StatusCode = statusCode;
+                            context.Response.OutputStream.WriteByte(0x1);
+                            context.Response.OutputStream.Close();
+                        }))
+                    {
+                        try
+                        {
+                            using (HttpResponseMessage response = await client.GetAsync(url))
+                            {
+                                Assert.AreEqual(1, response.Content.Headers.ContentLength);
+                            }
+                        }
+                        catch (WebException)
+                        {
+                            // ignore and let ValidateTelemetry method check status code
+                        }
+                    }
+
+                    using (new LocalServer(
+                        url,
+                        context =>
+                        {
+                            context.Response.ContentLength64 = 0;
+                            context.Response.StatusCode = statusCode;
+                        }))
+                    {
+                        try
+                        {
+                            using (HttpResponseMessage response = await client.GetAsync(url))
+                            {
+                                Assert.AreEqual(0, response.Content.Headers.ContentLength);
+                            }
+                        }
+                        catch (WebException)
+                        {
+                            // ignore and let ValidateTelemetry method check status code
+                        }
+                    }
+                }
+
+                Assert.AreEqual(2, this.sentTelemetry.Count);
+                this.ValidateTelemetry(true, this.sentTelemetry.Last(), new Uri(url), null, statusCode >= 200 && statusCode < 300, statusCode.ToString(CultureInfo.InvariantCulture));
             }
         }
 

--- a/Src/DependencyCollector/Net45.Tests/DependencyTrackingTelemetryModuleHttpTest.cs
+++ b/Src/DependencyCollector/Net45.Tests/DependencyTrackingTelemetryModuleHttpTest.cs
@@ -100,7 +100,7 @@
         }
 
         [TestMethod]
-        [Timeout(500000)]
+        [Timeout(5000)]
         public async Task TestZeroAndNonZeroContentResponseDiagnosticSource()
         {
             await this.TestZeroContentResponseAfterNonZeroResponse(LocalhostUrlDiagSource, 200);

--- a/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs
@@ -17,8 +17,9 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         private readonly PropertyFetcher requestFetcherRequestEvent;
         private readonly PropertyFetcher requestFetcherResponseEvent;
         private readonly PropertyFetcher responseFetcher;
-        private readonly PropertyFetcher responseStatusFetcher;
-        private readonly PropertyFetcher responseHeadersFetcher;
+        private readonly PropertyFetcher requestFetcherResponseExEvent;
+        private readonly PropertyFetcher responseExStatusFetcher;
+        private readonly PropertyFetcher responseExHeadersFetcher;
 
         private bool disposed = false;
 
@@ -29,8 +30,10 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.requestFetcherRequestEvent = new PropertyFetcher("Request");
             this.requestFetcherResponseEvent = new PropertyFetcher("Request");
             this.responseFetcher = new PropertyFetcher("Response");
-            this.responseStatusFetcher = new PropertyFetcher("StatusCode");
-            this.responseHeadersFetcher = new PropertyFetcher("Headers");
+
+            this.requestFetcherResponseExEvent = new PropertyFetcher("Request");
+            this.responseExStatusFetcher = new PropertyFetcher("StatusCode");
+            this.responseExHeadersFetcher = new PropertyFetcher("Headers");
         }
 
         /// <summary>
@@ -77,10 +80,10 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     case "System.Net.Http.Desktop.HttpRequestOut.Ex.Stop":
                     {
                         // request is never null
-                        var request = this.requestFetcherResponseEvent.Fetch(value.Value);
+                        var request = this.requestFetcherResponseExEvent.Fetch(value.Value);
                         DependencyCollectorEventSource.Log.HttpDesktopEndCallbackCalled(ClientServerDependencyTracker.GetIdForRequestObject(request));
-                        object statusCode = this.responseStatusFetcher.Fetch(value.Value);
-                        object headers = this.responseHeadersFetcher.Fetch(value.Value);
+                        object statusCode = this.responseExStatusFetcher.Fetch(value.Value);
+                        object headers = this.responseExHeadersFetcher.Fetch(value.Value);
                         this.httpDesktopProcessing.OnEndResponse(request, statusCode, headers);
                         break;
                     }


### PR DESCRIPTION
PropertyFetcher must be created for each property in each event, the same property fetcher cannot be used for 2 different events.
In this case, if request fetcher was first used for 'System.Net.Http.Desktop.HttpRequestOut.Stop' event, it won't be able to fetch Request from 'System.Net.Http.Desktop.HttpRequestOut.Ex.Stop' event and vice versa.

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.