### PR TITLE
Fix broken correlation for ServiceBus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.7.1
+- [Fix ServiceBus requests correlation](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/970)
+
 ## Version 2.7.0-beta4
 - [When there is no parent operation, generate W3C compatible operation Id](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/952)
 

--- a/Src/Common/ActivityExtensions.cs
+++ b/Src/Common/ActivityExtensions.cs
@@ -6,10 +6,9 @@
     {
         public static Activity UpdateParent(this Activity original, string newParentId)
         {
-            if (original == null || original.Parent != null)
-            {
-                return original;
-            }
+            Debug.Assert(original != null, "original Activity cannot be null");
+            Debug.Assert(original.ParentId == null, "cannot update parent - parentId is not null");
+            Debug.Assert(original.Parent == null, "cannot update parent - parent is not null");
 
             var auxActivity = new Activity(original.OperationName)
                 .SetParentId(newParentId)

--- a/Src/DependencyCollector/NetCore.Tests/DependencyTrackingTelemetryModuleTestNetCore.cs
+++ b/Src/DependencyCollector/NetCore.Tests/DependencyTrackingTelemetryModuleTestNetCore.cs
@@ -219,7 +219,7 @@
 
             if (parent == null)
             {
-                // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331)
+                // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331 TODO)
                 Assert.AreEqual(32, item.Context.Operation.Id.Length);
                 Assert.IsTrue(Regex.Match(item.Context.Operation.Id, @"[a-z][0-9]").Success);
                 // end of workaround test

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
@@ -134,7 +134,7 @@ namespace Microsoft.ApplicationInsights.Tests
 
             var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
 
-            // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331)
+            // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331 TODO)
             Assert.AreEqual(32, telemetry.Context.Operation.Id.Length);
             Assert.IsTrue(Regex.Match(telemetry.Context.Operation.Id, @"[a-z][0-9]").Success);
             // end of workaround test

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
@@ -5,6 +5,7 @@ namespace Microsoft.ApplicationInsights.Tests
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
 
     using Microsoft.ApplicationInsights.Common;
@@ -110,6 +111,76 @@ namespace Microsoft.ApplicationInsights.Tests
 
             // Check the operation details
             this.ValidateOperationDetails(telemetry);
+        }
+
+        /// <summary>
+        /// Tests that activity without parent gets a new W3C compatible root id.
+        /// </summary>
+        [TestMethod]
+        public void OnActivityWithoutParentGeneratesW3CTraceId()
+        {
+            var activity = new Activity("System.Net.Http.HttpRequestOut");
+            activity.AddBaggage("k", "v");
+            var startTime = DateTime.UtcNow.AddSeconds(-1);
+            activity.SetStartTime(startTime);
+            activity.Start();
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(request);
+
+            activity = Activity.Current;
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
+            this.listener.OnActivityStop(response, request, TaskStatus.RanToCompletion);
+
+            var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
+
+            // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331)
+            Assert.AreEqual(32, telemetry.Context.Operation.Id.Length);
+            Assert.IsTrue(Regex.Match(telemetry.Context.Operation.Id, @"[a-z][0-9]").Success);
+            // end of workaround test
+        }
+
+        /// <summary>
+        /// Tests that activity without parent id does not get a new W3C compatible root id.
+        /// </summary>
+        [TestMethod]
+        public void OnActivityWithParentId()
+        {
+            var activity = new Activity("System.Net.Http.HttpRequestOut")
+                .SetParentId("parent")
+                .Start();
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(request);
+
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
+            this.listener.OnActivityStop(response, request, TaskStatus.RanToCompletion);
+
+            var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
+
+            Assert.AreEqual("parent", telemetry.Context.Operation.Id);
+            Assert.AreEqual("parent", telemetry.Context.Operation.ParentId);
+        }
+
+        /// <summary>
+        /// Tests that activity without parent does not get a new W3C compatible root id.
+        /// </summary>
+        [TestMethod]
+        public void OnActivityWithParent()
+        {
+            var parent = new Activity("dummy").Start();
+            var activity = new Activity("System.Net.Http.HttpRequestOut").Start();
+ 
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(request);
+
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
+            this.listener.OnActivityStop(response, request, TaskStatus.RanToCompletion);
+
+            var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
+
+            Assert.AreEqual(parent.RootId, telemetry.Context.Operation.Id);
+            Assert.AreEqual(parent.Id, telemetry.Context.Operation.ParentId);
         }
 
         /// <summary>

--- a/Src/DependencyCollector/Shared.Tests/Implementation/EventHubsDiagnosticListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/EventHubsDiagnosticListenerTests.cs
@@ -126,6 +126,34 @@
         }
 
         [TestMethod]
+        public void EventHubsSuccessfulSendIsHandledWithExternalParent()
+        {
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.IncludeDiagnosticSourceActivities.Add("Microsoft.Azure.EventHubs");
+                module.Initialize(this.configuration);
+
+                DiagnosticListener listener = new DiagnosticListener("Microsoft.Azure.EventHubs");
+
+                var telemetry = this.TrackOperation<DependencyTelemetry>(listener, "Microsoft.Azure.EventHubs.Send", TaskStatus.RanToCompletion, "parent");
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("Send", telemetry.Name);
+                Assert.AreEqual(RemoteDependencyConstants.AzureEventHubs, telemetry.Type);
+                Assert.AreEqual("sb://eventhubname.servicebus.windows.net/ | ehname", telemetry.Target);
+                Assert.IsTrue(telemetry.Success.Value);
+
+                Assert.AreEqual("parent", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual("parent", telemetry.Context.Operation.Id);
+
+                Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["peer.hostname"]);
+                Assert.AreEqual("ehname", telemetry.Properties["eh.event_hub_name"]);
+                Assert.AreEqual("SomePartitionKeyHere", telemetry.Properties["eh.partition_key"]);
+                Assert.AreEqual("EventHubClient1(ehname)", telemetry.Properties["eh.client_id"]);
+            }
+        }
+
+        [TestMethod]
         public void EventHubsFailedSendIsHandled()
         {
             using (var module = new DependencyTrackingTelemetryModule())
@@ -175,7 +203,7 @@
             }
         }
 
