### PR TITLE
Fix race condition in generic diagnostic listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.7.0-beta3
 - [Fix: SerializationException resolving Activity in cross app-domain calls](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/613)
+- [Fix: Race condition in generic diagnostic source listener](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/948)
 
 ## Version 2.7.0-beta1
 - [Add operation details for HTTP and SQL operation to the dependency telemetry.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/900)

--- a/Src/DependencyCollector/Shared.Tests/Implementation/TelemetryDiagnosticSourceListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/TelemetryDiagnosticSourceListenerTests.cs
@@ -37,11 +37,24 @@
         #region Subscribtion tests
 
         [TestMethod]
+        public void TelemetryDiagnosticSourceListenerOnCreatedListener()
+        {
+            DiagnosticListener listener = new DiagnosticListener("Test.A");
+            var inclusionList = new[] { "Test.A" }.ToList();
+            using (var dl = new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
+            {
+                dl.Subscribe();
+                Assert.IsTrue(listener.IsEnabled(), "There is a subscriber for a new diagnostic source");
+            }
+        }
+
+        [TestMethod]
         public void TelemetryDiagnosticSourceListenerCapturesAllActivitiesByDefault()
         {
             var inclusionList = new[] { "Test.A" }.ToList();
-            using (new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
+            using (var dl = new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
             {
+                dl.Subscribe();
                 DiagnosticListener listener = new DiagnosticListener("Test.A");
                 Activity activity = new Activity("Test.A.Client.Monitoring");
 
@@ -74,8 +87,9 @@
         public void TelemetryDiagnosticSourceListenerIgnoresNotIncludedSources()
         {
             var inclusionList = new[] { "Test.B" }.ToList();
-            using (new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
+            using (var dl = new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
             {
+                dl.Subscribe();
                 // Diagnostic Source A is ignored
                 DiagnosticListener listenerA = new DiagnosticListener("Test.A");
                 Activity activityA = new Activity("Test.A.Client.Monitoring");
@@ -114,8 +128,9 @@
         public void TelemetryDiagnosticSourceListenerIgnoresNotIncludedActivities()
         {
             var inclusionList = new[] { "Test.A:Test.A.Client.Monitoring" }.ToList();
-            using (new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
+            using (var dl = new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
             {
+                dl.Subscribe();
                 // Diagnostic Source is not ignored
                 DiagnosticListener listener = new DiagnosticListener("Test.A");
 
@@ -167,8 +182,9 @@
         public void TelemetryDiagnosticSourceListenerCollectsTelemetryFromRawActivity()
         {
             var inclusionList = new[] { "Test.A" }.ToList();
-            using (new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
+            using (var dl = new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
             {
+                dl.Subscribe();
                 DiagnosticListener listener = new DiagnosticListener("Test.A");
 
                 // generic example
@@ -231,6 +247,7 @@
             var inclusionList = new[] { "Test.A:Send", "Test.B" }.ToList();
             using (var telemetryListener = new TelemetryDiagnosticSourceListener(this.configuration, inclusionList))
             {
+                telemetryListener.Subscribe();
                 TestableEventHandler ahandler = new TestableEventHandler();
                 TestableEventHandler bhandler = new TestableEventHandler();
                 telemetryListener.RegisterHandler("Test.A", ahandler);

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -151,6 +151,7 @@
                                 this.telemetryDiagnosticSourceListener = new TelemetryDiagnosticSourceListener(configuration, this.IncludeDiagnosticSourceActivities);
                                 this.telemetryDiagnosticSourceListener.RegisterHandler(EventHubsDiagnosticsEventHandler.DiagnosticSourceName, new EventHubsDiagnosticsEventHandler(configuration));
                                 this.telemetryDiagnosticSourceListener.RegisterHandler(ServiceBusDiagnosticsEventHandler.DiagnosticSourceName, new ServiceBusDiagnosticsEventHandler(configuration));
+                                this.telemetryDiagnosticSourceListener.Subscribe();
                             }
 
                             this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(configuration);

--- a/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
@@ -16,13 +16,21 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         protected readonly TelemetryClient Client;
         protected readonly TelemetryConfiguration Configuration;
 
-        private readonly IDisposable listenerSubscription;
+        private IDisposable listenerSubscription;
         private List<IDisposable> individualSubscriptions;
 
         protected DiagnosticSourceListenerBase(TelemetryConfiguration configuration)
         {
             this.Configuration = configuration;
             this.Client = new TelemetryClient(configuration);
+        }
+
+        public void Subscribe()
+        {
+            if (this.listenerSubscription != null)
+            {
+                return;
+            }
 
             try
             {

--- a/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
@@ -19,6 +19,12 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         private IDisposable listenerSubscription;
         private List<IDisposable> individualSubscriptions;
 
+        /// <summary>
+        /// Creates DiagnosticSourceListenerBase. To finish the initialization and subscribe to all enabled sources,
+        /// call <see cref="Subscribe"/>
+        /// </summary>
+        /// <param name="configuration"><see cref="TelemetryConfiguration"/> instance.
+        /// The listener tracks dependency calls and uses configuration to construct <see cref="TelemetryClient"/></param>
         protected DiagnosticSourceListenerBase(TelemetryConfiguration configuration)
         {
             this.Configuration = configuration;

--- a/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
@@ -25,6 +25,10 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.Client = new TelemetryClient(configuration);
         }
 
+        /// <summary>
+        /// Subscribes the listener to all enabled sources. This method must be called
+        /// to enable dependency calls collection.
+        /// </summary>
         public void Subscribe()
         {
             if (this.listenerSubscription != null)


### PR DESCRIPTION
When generic diagnostic listener subscribes to DiagnosticSource, it attempts to use this in its own constructor, while some properties (filters) are not initialized yet.

As a result, if DiagnosticSource is created BEFORE the generic listener, it's guaranteed to miss subscription event and never receive anything.

This PR fixes this issue.
- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.