### PR TITLE
Move QP telemetry processor to default sink instead of common pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Version 2.8.0-beta2
-- [Microsoft.AspNet.TelemetryCorrelaiton package update to 1.0.4](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/987)
+- [LiveMetrics (QuickPulse) TelemetryProcessor added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/987)
+	If you are upgrading, and have added/modified TelemetryProcessors, make sure to copy them to the default sink section.
+- [Microsoft.AspNet.TelemetryCorrelaiton package update to 1.0.4](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/991)
 
 ## Version 2.8.0-beta1
 - [Adds opt-in support for W3C distributed tracing standard](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/945)

--- a/Src/PerformanceCollector/NuGet/ApplicationInsights.config.install.xdt
+++ b/Src/PerformanceCollector/NuGet/ApplicationInsights.config.install.xdt
@@ -21,8 +21,19 @@
     </Add>
     <Add xdt:Transform="InsertIfMissing" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector" />
   </TelemetryModules>
- 
-  <!-- 
+
+  <TelemetryProcessors xdt:Transform="Remove"/>
+  <TelemetrySinks xdt:Transform="InsertIfMissing">
+  </TelemetrySinks>
+
+  <TelemetrySinks xdt:Transform="InsertIfMissing">
+    <Add Name="default" xdt:Transform="InsertIfMissing">
+    </Add>
+  </TelemetrySinks>
+
+  <TelemetrySinks>
+    <Add Name="default" xdt:Transform="InsertIfMissing">
+      <!-- 
     QuickPulse telemetry processor must always be the first telemetry processor.
     There is no syntax to allow insertion in the beginning of the list for when there are no siblings (we only have InsertBefore and InsertAfter), so do a trick:
     1. Remove all previously existing QuickPulse telemetry processors (if any)
@@ -33,12 +44,15 @@
     Note that we have a default namespace in ApplicationInsights.config, and since XDT won't allow us to specify the namespace map, we'll have to use local-name() in XPath expressions
   -->
 
-    <TelemetryProcessors xdt:Transform="InsertIfMissing">
-      <Add xdt:Transform="RemoveAll" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-      <Add xdt:Transform="Insert" Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-    </TelemetryProcessors>
+      <TelemetryProcessors xdt:Transform="InsertIfMissing">
+        <Add xdt:Transform="RemoveAll" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+        <Add xdt:Transform="Insert" Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+      </TelemetryProcessors>
 
-    <Add xdt:Transform="InsertBefore(/*[local-name()='ApplicationInsights']/*[local-name()='TelemetryProcessors']/*[local-name()='Add'][1])" Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+      <Add xdt:Transform="InsertBefore(/*[local-name()='ApplicationInsights']/*[local-name()='TelemetrySinks']/*[local-name()='Add'][1]/*[local-name()='TelemetryProcessors']/*[local-name()='Add'][1])" Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
 
-    <Add xdt:Transform="Remove" xdt:Locator="XPath(/*[local-name()='ApplicationInsights']/*[local-name()='TelemetryProcessors']/*[local-name()='Add' and starts-with(./@Type,'Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor') and contains(./@Type,' Microsoft.AI.PerfCounterCollector')][last()])"/>
+      <Add xdt:Transform="Remove" xdt:Locator="XPath(/*[local-name()='ApplicationInsights']/*[local-name()='TelemetrySinks']/*[local-name()='Add'][1]/*[local-name()='TelemetryProcessors']/*[local-name()='Add' and starts-with(./@Type,'Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor') and contains(./@Type,' Microsoft.AI.PerfCounterCollector')][last()])"/>
+
+    </Add>
+  </TelemetrySinks>
 </ApplicationInsights>

--- a/Src/PerformanceCollector/NuGet/ApplicationInsights.config.uninstall.xdt
+++ b/Src/PerformanceCollector/NuGet/ApplicationInsights.config.uninstall.xdt
@@ -5,8 +5,20 @@
   </TelemetryModules>
   <TelemetryModules xdt:Transform="Remove" xdt:Locator="Condition(count(*)=0)"/>
 
-  <TelemetryProcessors>
-    <Add xdt:Transform="Remove" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-  </TelemetryProcessors>
-  <TelemetryProcessors xdt:Transform="Remove" xdt:Locator="Condition(count(*)=0)"/>
+  <TelemetrySinks>
+    <Add Name="default">
+      <TelemetryProcessors>
+        <Add xdt:Transform="Remove" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+      </TelemetryProcessors>
+      <TelemetryProcessors xdt:Transform="Remove" xdt:Locator="Condition(count(*)=0)"/>
+    </Add>
+  </TelemetrySinks>
+
+  <TelemetrySinks>
+    <Add Name="default" xdt:Transform="Remove" xdt:Locator="Condition(count(*)=0)">
+    </Add>
+  </TelemetrySinks>
+
+  <TelemetrySinks xdt:Transform="Remove" xdt:Locator="Condition(count(*)=0)"/>
+  
 </ApplicationInsights>

--- a/Src/PerformanceCollector/Xdt.Tests/Resources/TestDataSet.xml
+++ b/Src/PerformanceCollector/Xdt.Tests/Resources/TestDataSet.xml
@@ -37,9 +37,13 @@
           </Add>
           <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector"/>
         </TelemetryModules>
-        <TelemetryProcessors>
-          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
       
     </expectedPostTransform>
