### PR TITLE
Use new DiagnosticSource 4.5.0  in Web SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Version 2.7.0-beta1
+- [Fix: SerializationException resolving Activity in cross app-domain calls](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/613)
 
 ## Version 2.7.0-beta1
 - [Add operation details for HTTP and SQL operation to the dependency telemetry.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/900)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 2.7.0-beta1
+## Version 2.7.0-beta3
 - [Fix: SerializationException resolving Activity in cross app-domain calls](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/613)
 
 ## Version 2.7.0-beta1

--- a/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
+++ b/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -34,8 +34,8 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0-preview1-26015-06\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/DependencyCollector/Net45.Tests/packages.config
+++ b/Src/DependencyCollector/Net45.Tests/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net451" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net451" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0-preview1-26015-06" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />

--- a/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
+++ b/Src/DependencyCollector/Net45/DependencyCollector.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -32,8 +32,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/DependencyCollector/Net45/packages.config
+++ b/Src/DependencyCollector/Net45/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
+++ b/Src/DependencyCollector/NetCore/DependencyCollector.NetCore.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.3.1" />
   </ItemGroup>

--- a/Src/DependencyCollector/NuGet.Tests/app.config
+++ b/Src/DependencyCollector/NuGet.Tests/app.config
@@ -1,10 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Diagnostics.Tracing.EventSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.28.0" newVersion="1.1.28.0"/>
+        <assemblyIdentity name="Microsoft.Diagnostics.Tracing.EventSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.28.0" newVersion="1.1.28.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Src/DependencyCollector/NuGet/Package.nuspec
+++ b/Src/DependencyCollector/NuGet/Package.nuspec
@@ -19,14 +19,14 @@
       <group targetFramework="net45">
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.5.0" />
       </group>
       <group targetFramework="netstandard1.6">
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.Extensions.PlatformAbstractions" version="1.1.0" />
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Diagnostics.StackTrace" version="4.3.0" />        
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.5.0" />
         <dependency id="System.Data.SqlClient" version="4.3.1" />
       </group>
     </dependencies>

--- a/Src/HostingStartup/HostingStartup.Net45.Tests/HostingStartup.Net45.Tests.csproj
+++ b/Src/HostingStartup/HostingStartup.Net45.Tests/HostingStartup.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
@@ -33,8 +33,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/Src/HostingStartup/HostingStartup.Net45.Tests/packages.config
+++ b/Src/HostingStartup/HostingStartup.Net45.Tests/packages.config
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
-  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/HostingStartup/HostingStartup.Net45/HostingStartup.Net45.csproj
+++ b/Src/HostingStartup/HostingStartup.Net45/HostingStartup.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -31,8 +31,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/HostingStartup/HostingStartup.Net45/packages.config
+++ b/Src/HostingStartup/HostingStartup.Net45/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
@@ -6,5 +6,5 @@
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/PerformanceCollector/Net45/Perf.Net45.csproj
+++ b/Src/PerformanceCollector/Net45/Perf.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -28,8 +28,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Caching" />

--- a/Src/PerformanceCollector/Net45/packages.config
+++ b/Src/PerformanceCollector/Net45/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
-  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/PerformanceCollector/Perf.NetFull.Tests/Perf.NetFull.Tests.csproj
+++ b/Src/PerformanceCollector/Perf.NetFull.Tests/Perf.NetFull.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -42,8 +42,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/Src/PerformanceCollector/Perf.NetFull.Tests/app.config
+++ b/Src/PerformanceCollector/Perf.NetFull.Tests/app.config
@@ -14,6 +14,10 @@
         <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Src/PerformanceCollector/Perf.NetFull.Tests/packages.config
+++ b/Src/PerformanceCollector/Perf.NetFull.Tests/packages.config
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -49,8 +49,8 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -113,6 +113,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/Src/Web/Web.Net45.Tests/app.config
+++ b/Src/Web/Web.Net45.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Src/Web/Web.Net45.Tests/packages.config
+++ b/Src/Web/Web.Net45.Tests/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net451" />
@@ -14,7 +14,7 @@
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
   <package id="OpenCover" version="4.6.519" targetFramework="net451" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net451" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net451" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net451" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />

