### PR TITLE
For .net core apps running in azure webapp, use a different sdk prefix

### DIFF
--- a/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
@@ -25,6 +25,7 @@
 
         private const string StandardSdkVersionPrefix = "pc:";
         private const string AzureWebAppSdkVersionPrefix = "azwapc:";
+        private const string AzureWebAppCoreSdkVersionPrefix = "azwapccore:";
 
         private const string WebSiteEnvironmentVariable = "WEBSITE_SITE_NAME";
         private const string ProcessorsCountEnvironmentVariable = "NUMBER_OF_PROCESSORS";
@@ -131,7 +132,18 @@
         /// <returns>Returns the SDK version prefix based on the platform.</returns>
         public static string SDKVersionPrefix()
         {
-            return IsWebAppRunningInAzure() ? AzureWebAppSdkVersionPrefix : StandardSdkVersionPrefix;
+            if (IsWebAppRunningInAzure())
+            {
+#if NETSTANDARD1_6
+                return AzureWebAppCoreSdkVersionPrefix;
+#else
+                return AzureWebAppSdkVersionPrefix;
+#endif                                
+            }
+            else
+            {
+                return StandardSdkVersionPrefix;
+            }
         }
 
         /// <summary>
@@ -298,7 +310,7 @@
 #endif
         }
 
-#if !NETSTANDARD1_6        
+#if !NETSTANDARD1_6
         internal static IList<string> GetWin32ProcessInstances()
         {
             return GetInstances(Win32ProcessCategoryName);


### PR DESCRIPTION
Purely for telemetry, no func changes.

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.