### PR TITLE
Fixes misspelling #988

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
@@ -10,7 +10,7 @@
 
     internal static class ClientServerDependencyTracker
     {
-        internal const string DependencyActivityName = "Microsoft.ApplivationInsights.Web.Dependency";
+        internal const string DependencyActivityName = "Microsoft.ApplicationInsights.Web.Dependency";
 
         internal static bool IsW3CEnabled { get; set; } = false;
 


### PR DESCRIPTION
Fix Issue #988.
Misspelling in `ClientServerDependencyTracker` constant.

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.