@@ -77,9 +81,13 @@
           </Add>
           <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector"/>
         </TelemetryModules>
-        <TelemetryProcessors>
-          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </expectedPostTransform>
@@ -138,9 +146,13 @@
           </Add>
           <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector"/>
         </TelemetryModules>
-        <TelemetryProcessors>
-          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </expectedPostTransform>
@@ -188,9 +200,13 @@
       -->
           </Add>
         </TelemetryModules>
-        <TelemetryProcessors>
-          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </expectedPostTransform>
@@ -202,7 +218,7 @@
 
     </expectedPostUninstall>
   </item>
-  <!--Installing NuGet when QuickPulse telemetry processor is already present-->
+  <!--Installing NuGet when QuickPulse telemetry processor is already present in common pipeline-->
   <item>
     <original>
 
@@ -240,9 +256,13 @@
           </Add>
           <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector"/>
         </TelemetryModules>
-        <TelemetryProcessors>
-          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </expectedPostTransform>
@@ -254,6 +274,68 @@
 
     </expectedPostUninstall>
   </item>
+
+  <!--Installing NuGet when QuickPulse telemetry processor is already present in default sink-->
+  <item>
+    <original>
+
+      <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
+        <TelemetryModules>
+        </TelemetryModules>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
+      </ApplicationInsights>
+
+    </original>
+    <expectedPostTransform>
+
+      <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
+        <TelemetryModules>
+          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.AI.PerfCounterCollector">
+            <!--
+      Use the following syntax here to collect additional performance counters:
+      
+      <Counters>
+        <Add PerformanceCounter="\Process(??APP_WIN32_PROC??)\Handle Count" ReportAs="Process handle count" />
+        ...
+      </Counters>
+      
+      PerformanceCounter must be either \CategoryName(InstanceName)\CounterName or \CategoryName\CounterName
+      
+      NOTE: performance counters configuration will be lost upon NuGet upgrade.
+      
+      The following placeholders are supported as InstanceName:
+        ??APP_WIN32_PROC?? - instance name of the application process  for Win32 counters.
+        ??APP_W3SVC_PROC?? - instance name of the application IIS worker process for IIS/ASP.NET counters.
+        ??APP_CLR_PROC?? - instance name of the application CLR process for .NET counters.
+      -->
+          </Add>
+          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector"/>
+        </TelemetryModules>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
+      </ApplicationInsights>
+
+    </expectedPostTransform>
+
+    <expectedPostUninstall>
+
+      <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
+      </ApplicationInsights>
+
+    </expectedPostUninstall>
+  </item>
+  
   <!--Installing NuGet when QuickPulse telemetry processor is not present, but others are. QuickPulse telemetry processor must always be first-->
   <item>
     <original>
@@ -261,9 +343,13 @@
       <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
         <TelemetryModules>
         </TelemetryModules>
-        <TelemetryProcessors>
-          <Add Type="SomeTelemetryProcessor, SomeAssembly" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="SomeTelemetryProcessor, SomeAssembly" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </original>
@@ -292,10 +378,14 @@
           </Add>
           <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector"/>
         </TelemetryModules>
-        <TelemetryProcessors>
-          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-          <Add Type="SomeTelemetryProcessor, SomeAssembly" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+              <Add Type="SomeTelemetryProcessor, SomeAssembly" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </expectedPostTransform>
@@ -303,9 +393,13 @@
     <expectedPostUninstall>
 
       <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
-        <TelemetryProcessors>
-          <Add Type="SomeTelemetryProcessor, SomeAssembly" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="SomeTelemetryProcessor, SomeAssembly" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </expectedPostUninstall>
@@ -317,11 +411,15 @@
       <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
         <TelemetryModules>
         </TelemetryModules>
-        <TelemetryProcessors>
-          <Add Type="SomeTelemetryProcessor, SomeAssembly" />
-          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-          <Add Type="SomeOtherTelemetryProcessor, SomeOtherAssembly" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="SomeTelemetryProcessor, SomeAssembly" />
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+              <Add Type="SomeOtherTelemetryProcessor, SomeOtherAssembly" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </original>
@@ -350,11 +448,15 @@
           </Add>
           <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector"/>
         </TelemetryModules>
-        <TelemetryProcessors>
-          <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
-          <Add Type="SomeTelemetryProcessor, SomeAssembly" />
-          <Add Type="SomeOtherTelemetryProcessor, SomeOtherAssembly" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+              <Add Type="SomeTelemetryProcessor, SomeAssembly" />
+              <Add Type="SomeOtherTelemetryProcessor, SomeOtherAssembly" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </expectedPostTransform>
@@ -362,10 +464,14 @@
     <expectedPostUninstall>
 
       <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
-        <TelemetryProcessors>
-          <Add Type="SomeTelemetryProcessor, SomeAssembly" />
-          <Add Type="SomeOtherTelemetryProcessor, SomeOtherAssembly" />
-        </TelemetryProcessors>
+        <TelemetrySinks>
+          <Add Name="default">
+            <TelemetryProcessors>
+              <Add Type="SomeTelemetryProcessor, SomeAssembly" />
+              <Add Type="SomeOtherTelemetryProcessor, SomeOtherAssembly" />
+            </TelemetryProcessors>
+          </Add>
+        </TelemetrySinks>
       </ApplicationInsights>
 
     </expectedPostUninstall>


### PR DESCRIPTION
Fix Issue #991 
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.