### PR TITLE
Do not call base HandleErrorAttribute.OnException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version 2.7.0-beta1
+- [Fix: Do not call base HandleErrorAttribute.OnException in MVC unhandled exception filter](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/921)
 - [Send UserActionable event about correlation issue with HTTP request with body when .NET 4.7.1 is not installed](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/903)
 - [Added support to collect Perf Counters for .NET Core Apps if running inside Azure WebApps](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/889)
 - [Opt-in legacy correlation headers (x-ms-request-id and x-ms-request-root-id) extraction and injection](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/887)


### PR DESCRIPTION
Fix Issue #921

There is no need to call base HandleErrorAttribute.OnException for MVC exceptions and ExceptionLogger.OnLog for WebAPI exceptions.

The former (`HandleErrorAttribute.OnException`) causes issues with custom error pages as base HandleErrorAttribute attempts to respond with some default Error page that could be missing. 

HandleErrorAttribute does not implement chaining pattern, so removing this call does not prevent other error filters to execute and limits AppInsights exception filter to exception tracking only.

Users are still responsible to add `HandleErrorFilter` or their custom filters to the global filter collection.

The latter (`ExceptionLogger.OnLog`) is empty anyway and calling it does not harm, but does not bring any value.

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.