-        private T TrackOperation<T>(DiagnosticListener listener, string activityName, TaskStatus status) where T : OperationTelemetry
+        private T TrackOperation<T>(DiagnosticListener listener, string activityName, TaskStatus status, string parentId = null) where T : OperationTelemetry
         {
             Activity activity = null;
             int itemCountBefore = this.sentItems.Count;
@@ -187,6 +215,12 @@
                 activity.AddTag("eh.event_hub_name", "ehname");
                 activity.AddTag("eh.partition_key", "SomePartitionKeyHere");
                 activity.AddTag("eh.client_id", "EventHubClient1(ehname)");
+
+                if (Activity.Current == null && parentId != null)
+                {
+                    activity.SetParentId(parentId);
+                }
+
                 if (listener.IsEnabled(activityName + ".Start"))
                 {
                     listener.StartActivity(

--- a/Src/DependencyCollector/Shared.Tests/Implementation/EventHubsDiagnosticListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/EventHubsDiagnosticListenerTests.cs
@@ -113,7 +113,7 @@
                 Assert.AreEqual("sb://eventhubname.servicebus.windows.net/ | ehname", telemetry.Target);
                 Assert.IsTrue(telemetry.Success.Value);
 
-                // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331)
+                // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331 TODO)
                 Assert.AreEqual(32, telemetry.Context.Operation.Id.Length);
                 Assert.IsTrue(Regex.Match(telemetry.Context.Operation.Id, @"[a-z][0-9]").Success);
                 // end of workaround test

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ServiceBusDiagnosticListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ServiceBusDiagnosticListenerTests.cs
@@ -242,7 +242,7 @@
             {
                 activity = new Activity(activityName);
                 activity.AddTag("MessageId", "messageId");
-                if (Activity.Current == null)
+                if (Activity.Current == null && parentId != null)
                 {
                     activity.SetParentId(parentId);
                 }

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ServiceBusDiagnosticListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ServiceBusDiagnosticListenerTests.cs
@@ -204,7 +204,7 @@
                 Assert.AreEqual($"type:{RemoteDependencyConstants.AzureServiceBus} | name:queueName | endpoint:sb://queuename.myservicebus.com/", telemetry.Source);
                 Assert.IsTrue(telemetry.Success.Value);
 
-                // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331)
+                // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331 TODO)
                 Assert.AreEqual(32, telemetry.Context.Operation.Id.Length);
                 Assert.IsTrue(Regex.Match(telemetry.Context.Operation.Id, @"[a-z][0-9]").Success);
                 // end of workaround test

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ServiceBusDiagnosticListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ServiceBusDiagnosticListenerTests.cs
@@ -165,6 +165,29 @@
         }
 
         [TestMethod]
+        public void ServiceBusProcessHandingExternalParent()
+        {
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.IncludeDiagnosticSourceActivities.Add("Microsoft.Azure.ServiceBus");
+                module.Initialize(this.configuration);
+
+                DiagnosticListener listener = new DiagnosticListener("Microsoft.Azure.ServiceBus");
+
+                var telemetry = this.TrackOperation<RequestTelemetry>(listener, "Microsoft.Azure.ServiceBus.Process", TaskStatus.RanToCompletion, "parent");
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("Process", telemetry.Name);
+                Assert.AreEqual($"type:{RemoteDependencyConstants.AzureServiceBus} | name:queueName | endpoint:sb://queuename.myservicebus.com/", telemetry.Source);
+                Assert.IsTrue(telemetry.Success.Value);
+
+                Assert.AreEqual("parent", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual("parent", telemetry.Context.Operation.Id);
+                Assert.AreEqual("messageId", telemetry.Properties["MessageId"]);
+            }
+        }
+
+        [TestMethod]
         public void ServiceBusProcessHandingWithoutParent()
         {
             using (var module = new DependencyTrackingTelemetryModule())
@@ -211,7 +234,7 @@
             }
         }
 
-        private T TrackOperation<T>(DiagnosticListener listener, string activityName, TaskStatus status) where T : OperationTelemetry
+        private T TrackOperation<T>(DiagnosticListener listener, string activityName, TaskStatus status, string parentId = null) where T : OperationTelemetry
         {
             Activity activity = null;
 
@@ -219,6 +242,11 @@
             {
                 activity = new Activity(activityName);
                 activity.AddTag("MessageId", "messageId");
+                if (Activity.Current == null)
+                {
+                    activity.SetParentId(parentId);
+                }
+
                 if (listener.IsEnabled(activityName + ".Start"))
                 {
                     listener.StartActivity(activity, new { Entity = "queueName", Endpoint = new Uri("sb://queuename.myservicebus.com/") });

--- a/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
@@ -303,7 +303,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             // So if there is no parent Activity (i.e. this request has happened in the background, without parent scope), we'll override 
             // the current Activity with the one with properly formatted Id. This workaround should go away
             // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
-            if (currentActivity.Parent == null)
+            if (currentActivity.Parent == null && currentActivity.ParentId == null)
             {
                 currentActivity.UpdateParent(StringUtilities.GenerateTraceId());
             }

--- a/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
@@ -302,7 +302,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             // as early as possible, so that everyone has a chance to upgrade and have compatibility with W3C systems once they arrive.
             // So if there is no parent Activity (i.e. this request has happened in the background, without parent scope), we'll override 
             // the current Activity with the one with properly formatted Id. This workaround should go away
-            // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
+            // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331 (TODO)
             if (currentActivity.Parent == null && currentActivity.ParentId == null)
             {
                 currentActivity.UpdateParent(StringUtilities.GenerateTraceId());

--- a/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
@@ -68,7 +68,7 @@
                 // as early as possible, so that everyone has a chance to upgrade and have compatibility with W3C systems once they arrive.
                 // So if there is no parent Activity (i.e. this request has happened in the background, without parent scope), we'll override 
                 // the current Activity with the one with properly formatted Id. This workaround should go away
-                // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
+                // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331 (TODO)
                 if (currentActivity == null)
                 {
                     activity.SetParentId(StringUtilities.GenerateTraceId());

--- a/Src/DependencyCollector/Shared/Implementation/EventHandlers/EventHubsDiagnosticsEventHandler.cs
+++ b/Src/DependencyCollector/Shared/Implementation/EventHandlers/EventHubsDiagnosticsEventHandler.cs
@@ -34,13 +34,14 @@
             {
                 case "Microsoft.Azure.EventHubs.Send.Start":
                 case "Microsoft.Azure.EventHubs.Receive.Start":
+
                     // As a first step in supporting W3C protocol in ApplicationInsights,
                     // we want to generate Activity Ids in the W3C compatible format.
                     // While .NET changes to Activity are pending, we want to ensure trace starts with W3C compatible Id
                     // as early as possible, so that everyone has a chance to upgrade and have compatibility with W3C systems once they arrive.
                     // So if there is no parent Activity (i.e. this request has happened in the background, without parent scope), we'll override 
                     // the current Activity with the one with properly formatted Id. This workaround should go away
-                    // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
+                    // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331 (TODO)
                     if (currentActivity.Parent == null && currentActivity.ParentId == null)
                     {
                         currentActivity.UpdateParent(StringUtilities.GenerateTraceId());

--- a/Src/DependencyCollector/Shared/Implementation/EventHandlers/EventHubsDiagnosticsEventHandler.cs
+++ b/Src/DependencyCollector/Shared/Implementation/EventHandlers/EventHubsDiagnosticsEventHandler.cs
@@ -41,7 +41,7 @@
                     // So if there is no parent Activity (i.e. this request has happened in the background, without parent scope), we'll override 
                     // the current Activity with the one with properly formatted Id. This workaround should go away
                     // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
-                    if (currentActivity.Parent == null)
+                    if (currentActivity.Parent == null && currentActivity.ParentId == null)
                     {
                         currentActivity.UpdateParent(StringUtilities.GenerateTraceId());
                     }

--- a/Src/DependencyCollector/Shared/Implementation/EventHandlers/ServiceBusDiagnosticsEventHandler.cs
+++ b/Src/DependencyCollector/Shared/Implementation/EventHandlers/ServiceBusDiagnosticsEventHandler.cs
@@ -53,7 +53,7 @@
                         // as early as possible, so that everyone has a chance to upgrade and have compatibility with W3C systems once they arrive.
                         // So if there is no parent Activity (i.e. this request has happened in the background, without parent scope), we'll override 
                         // the current Activity with the one with properly formatted Id. This workaround should go away
-                        // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
+                        // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331 (TODO)
                         if (currentActivity.Parent == null && currentActivity.ParentId == null)
                         {
                             currentActivity.UpdateParent(StringUtilities.GenerateTraceId());

--- a/Src/DependencyCollector/Shared/Implementation/EventHandlers/ServiceBusDiagnosticsEventHandler.cs
+++ b/Src/DependencyCollector/Shared/Implementation/EventHandlers/ServiceBusDiagnosticsEventHandler.cs
@@ -54,7 +54,7 @@
                         // So if there is no parent Activity (i.e. this request has happened in the background, without parent scope), we'll override 
                         // the current Activity with the one with properly formatted Id. This workaround should go away
                         // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
-                        if (currentActivity.ParentId == null)
+                        if (currentActivity.Parent == null && currentActivity.ParentId == null)
                         {
                             currentActivity.UpdateParent(StringUtilities.GenerateTraceId());
                         }

--- a/Src/DependencyCollector/Shared/Implementation/EventHandlers/ServiceBusDiagnosticsEventHandler.cs
+++ b/Src/DependencyCollector/Shared/Implementation/EventHandlers/ServiceBusDiagnosticsEventHandler.cs
@@ -54,7 +54,7 @@
                         // So if there is no parent Activity (i.e. this request has happened in the background, without parent scope), we'll override 
                         // the current Activity with the one with properly formatted Id. This workaround should go away
                         // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
-                        if (currentActivity.Parent == null)
+                        if (currentActivity.ParentId == null)
                         {
                             currentActivity.UpdateParent(StringUtilities.GenerateTraceId());
                         }

--- a/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
+++ b/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
@@ -315,7 +315,7 @@
             // so they look like OperationTelemetry.Id
             foreach (var operationId in ids)
             {
-                // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331)
+                // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331 TODO)
                 Assert.AreEqual(32, operationId.Length);
                 Assert.IsTrue(Regex.Match(operationId, @"[a-z][0-9]").Success);
                 // end of workaround test

--- a/Src/Web/Web.Net45.Tests/RequestTrackingTelemetryModuleTest.Net45.cs
+++ b/Src/Web/Web.Net45.Tests/RequestTrackingTelemetryModuleTest.Net45.cs
@@ -85,7 +85,7 @@
             Assert.True(requestTelemetry.Id.StartsWith('|' + operationId + '.', StringComparison.Ordinal));
             Assert.NotEqual(operationId, requestTelemetry.Id);
 
-            // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331)
+            // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331 TODO)
             Assert.Equal(32, operationId.Length);
             Assert.True(Regex.Match(operationId, @"[a-z][0-9]").Success);
             // end of workaround test

--- a/Src/Web/Web.Net45/AspNetDiagnosticTelemetryModule.cs
+++ b/Src/Web/Web.Net45/AspNetDiagnosticTelemetryModule.cs
@@ -162,7 +162,7 @@
                             // as early as possible, so that everyone has a chance to upgrade and have compatibility with W3C systems once they arrive.
                             // So if there is no current Activity (i.e. there were no Request-Id header in the incoming request), we'll override ParentId on 
                             // the current Activity by the properly formatted one. This workaround should go away
-                            // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
+                            // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331 (TODO)
                             activity.SetParentId(StringUtilities.GenerateTraceId());
 
                             // end of workaround

--- a/Src/Web/Web.Shared.Net.Tests/ActivityExtensionsTests.cs
+++ b/Src/Web/Web.Shared.Net.Tests/ActivityExtensionsTests.cs
@@ -66,27 +66,6 @@
         }
 
         [TestMethod]
-        public void UpdateParentNoopWhenActivityIsNull()
-        {
-            Activity originalActivity = null;
-
-            var newActivity = originalActivity.UpdateParent("newparent");
-            Assert.IsNull(newActivity);
-            Assert.IsNull(Activity.Current);
-        }
-
-        [TestMethod]
-        public void UpdateParentNoopWhenActivityHasInProcParent()
-        {
-            Activity grandpa = new Activity("grandpa").Start();
-            Activity parent = new Activity("parent").Start();
-
-            var newActivity = parent.UpdateParent("newparent");
-            Assert.AreEqual(parent, newActivity);
-            Assert.AreEqual(Activity.Current, parent);
-        }
-
-        [TestMethod]
         public void UpdateParentCopiesNotStartedActivity()
         {
             Activity originalActivity = new Activity("dummy");

--- a/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
@@ -48,7 +48,7 @@
                         // as early as possible, so that everyone has a chance to upgrade and have compatibility with W3C systems once they arrive.
                         // So if there is no current Activity (i.e. there were no Request-Id header in the incoming request), we'll override ParentId on 
                         // the current Activity by the properly formatted one. This workaround should go away
-                        // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
+                        // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331 (TODO)
                         currentActivity.SetParentId(StringUtilities.GenerateTraceId());
 
                         // end of workaround


### PR DESCRIPTION
Fix Issue #970  .

When we generate W3C compatible trace id, we should check that activity does not have a parent and parent id, and only then assign the new operation id.