--- a/Src/Web/Web.Net45/Web.Net45.csproj
+++ b/Src/Web/Web.Net45/Web.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -31,8 +31,8 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/Src/Web/Web.Net45/packages.config
+++ b/Src/Web/Web.Net45/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/Web/Web.Nuget.Tests/Web.Nuget.Tests.csproj
+++ b/Src/Web/Web.Nuget.Tests/Web.Nuget.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -33,8 +33,8 @@
       <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.XML" />

--- a/Src/Web/Web.Nuget.Tests/app.config
+++ b/Src/Web/Web.Nuget.Tests/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="Microsoft.Diagnostics.Tracing.EventSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.28.0" newVersion="1.1.28.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Src/Web/Web.Nuget.Tests/packages.config
+++ b/Src/Web/Web.Nuget.Tests/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/Src/Web/Web.Nuget/Package.nuspec
+++ b/Src/Web/Web.Nuget/Package.nuspec
@@ -20,7 +20,7 @@
         <dependency id="Microsoft.ApplicationInsights" version="[$coresdkversion$]" />
         <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="$version$" />
         <dependency id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.5.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
@@ -1,16 +1,12 @@
 ﻿namespace Microsoft.ApplicationInsights.Web.Implementation
 {
     using System;
-#if NET45
     using System.Diagnostics;
-#endif
     using System.Linq;
     using System.Web;
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
-#if NET45
     using Microsoft.AspNet.TelemetryCorrelation;
-#endif
 
     internal static class RequestTrackingExtensions
     {

--- a/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
+++ b/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -28,8 +28,8 @@
       <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.7.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.EnterpriseServices">
       <Private>True</Private>

--- a/Src/WindowsServer/WindowsServer.Net45.Tests/packages.config
+++ b/Src/WindowsServer/WindowsServer.Net45.Tests/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/Src/WindowsServer/WindowsServer.Net45/WindowsServer.Net45.csproj
+++ b/Src/WindowsServer/WindowsServer.Net45/WindowsServer.Net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
@@ -26,8 +26,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Management" />
     <Reference Include="System.Net.Http" />

--- a/Src/WindowsServer/WindowsServer.Net45/packages.config
+++ b/Src/WindowsServer/WindowsServer.Net45/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/WindowsServer/WindowsServer.Nuget.Tests/WindowsServer.Nuget.Tests.csproj
+++ b/Src/WindowsServer/WindowsServer.Nuget.Tests/WindowsServer.Nuget.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -38,8 +38,8 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.XML" />

--- a/Src/WindowsServer/WindowsServer.Nuget.Tests/packages.config
+++ b/Src/WindowsServer/WindowsServer.Nuget.Tests/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
+++ b/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\..\..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.Common.props'))\Test.Common.props" />
@@ -68,8 +68,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
   </ItemGroup>
@@ -87,6 +87,7 @@
     <Compile Include="Test452Base.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="AzureEmulator\entry.cmd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
+++ b/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
@@ -87,7 +87,6 @@
     <Compile Include="Test452Base.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="AzureEmulator\entry.cmd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Test/E2ETests/E2ETests/packages.config
+++ b/Test/E2ETests/E2ETests/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net47" />
   <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net47" />
   <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net47" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net47" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net47" />
 </packages>

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="..\..\..\..\..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\..\..\..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
@@ -96,8 +96,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/Web.config
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/Web.config
@@ -25,7 +25,7 @@
     <httpModules>
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
     </httpModules>
-    <customErrors mode="Off"/>
+    <customErrors mode="Off" />
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -36,6 +36,10 @@
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" culture="neutral" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/packages.config
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net452" />
   <package id="AspNet.ScriptManager.bootstrap" version="3.0.0" targetFramework="net452" />
@@ -27,7 +27,7 @@
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net452" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net452" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />

--- a/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
+++ b/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="..\..\..\..\..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\..\..\..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
@@ -66,8 +66,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.Entity" />

--- a/Test/E2ETests/TestApps/Net452/E2ETestWebApi/Web.config
+++ b/Test/E2ETests/TestApps/Net452/E2ETestWebApi/Web.config
@@ -59,6 +59,10 @@
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.codedom>

--- a/Test/E2ETests/TestApps/Net452/E2ETestWebApi/packages.config
+++ b/Test/E2ETests/TestApps/Net452/E2ETestWebApi/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net452" />
   <package id="bootstrap" version="3.0.0" targetFramework="net452" />
@@ -22,6 +22,6 @@
   <package id="Modernizr" version="2.6.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net452" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net452" />
   <package id="WebGrease" version="1.5.2" targetFramework="net452" />
 </packages>

--- a/Test/E2ETests/TestApps/NetCore20/E2ETestAppCore20/E2ETestAppCore20.csproj
+++ b/Test/E2ETests/TestApps/NetCore20/E2ETestAppCore20/E2ETestAppCore20.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0	" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\Test.Common.props" />
   <PropertyGroup>
@@ -23,6 +23,7 @@
     <WcfConfigValidationEnabled>True</WcfConfigValidationEnabled>
     <TargetFrameworkProfile />
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,8 +57,8 @@
       <HintPath>$(PackagesDir)\Newtonsoft.Json.6.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview2-25330-01\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/Web.config
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/Web.config
@@ -5,7 +5,7 @@
   -->
 <configuration>
   <appSettings>
-    <add key="QuickPulseEndpointPort" value="{QuickPulseEndpointPort}"/>
+    <add key="QuickPulseEndpointPort" value="{QuickPulseEndpointPort}" />
   </appSettings>
   
   <!--
@@ -64,6 +64,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/packages.config
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.7.0-beta2" targetFramework="net451" />
@@ -7,5 +7,5 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview2-25330-01" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net451" />
 </packages>

--- a/Test/Web/FunctionalTests.sln
+++ b/Test/Web/FunctionalTests.sln
@@ -26,7 +26,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAppFW45Sampled", "Functi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleAppFW45", "FunctionalTests\TestApps\ConsoleAppFW45\ConsoleAppFW45.csproj", "{B3284820-85BB-4273-B05F-D64FB175015A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationInsightsTypes", "..\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj", "{4B0BC3B7-C7FC-4333-9E28-5790D9153F07}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplicationInsightsTypes", "..\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj", "{4B0BC3B7-C7FC-4333-9E28-5790D9153F07}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -129,5 +129,8 @@ Global
 		{BD4C55CF-0513-4F93-936B-6EE57497ED84} = {B439008F-8E36-41F4-AF58-A4197C7D2D81}
 		{4E735DB0-178C-4719-9F5A-A04280739A3F} = {B439008F-8E36-41F4-AF58-A4197C7D2D81}
 		{B3284820-85BB-4273-B05F-D64FB175015A} = {B439008F-8E36-41F4-AF58-A4197C7D2D81}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {641403C1-6462-4AC0-8F1F-8921D5B4AF28}
 	EndGlobalSection
 EndGlobal

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -55,8 +55,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/Web.config
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/Web.config
@@ -83,6 +83,10 @@
         <assemblyIdentity name="EntityFramework" publicKeyToken="b77a5c561934e089" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="AspNet.ScriptManager.bootstrap" version="3.0.0" targetFramework="net45" />
@@ -33,6 +33,6 @@
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Respond" version="1.2.0" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
   <package id="WebGrease" version="1.5.2" targetFramework="net45" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -63,8 +63,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />

--- a/Test/Web/FunctionalTests/TestApps/Aspx45/Web.config
+++ b/Test/Web/FunctionalTests/TestApps/Aspx45/Web.config
@@ -99,6 +99,10 @@
         <assemblyIdentity name="EntityFramework" publicKeyToken="b77a5c561934e089" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
     <!-- This prevents the Windows Event Log from frequently logging that HMAC1 is being used (when the other party needs it). -->
     <legacyHMACWarning enabled="0" />

--- a/Test/Web/FunctionalTests/TestApps/Aspx45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Aspx45/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AspNet.ScriptManager.jQuery" version="1.8.2" targetFramework="net45" />
   <package id="AspNet.ScriptManager.jQuery.UI.Combined" version="1.8.24" targetFramework="net45" />
@@ -23,5 +23,5 @@
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.6.2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/ConsoleAppFW45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/ConsoleAppFW45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.Common.props'))\Test.Common.props" />
   <PropertyGroup>
@@ -47,8 +47,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Web" />

--- a/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/app.config
+++ b/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/app.config
@@ -14,6 +14,10 @@
         <assemblyIdentity name="Microsoft.Diagnostics.Tracing.EventSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.28.0" newVersion="1.1.28.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/packages.config
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -78,8 +78,8 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Web.config
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Web.config
@@ -106,6 +106,10 @@
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DotNetOpenAuth.AspNet" version="4.1.4.12333" targetFramework="net45" />
   <package id="DotNetOpenAuth.Core" version="4.1.4.12333" targetFramework="net45" />
@@ -36,7 +36,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.6.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.2.0" targetFramework="net45" />
   <package id="WebGrease" version="1.3.0" targetFramework="net45" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/App_Data/HttpModuleWeb.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/App_Data/HttpModuleWeb.config
@@ -29,6 +29,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <probing privatePath="bin;bin\ai_sdk"/>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/App_Data/Integrated.WebSecurityOn.Web.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/App_Data/Integrated.WebSecurityOn.Web.config
@@ -34,6 +34,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <probing privatePath="bin;bin\ai_sdk"/>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/App_Data/IntegratedPipeline.Web.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/App_Data/IntegratedPipeline.Web.config
@@ -28,6 +28,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <probing privatePath="bin;bin\ai_sdk"/>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -73,8 +73,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Web.Extensions" />

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/web.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/web.config
@@ -2,8 +2,8 @@
 <configuration>
 
     <system.web>
-      <compilation debug="true" targetFramework="4.5"/>
-      <hostingEnvironment shadowCopyBinAssemblies="false"/>
+      <compilation debug="true" targetFramework="4.5" />
+      <hostingEnvironment shadowCopyBinAssemblies="false" />
     </system.web>
 
   <runtime>
@@ -12,25 +12,33 @@
 
       <dependentAssembly>
 
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 
-        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0"/>
-
-      </dependentAssembly>
-
-      <dependentAssembly>
-
-        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-
-        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
 
       </dependentAssembly>
 
       <dependentAssembly>
 
-        <assemblyIdentity name="Microsoft.Diagnostics.Tracing.EventSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 
-        <bindingRedirect oldVersion="0.0.0.0-1.1.28.0" newVersion="1.1.28.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
+
+      </dependentAssembly>
+
+      <dependentAssembly>
+
+        <assemblyIdentity name="Microsoft.Diagnostics.Tracing.EventSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+
+        <bindingRedirect oldVersion="0.0.0.0-1.1.28.0" newVersion="1.1.28.0" />
+
+      </dependentAssembly>
+
+      <dependentAssembly>
+
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
 
       </dependentAssembly>
 

--- a/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -65,8 +65,8 @@
       <HintPath>..\..\..\..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Web.DynamicData" />

--- a/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Web.config
+++ b/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Web.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.web>
-    <compilation debug="true" targetFramework="4.5"/>
+    <compilation debug="true" targetFramework="4.5" />
     <webServices>
       <protocols>
-        <add name="HttpGet"/>
-        <add name="HttpPost"/>
+        <add name="HttpGet" />
+        <add name="HttpPost" />
       </protocols>
     </webServices>
-    <hostingEnvironment shadowCopyBinAssemblies="false"/>
+    <hostingEnvironment shadowCopyBinAssemblies="false" />
   </system.web>
   <!--<system.serviceModel>
     <behaviors>
@@ -24,71 +24,67 @@
     <serviceHostingEnvironment aspNetCompatibilityEnabled="true" multipleSiteBindingsEnabled="false" />
   </system.serviceModel>-->
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false"/>
+    <validation validateIntegratedModeConfiguration="false" />
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <remove name="OPTIONSVerbHandler"/>
-      <remove name="TRACEVerbHandler"/>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit"/>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit"/>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule"
-        scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32"
-        responseBufferLimit="0"/>
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule"
-        scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64"
-        responseBufferLimit="0"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS"
-        type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" />
+      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" />
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
     <modules runAllManagedModulesForAllRequests="true">
-      <add name="ApplicationInsightsHttpModule" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"
-        preCondition="managedHandler"/>
-      <remove name="TelemetryCorrelationHttpModule"/>
-      <add name="TelemetryCorrelationHttpModule"
-        type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"
-        preCondition="integratedMode,managedHandler"/>
+      <add name="ApplicationInsightsHttpModule" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
+      <remove name="TelemetryCorrelationHttpModule" />
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
     </modules>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <probing privatePath="bin;bin\ai_sdk"/>
+      <probing privatePath="bin;bin\ai_sdk" />
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0"/>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0"/>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Diagnostics.Tracing.EventSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.28.0" newVersion="1.1.28.0"/>
+        <assemblyIdentity name="Microsoft.Diagnostics.Tracing.EventSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.28.0" newVersion="1.1.28.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.serviceModel>
-    <serviceHostingEnvironment aspNetCompatibilityEnabled="true" multipleSiteBindingsEnabled="false"/>
+    <serviceHostingEnvironment aspNetCompatibilityEnabled="true" multipleSiteBindingsEnabled="false" />
     <services>
       <service name="Wcf45Tests.WcfEndpoint" behaviorConfiguration="custom">
-        <endpoint name="webHttpBinding" address="" binding="webHttpBinding" contract="Wcf45Tests.IWcfEndpoint" behaviorConfiguration="webHttp"/>
-        <endpoint name="mexHttpBinding" address="mex" binding="mexHttpBinding" contract="IMetadataExchange"/>
+        <endpoint name="webHttpBinding" address="" binding="webHttpBinding" contract="Wcf45Tests.IWcfEndpoint" behaviorConfiguration="webHttp" />
+        <endpoint name="mexHttpBinding" address="mex" binding="mexHttpBinding" contract="IMetadataExchange" />
       </service>
     </services>
     <behaviors>
       <serviceBehaviors>
         <behavior name="custom">
-          <serviceMetadata httpGetEnabled="true"/>
-          <serviceDebug includeExceptionDetailInFaults="false"/>
+          <serviceMetadata httpGetEnabled="true" />
+          <serviceDebug includeExceptionDetailInFaults="false" />
         </behavior>
         <behavior>
-          <serviceMetadata httpGetEnabled="true"/>
-          <serviceDebug includeExceptionDetailInFaults="false"/>
+          <serviceMetadata httpGetEnabled="true" />
+          <serviceDebug includeExceptionDetailInFaults="false" />
         </behavior>
       </serviceBehaviors>
       <endpointBehaviors>
         <behavior name="webHttp">
-          <webHttp/>
+          <webHttp />
         </behavior>
       </endpointBehaviors>
     </behaviors>

--- a/Test/Web/FunctionalTests/TestApps/Wcf45Tests/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Wcf45Tests/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.7.0-beta2" targetFramework="net45" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/Web.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/Web.config
@@ -63,6 +63,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.serviceModel>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -68,8 +68,8 @@
       <HintPath>$(PackagesDir)\Newtonsoft.Json.6.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.7.0-beta2" targetFramework="net451" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net451" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/Web.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/Web.config
@@ -65,6 +65,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.serviceModel>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\FunctionalTests\Test.Common.props" />
   <PropertyGroup>
@@ -68,8 +68,8 @@
       <HintPath>$(PackagesDir)\Newtonsoft.Json.6.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights" version="2.7.0-beta2" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.7.0-beta2" targetFramework="net451" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Fix Issue #613.

Updates diagnosicsource to the stable 4.5.0 version that has a fix for https://github.com/dotnet/corefx/issues/21027

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.