### PR TITLE
fix document stream identified by fxcop

### DIFF
--- a/Src/PerformanceCollector/Filtering.Shared/DocumentStream.cs
+++ b/Src/PerformanceCollector/Filtering.Shared/DocumentStream.cs
@@ -65,27 +65,27 @@
 
         public bool CheckFilters(RequestTelemetry document, out CollectionConfigurationError[] errors)
         {
-            return CheckFilters(this.requestFilterGroups, document, out errors);
+            return DocumentStream.CheckFilters(this.requestFilterGroups, document, out errors);
         }
         
         public bool CheckFilters(DependencyTelemetry document, out CollectionConfigurationError[] errors)
         {
-            return CheckFilters(this.dependencyFilterGroups, document, out errors);
+            return DocumentStream.CheckFilters(this.dependencyFilterGroups, document, out errors);
         }
 
         public bool CheckFilters(ExceptionTelemetry document, out CollectionConfigurationError[] errors)
         {
-            return CheckFilters(this.exceptionFilterGroups, document, out errors);
+            return DocumentStream.CheckFilters(this.exceptionFilterGroups, document, out errors);
         }
 
         public bool CheckFilters(EventTelemetry document, out CollectionConfigurationError[] errors)
         {
-            return CheckFilters(this.eventFilterGroups, document, out errors);
+            return DocumentStream.CheckFilters(this.eventFilterGroups, document, out errors);
         }
 
         public bool CheckFilters(TraceTelemetry document, out CollectionConfigurationError[] errors)
         {
-            return CheckFilters(this.traceFilterGroups, document, out errors);
+            return DocumentStream.CheckFilters(this.traceFilterGroups, document, out errors);
         }
 
         private static bool CheckFilters<TTelemetry>(
@@ -107,7 +107,7 @@
             // iterate over filter groups (filters within each group are evaluated as AND, the groups are evaluated as OR)
             foreach (FilterConjunctionGroup<TTelemetry> conjunctionFilterGroup in filterGroups)
             {
-                if (CheckFiltersGeneric(document, conjunctionFilterGroup, errorList))
+                if (DocumentStream.CheckFiltersGeneric(document, conjunctionFilterGroup, errorList))
                 {
                     // no need to check remaining groups, one OR-connected group has passed
                     leastOneConjunctionGroupPassed = true;

--- a/Src/PerformanceCollector/Filtering.Shared/DocumentStream.cs
+++ b/Src/PerformanceCollector/Filtering.Shared/DocumentStream.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-
+    using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse.Helpers;
 
@@ -98,11 +98,7 @@
 
             if (filterGroups.Count == 0)
             {
-#if NET45
-                errors = new CollectionConfigurationError[0];
-#else
-                errors = Array.Empty<CollectionConfigurationError>();
-#endif
+                errors = ArrayExtensions.Empty<CollectionConfigurationError>();
 
                 // no filters for the telemetry type - filter out, we're not interested
                 return false;

--- a/Src/PerformanceCollector/Filtering.Shared/DocumentStream.cs
+++ b/Src/PerformanceCollector/Filtering.Shared/DocumentStream.cs
@@ -122,15 +122,15 @@
         
         private static bool CheckFiltersGeneric<TTelemetry>(TTelemetry document, FilterConjunctionGroup<TTelemetry> filterGroup, List<CollectionConfigurationError> errorList)
         {
+            bool filterPassed = false;
+
             try
             {
                 if (filterGroup.CheckFilters(document, out CollectionConfigurationError[] groupErrors))
                 {
                     errorList.AddRange(groupErrors);
-                    return true;
+                    filterPassed = true;
                 }
-
-                return false;
             }
             catch (Exception)
             {
@@ -141,8 +141,9 @@
                 ////        CollectionConfigurationErrorType.DocumentStreamFilterFailureToRun,
                 ////        string.Format(CultureInfo.InvariantCulture, "Document stream filter failed to run"),
                 ////        e));
-                return false;
             }
+
+            return filterPassed;
         }
 
         private void CreateFilters(out CollectionConfigurationError[] errors)


### PR DESCRIPTION
- several empty arrays were being created that were not needed.
- identical inline anon function was created 5 times, refactor to private method.
- simplified large method