### PR TITLE
Some OperationDetails tests  improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## Version 2.8.0-beta3
-- [Partial fix for Activity is null for event = System.Net.Http.HttpRequestOut.Stop](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1009)
-
 ## Version 2.8.0-beta2
 - [LiveMetrics (QuickPulse) TelemetryProcessor added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/987)
 	If you are upgrading, and have added/modified TelemetryProcessors, make sure to copy them to the default sink section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.8.0-beta3
+- [Partial fix for Activity is null for event = System.Net.Http.HttpRequestOut.Stop](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1009)
+
 ## Version 2.8.0-beta2
 - [LiveMetrics (QuickPulse) TelemetryProcessor added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/987)
 	If you are upgrading, and have added/modified TelemetryProcessors, make sure to copy them to the default sink section.

--- a/Src/DependencyCollector/Net45.Tests/DependencyTrackingTelemetryModuleTest.cs
+++ b/Src/DependencyCollector/Net45.Tests/DependencyTrackingTelemetryModuleTest.cs
@@ -1,16 +1,11 @@
 ﻿namespace Microsoft.ApplicationInsights.Tests
 {
     using System;
-    using System.Net.Http;
     using System.Reflection;
-    using System.Threading;
 
-    using Microsoft.ApplicationInsights.Channel;
-    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
     using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.Web.TestFramework;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     /// <summary>

--- a/Src/DependencyCollector/Shared.Tests/DependencyCollector.Shared.Tests.projitems
+++ b/Src/DependencyCollector/Shared.Tests/DependencyCollector.Shared.Tests.projitems
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ServiceBusDiagnosticListenerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\SqlClientDiagnosticSourceListenerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\TelemetryDiagnosticSourceListenerTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)OperationDetailsInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)W3C\W3CActiviityExtentionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)W3C\W3COperationCorrelationTelemetryInitializerTests.cs" />
   </ItemGroup>

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
@@ -1,6 +1,7 @@
 namespace Microsoft.ApplicationInsights.Tests
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
@@ -29,10 +30,8 @@ namespace Microsoft.ApplicationInsights.Tests
         private const string HttpOkResultCode = "200";
         private const string NotFoundResultCode = "404";
 
-        private List<ITelemetry> sentTelemetry;
-        private object request;
-        private object response;
-        private object responseHeaders;
+        private readonly OperationDetailsInitializer operationDetailsInitializer = new OperationDetailsInitializer();
+        private readonly List<ITelemetry> sentTelemetry = new List<ITelemetry>();
 
         private TelemetryConfiguration configuration;
         private string testInstrumentationKey1 = nameof(testInstrumentationKey1);
@@ -47,27 +46,10 @@ namespace Microsoft.ApplicationInsights.Tests
         [TestInitialize]
         public void Initialize()
         {
-            this.sentTelemetry = new List<ITelemetry>();
-            this.request = null;
-            this.response = null;
-            this.responseHeaders = null;
-
-            this.telemetryChannel = new StubTelemetryChannel()
+            this.telemetryChannel = new StubTelemetryChannel
             {
                 EndpointAddress = "https://endpointaddress",
-                OnSend = telemetry =>
-                {
-                    this.sentTelemetry.Add(telemetry);
-
-                    // The correlation id lookup service also makes http call, just make sure we skip that
-                    DependencyTelemetry depTelemetry = telemetry as DependencyTelemetry;
-                    if (depTelemetry != null)
-                    {
-                        depTelemetry.TryGetOperationDetail(RemoteDependencyConstants.HttpRequestOperationDetailName, out this.request);
-                        depTelemetry.TryGetOperationDetail(RemoteDependencyConstants.HttpResponseOperationDetailName, out this.response);
-                        depTelemetry.TryGetOperationDetail(RemoteDependencyConstants.HttpResponseHeadersOperationDetailName, out this.responseHeaders);
-                    }
-                },
+                OnSend = telemetry => this.sentTelemetry.Add(telemetry)
             };
 
             this.testInstrumentationKey1 = Guid.NewGuid().ToString();
@@ -80,6 +62,8 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.configuration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
+            this.configuration.TelemetryInitializers.Add(this.operationDetailsInitializer);
+
             this.listener = new HttpCoreDiagnosticSourceListener(
                 this.configuration,
                 setComponentCorrelationHttpHeaders: true,
@@ -108,12 +92,11 @@ namespace Microsoft.ApplicationInsights.Tests
         [TestMethod]
         public void OnRequestWithRequestEventWithNoRequestUri()
         {
-            var request = new HttpRequestMessage();
+            var requestMsg = new HttpRequestMessage();
 
-            this.listener.OnRequest(request, Guid.NewGuid());
+            this.listener.OnRequest(requestMsg, Guid.NewGuid());
 
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
             Assert.AreEqual(0, this.sentTelemetry.Count);
         }
 
@@ -123,12 +106,12 @@ namespace Microsoft.ApplicationInsights.Tests
         [TestMethod]
         public void VerifyOnRequestWithSameDoesNotThrowException()
         {
-            Guid loggingRequestId = Guid.NewGuid();
+            var loggingRequestId = Guid.NewGuid();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, RequestUrlWithScheme);
+            var requestMsg = new HttpRequestMessage(HttpMethod.Get, RequestUrlWithScheme);
 
-            this.listener.OnRequest(request, loggingRequestId);
-            this.listener.OnRequest(request, loggingRequestId);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
         }
 
         /// <summary>
@@ -147,26 +130,25 @@ namespace Microsoft.ApplicationInsights.Tests
         {
             Guid loggingRequestId = Guid.NewGuid();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, RequestUrlWithScheme);
+            var requestMsg = new HttpRequestMessage(HttpMethod.Get, RequestUrlWithScheme);
 
             // first request, expected to fail
-            this.listener.OnRequest(request, loggingRequestId);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
 
             // second request (BEFORE HANDLING FIRST RESPONSE), expected to pass 
-            this.listener.OnRequest(request, loggingRequestId);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             // first request fails
-            HttpResponseMessage response1 = new HttpResponseMessage(HttpStatusCode.NotFound)
+            HttpResponseMessage responseMsg1 = new HttpResponseMessage(HttpStatusCode.NotFound)
             {
-                RequestMessage = request
+                RequestMessage = requestMsg
             };
 
-            this.listener.OnResponse(response1, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            this.listener.OnResponse(responseMsg1, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreEqual(false, ((DependencyTelemetry)this.sentTelemetry.Last()).Success); // first request fails
 
@@ -176,13 +158,13 @@ namespace Microsoft.ApplicationInsights.Tests
             // Because two identical requests were sent, whichever completes first will remove the request from pending telemetry.
 
             // second request is success
-            HttpResponseMessage response2 = new HttpResponseMessage(HttpStatusCode.OK)
+            HttpResponseMessage responseMsg2 = new HttpResponseMessage(HttpStatusCode.OK)
             {
-                RequestMessage = request
+                RequestMessage = requestMsg
             };
 
-            this.listener.OnResponse(response2, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            this.listener.OnResponse(responseMsg2, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
             Assert.AreEqual(2, this.sentTelemetry.Count);
             Assert.AreEqual(true, ((DependencyTelemetry)this.sentTelemetry.Last()).Success); // second request is success
         }
@@ -194,17 +176,16 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnRequestWithUriInExcludedDomainList()
         {
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "http://excluded.host.com/path/to/file.html");
-            this.listener.OnRequest(request, loggingRequestId);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, "http://excluded.host.com/path/to/file.html");
+            this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.RequestContextCorrelationSourceKey));
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.RequestIdHeader));
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.StandardParentIdHeader));
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.StandardRootIdHeader));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.RequestIdHeader));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.StandardParentIdHeader));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.StandardRootIdHeader));
         }
 
         /// <summary>
@@ -223,19 +204,18 @@ namespace Microsoft.ApplicationInsights.Tests
             using (listenerWithLegacyHeaders)
             {
                 Guid loggingRequestId = Guid.NewGuid();
-                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-                listenerWithLegacyHeaders.OnRequest(request, loggingRequestId);
+                HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+                listenerWithLegacyHeaders.OnRequest(requestMsg, loggingRequestId);
 
-                IOperationHolder<DependencyTelemetry> dependency;
                 Assert.IsTrue(
-                    listenerWithLegacyHeaders.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+                    listenerWithLegacyHeaders.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
                 Assert.AreEqual(0, this.sentTelemetry.Count);
 
-                var legacyRootIdHeader = GetRequestHeaderValues(request, RequestResponseHeaders.StandardRootIdHeader)
+                var legacyRootIdHeader = GetRequestHeaderValues(requestMsg, RequestResponseHeaders.StandardRootIdHeader)
                     .Single();
                 var legacyParentIdHeader =
-                    GetRequestHeaderValues(request, RequestResponseHeaders.StandardParentIdHeader).Single();
-                var requestIdHeader = GetRequestHeaderValues(request, RequestResponseHeaders.RequestIdHeader).Single();
+                    GetRequestHeaderValues(requestMsg, RequestResponseHeaders.StandardParentIdHeader).Single();
+                var requestIdHeader = GetRequestHeaderValues(requestMsg, RequestResponseHeaders.RequestIdHeader).Single();
                 Assert.AreEqual(dependency.Telemetry.Id, legacyParentIdHeader);
                 Assert.AreEqual(dependency.Telemetry.Context.Operation.Id, legacyRootIdHeader);
                 Assert.AreEqual(dependency.Telemetry.Id, requestIdHeader);
@@ -249,16 +229,15 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnRequestDoesNotInjectLegacyHeaders()
         {
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnRequest(request, loggingRequestId);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
-            var requestIdHeader = GetRequestHeaderValues(request, RequestResponseHeaders.RequestIdHeader).Single();
-            Assert.IsFalse(request.Headers.Contains(RequestResponseHeaders.StandardRootIdHeader));
-            Assert.IsFalse(request.Headers.Contains(RequestResponseHeaders.StandardParentIdHeader));
+            var requestIdHeader = GetRequestHeaderValues(requestMsg, RequestResponseHeaders.RequestIdHeader).Single();
+            Assert.IsFalse(requestMsg.Headers.Contains(RequestResponseHeaders.StandardRootIdHeader));
+            Assert.IsFalse(requestMsg.Headers.Contains(RequestResponseHeaders.StandardParentIdHeader));
             Assert.AreEqual(dependency.Telemetry.Id, requestIdHeader);
         }
 
@@ -269,11 +248,10 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnRequestWithRequestEvent()
         {
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnRequest(request, loggingRequestId);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
 
             DependencyTelemetry telemetry = dependency.Telemetry;
             Assert.AreEqual("POST /", telemetry.Name);
@@ -283,9 +261,9 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(string.Empty, telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success);
 
-            Assert.AreEqual(this.testApplicationId1, GetRequestContextKeyValue(request, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+            Assert.AreEqual(this.testApplicationId1, GetRequestContextKeyValue(requestMsg, RequestResponseHeaders.RequestContextCorrelationSourceKey));
 
-            var requestIdHeader = GetRequestHeaderValues(request, RequestResponseHeaders.RequestIdHeader).Single();
+            var requestIdHeader = GetRequestHeaderValues(requestMsg, RequestResponseHeaders.RequestIdHeader).Single();
             Assert.IsFalse(string.IsNullOrEmpty(requestIdHeader));
             Assert.AreEqual(0, this.sentTelemetry.Count);
         }
@@ -296,12 +274,12 @@ namespace Microsoft.ApplicationInsights.Tests
         [TestMethod]
         public void OnResponseWithResponseEventButNoMatchingRequest()
         {
-            var response = new HttpResponseMessage
+            var responseMsg = new HttpResponseMessage
             {
                 RequestMessage = new HttpRequestMessage(HttpMethod.Get, RequestUrlWithScheme)
             };
 
-            this.listener.OnResponse(response, Guid.NewGuid());
+            this.listener.OnResponse(responseMsg, Guid.NewGuid());
             Assert.AreEqual(0, this.sentTelemetry.Count);
         }
 
@@ -312,11 +290,10 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnResponseWithSuccessfulResponseEventWithMatchingRequestAndNoTargetInstrumentationKeyHasHeader()
         {
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnRequest(request, loggingRequestId);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
 
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
@@ -324,13 +301,13 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(string.Empty, telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success);
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK)
             {
-                RequestMessage = request
+                RequestMessage = requestMsg
             };
 
-            this.listener.OnResponse(response, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            this.listener.OnResponse(responseMsg, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -344,7 +321,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
         }
 
         /// <summary>
@@ -354,11 +331,10 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnResponseWithNotFoundResponseEventWithMatchingRequestAndNoTargetInstrumentationKeyHasHeader()
         {
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnRequest(request, loggingRequestId);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
 
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
@@ -366,13 +342,13 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(string.Empty, telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success);
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.NotFound)
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.NotFound)
             {
-                RequestMessage = request
+                RequestMessage = requestMsg
             };
 
-            this.listener.OnResponse(response, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            this.listener.OnResponse(responseMsg, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -382,7 +358,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(false, telemetry.Success);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
         }
 
         /// <summary>
@@ -392,10 +368,9 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnResponseWithSuccessfulResponseEventWithMatchingRequestAndSameTargetInstrumentationKeyHashHeader()
         {
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnRequest(request, loggingRequestId);
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
 
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
@@ -403,15 +378,15 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(string.Empty, telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success, "request was not successful");
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK)
             {
-                RequestMessage = request
+                RequestMessage = requestMsg
             };
 
-            response.Headers.Add(RequestResponseHeaders.RequestContextCorrelationTargetKey, this.testApplicationId1);
+            responseMsg.Headers.Add(RequestResponseHeaders.RequestContextCorrelationTargetKey, this.testApplicationId1);
 
-            this.listener.OnResponse(response, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            this.listener.OnResponse(responseMsg, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -421,7 +396,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(true, telemetry.Success, "response was not successful");
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
         }
 
         /// <summary>
@@ -431,25 +406,24 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnResponseWithFailedResponseEventWithMatchingRequestAndSameTargetInstrumentationKeyHashHeader()
         {
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnRequest(request, loggingRequestId);
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             DependencyTelemetry telemetry = dependency.Telemetry;
             Assert.AreEqual(string.Empty, telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success);
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.NotFound)
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.NotFound)
             {
-                RequestMessage = request
+                RequestMessage = requestMsg
             };
 
-            response.Headers.Add(RequestResponseHeaders.RequestContextCorrelationTargetKey, this.testApplicationId1);
+            responseMsg.Headers.Add(RequestResponseHeaders.RequestContextCorrelationTargetKey, this.testApplicationId1);
 
-            this.listener.OnResponse(response, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            this.listener.OnResponse(responseMsg, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -459,7 +433,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(false, telemetry.Success);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
         }
 
         /// <summary>
@@ -469,26 +443,25 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnResponseWithSuccessfulResponseEventWithMatchingRequestAndDifferentTargetInstrumentationKeyHashHeader()
         {
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnRequest(request, loggingRequestId);
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             DependencyTelemetry telemetry = dependency.Telemetry;
             Assert.AreEqual(string.Empty, telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success);
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK)
             {
-                RequestMessage = request
+                RequestMessage = requestMsg
             };
 
             string targetApplicationId = this.testApplicationId2;
-            HttpHeadersUtilities.SetRequestContextKeyValue(response.Headers, RequestResponseHeaders.RequestContextCorrelationTargetKey, targetApplicationId);
+            HttpHeadersUtilities.SetRequestContextKeyValue(responseMsg.Headers, RequestResponseHeaders.RequestContextCorrelationTargetKey, targetApplicationId);
 
-            this.listener.OnResponse(response, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            this.listener.OnResponse(responseMsg, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -498,7 +471,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(true, telemetry.Success);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
         }
 
         /// <summary>
@@ -508,26 +481,25 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnResponseWithFailedResponseEventWithMatchingRequestAndDifferentTargetInstrumentationKeyHashHeader()
         {
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnRequest(request, loggingRequestId);
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             DependencyTelemetry telemetry = dependency.Telemetry;
             Assert.AreEqual(string.Empty, telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success);
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.NotFound)
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.NotFound)
             {
-                RequestMessage = request
+                RequestMessage = requestMsg
             };
 
             string targetApplicationId = this.testApplicationId2;
-            HttpHeadersUtilities.SetRequestContextKeyValue(response.Headers, RequestResponseHeaders.RequestContextCorrelationTargetKey, targetApplicationId);
+            HttpHeadersUtilities.SetRequestContextKeyValue(responseMsg.Headers, RequestResponseHeaders.RequestContextCorrelationTargetKey, targetApplicationId);
 
-            this.listener.OnResponse(response, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            this.listener.OnResponse(responseMsg, loggingRequestId);
+            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -537,7 +509,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(false, telemetry.Success);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
         }
 
         /// <summary>
@@ -552,36 +524,35 @@ namespace Microsoft.ApplicationInsights.Tests
             parentActivity.Start();
 
             Guid loggingRequestId = Guid.NewGuid();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnRequest(request, loggingRequestId);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnRequest(requestMsg, loggingRequestId);
             Assert.IsNotNull(Activity.Current);
 
-            var parentId = request.Headers.GetValues(RequestResponseHeaders.RequestIdHeader).Single();
+            var parentId = requestMsg.Headers.GetValues(RequestResponseHeaders.RequestIdHeader).Single();
             Assert.AreEqual(Activity.Current.Id, parentId);
 
-            var correlationContextHeader = request.Headers.GetValues(RequestResponseHeaders.CorrelationContextHeader).ToArray();
+            var correlationContextHeader = requestMsg.Headers.GetValues(RequestResponseHeaders.CorrelationContextHeader).ToArray();
             Assert.AreEqual(2, correlationContextHeader.Length);
             Assert.IsTrue(correlationContextHeader.Contains("k1=v1"));
             Assert.IsTrue(correlationContextHeader.Contains("k2=v2"));
 
-            IOperationHolder<DependencyTelemetry> dependency;
-            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(request, out dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
 
             DependencyTelemetry telemetry = dependency.Telemetry;
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK)
             {
-                RequestMessage = request
+                RequestMessage = requestMsg
             };
 
-            this.listener.OnResponse(response, loggingRequestId);
+            this.listener.OnResponse(responseMsg, loggingRequestId);
             Assert.AreEqual(parentActivity, Activity.Current);
             Assert.AreEqual(parentId, telemetry.Id);
             Assert.AreEqual(parentActivity.RootId, telemetry.Context.Operation.Id);
             Assert.AreEqual(parentActivity.Id, telemetry.Context.Operation.ParentId);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
 
             parentActivity.Stop();
         }
@@ -599,22 +570,6 @@ namespace Microsoft.ApplicationInsights.Tests
         private static string GetRequestContextKeyValue(HttpRequestMessage request, string keyName)
         {
             return HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, keyName);
-        }
-
-        private void ValidateOperationDetails(DependencyTelemetry telemetry, bool responseExpected = true)
-        {
-            Assert.IsNotNull(this.request, "Request was not present and expected.");
-            Assert.IsNotNull(this.request as HttpRequestMessage, "Request was not the expected type.");
-            Assert.IsNull(this.responseHeaders, "Response headers were present and not expected.");
-            if (responseExpected)
-            {
-                Assert.IsNotNull(this.response, "Response was not present and expected.");
-                Assert.IsNotNull(this.response as HttpResponseMessage, "Response was not the expected type.");
-            }
-            else
-            {
-                Assert.IsNull(this.response, "Response was present and not expected.");
-            }
         }
     }
 }

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard16.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ApplicationInsights.Tests
 
             this.listener.OnRequest(requestMsg, Guid.NewGuid());
 
-            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out _));
             Assert.AreEqual(0, this.sentTelemetry.Count);
         }
 
@@ -138,7 +138,7 @@ namespace Microsoft.ApplicationInsights.Tests
             // second request (BEFORE HANDLING FIRST RESPONSE), expected to pass 
             this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out _));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             // first request fails
@@ -148,7 +148,7 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.listener.OnResponse(responseMsg1, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out _));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreEqual(false, ((DependencyTelemetry)this.sentTelemetry.Last()).Success); // first request fails
 
@@ -164,7 +164,7 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.listener.OnResponse(responseMsg2, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out _));
             Assert.AreEqual(2, this.sentTelemetry.Count);
             Assert.AreEqual(true, ((DependencyTelemetry)this.sentTelemetry.Last()).Success); // second request is success
         }
@@ -179,7 +179,7 @@ namespace Microsoft.ApplicationInsights.Tests
             HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, "http://excluded.host.com/path/to/file.html");
             this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out _));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out _));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.RequestContextCorrelationSourceKey));
@@ -208,7 +208,7 @@ namespace Microsoft.ApplicationInsights.Tests
                 listenerWithLegacyHeaders.OnRequest(requestMsg, loggingRequestId);
 
                 Assert.IsTrue(
-                    listenerWithLegacyHeaders.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+                    listenerWithLegacyHeaders.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
                 Assert.AreEqual(0, this.sentTelemetry.Count);
 
                 var legacyRootIdHeader = GetRequestHeaderValues(requestMsg, RequestResponseHeaders.StandardRootIdHeader)
@@ -232,7 +232,7 @@ namespace Microsoft.ApplicationInsights.Tests
             HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
             this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             var requestIdHeader = GetRequestHeaderValues(requestMsg, RequestResponseHeaders.RequestIdHeader).Single();
@@ -251,7 +251,7 @@ namespace Microsoft.ApplicationInsights.Tests
             HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
             this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
 
             DependencyTelemetry telemetry = dependency.Telemetry;
             Assert.AreEqual("POST /", telemetry.Name);
@@ -293,7 +293,7 @@ namespace Microsoft.ApplicationInsights.Tests
             HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
             this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
 
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
@@ -307,7 +307,7 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.listener.OnResponse(responseMsg, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -334,7 +334,7 @@ namespace Microsoft.ApplicationInsights.Tests
             HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
             this.listener.OnRequest(requestMsg, loggingRequestId);
 
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
 
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
@@ -348,7 +348,7 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.listener.OnResponse(responseMsg, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -370,7 +370,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Guid loggingRequestId = Guid.NewGuid();
             HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
             this.listener.OnRequest(requestMsg, loggingRequestId);
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
 
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
@@ -386,7 +386,7 @@ namespace Microsoft.ApplicationInsights.Tests
             responseMsg.Headers.Add(RequestResponseHeaders.RequestContextCorrelationTargetKey, this.testApplicationId1);
 
             this.listener.OnResponse(responseMsg, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -408,7 +408,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Guid loggingRequestId = Guid.NewGuid();
             HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
             this.listener.OnRequest(requestMsg, loggingRequestId);
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             DependencyTelemetry telemetry = dependency.Telemetry;
@@ -423,7 +423,7 @@ namespace Microsoft.ApplicationInsights.Tests
             responseMsg.Headers.Add(RequestResponseHeaders.RequestContextCorrelationTargetKey, this.testApplicationId1);
 
             this.listener.OnResponse(responseMsg, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -445,7 +445,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Guid loggingRequestId = Guid.NewGuid();
             HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
             this.listener.OnRequest(requestMsg, loggingRequestId);
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             DependencyTelemetry telemetry = dependency.Telemetry;
@@ -461,7 +461,7 @@ namespace Microsoft.ApplicationInsights.Tests
             HttpHeadersUtilities.SetRequestContextKeyValue(responseMsg.Headers, RequestResponseHeaders.RequestContextCorrelationTargetKey, targetApplicationId);
 
             this.listener.OnResponse(responseMsg, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -483,7 +483,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Guid loggingRequestId = Guid.NewGuid();
             HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
             this.listener.OnRequest(requestMsg, loggingRequestId);
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
             Assert.AreEqual(0, this.sentTelemetry.Count);
 
             DependencyTelemetry telemetry = dependency.Telemetry;
@@ -499,7 +499,7 @@ namespace Microsoft.ApplicationInsights.Tests
             HttpHeadersUtilities.SetRequestContextKeyValue(responseMsg.Headers, RequestResponseHeaders.RequestContextCorrelationTargetKey, targetApplicationId);
 
             this.listener.OnResponse(responseMsg, loggingRequestId);
-            Assert.IsFalse(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out dependency));
+            Assert.IsFalse(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out dependency));
             Assert.AreEqual(1, this.sentTelemetry.Count);
             Assert.AreSame(telemetry, this.sentTelemetry.Single());
 
@@ -536,7 +536,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.IsTrue(correlationContextHeader.Contains("k1=v1"));
             Assert.IsTrue(correlationContextHeader.Contains("k2=v2"));
 
-            Assert.IsTrue(this.listener.PendingDependencyTelemetryCore10.TryGetValue(requestMsg, out var dependency));
+            Assert.IsTrue(this.listener.PendingDependencyTelemetry.TryGetValue(requestMsg, out var dependency));
 
             DependencyTelemetry telemetry = dependency.Telemetry;
 

--- a/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netstandard20.cs
@@ -33,14 +33,14 @@ namespace Microsoft.ApplicationInsights.Tests
             activity.AddBaggage("k", "v");
             activity.Start();
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnActivityStart(request);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
 
             // Request-Id and Correlation-Context are injected by HttpClient
             // check only legacy headers here
-            Assert.IsFalse(request.Headers.Contains(RequestResponseHeaders.StandardRootIdHeader));
-            Assert.IsFalse(request.Headers.Contains(RequestResponseHeaders.StandardParentIdHeader));
-            Assert.AreEqual(this.testApplicationId1, GetRequestContextKeyValue(request, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+            Assert.IsFalse(requestMsg.Headers.Contains(RequestResponseHeaders.StandardRootIdHeader));
+            Assert.IsFalse(requestMsg.Headers.Contains(RequestResponseHeaders.StandardParentIdHeader));
+            Assert.AreEqual(this.testApplicationId1, GetRequestContextKeyValue(requestMsg, RequestResponseHeaders.RequestContextCorrelationSourceKey));
         }
 
         /// <summary>
@@ -62,17 +62,17 @@ namespace Microsoft.ApplicationInsights.Tests
                 activity.AddBaggage("k", "v");
                 activity.Start();
 
-                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-                listenerWithLegacyHeaders.OnActivityStart(request);
+                HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+                listenerWithLegacyHeaders.OnActivityStart(requestMsg);
 
                 // Request-Id and Correlation-Context are injected by HttpClient
                 // check only legacy headers here
                 Assert.AreEqual(Activity.Current.RootId,
-                    request.Headers.GetValues(RequestResponseHeaders.StandardRootIdHeader).Single());
+                    requestMsg.Headers.GetValues(RequestResponseHeaders.StandardRootIdHeader).Single());
                 Assert.AreEqual(Activity.Current.Id,
-                    request.Headers.GetValues(RequestResponseHeaders.StandardParentIdHeader).Single());
+                    requestMsg.Headers.GetValues(RequestResponseHeaders.StandardParentIdHeader).Single());
                 Assert.AreEqual(this.testApplicationId1,
-                    GetRequestContextKeyValue(request, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+                    GetRequestContextKeyValue(requestMsg, RequestResponseHeaders.RequestContextCorrelationSourceKey));
             }
         }
 
@@ -96,14 +96,14 @@ namespace Microsoft.ApplicationInsights.Tests
             {
                 var activity = new Activity("System.Net.Http.HttpRequestOut").SetParentId("|guid.").Start();
 
-                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-                listenerWithW3CHeaders.OnActivityStart(request);
+                HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+                listenerWithW3CHeaders.OnActivityStart(requestMsg);
 
                 // Request-Id and Correlation-Context are injected by HttpClient
                 // check only W3C headers here
-                Assert.AreEqual(this.testApplicationId1, GetRequestContextKeyValue(request, RequestResponseHeaders.RequestContextCorrelationSourceKey));
-                Assert.AreEqual($"00-{activity.GetTraceId()}-{activity.GetSpanId()}-02", request.Headers.GetValues(W3CConstants.TraceParentHeader).Single());
-                Assert.AreEqual($"{W3CConstants.AzureTracestateNamespace}={this.testApplicationId1}", request.Headers.GetValues(W3CConstants.TraceStateHeader).Single());
+                Assert.AreEqual(this.testApplicationId1, GetRequestContextKeyValue(requestMsg, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+                Assert.AreEqual($"00-{activity.GetTraceId()}-{activity.GetSpanId()}-02", requestMsg.Headers.GetValues(W3CConstants.TraceParentHeader).Single());
+                Assert.AreEqual($"{W3CConstants.AzureTracestateNamespace}={this.testApplicationId1}", requestMsg.Headers.GetValues(W3CConstants.TraceStateHeader).Single());
             }
         }
 
@@ -125,15 +125,54 @@ namespace Microsoft.ApplicationInsights.Tests
             {
                 var activity = new Activity("System.Net.Http.HttpRequestOut").SetParentId("foo").Start();
 
-                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-                listenerWithW3CHeaders.OnActivityStart(request);
+                HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+                listenerWithW3CHeaders.OnActivityStart(requestMsg);
 
                 // simulate Request-Id injection by .NET
-                request.Headers.Add(RequestResponseHeaders.RequestIdHeader, activity.Id);
+                requestMsg.Headers.Add(RequestResponseHeaders.RequestIdHeader, activity.Id);
 
-                listenerWithW3CHeaders.OnActivityStop(new HttpResponseMessage(HttpStatusCode.OK), request, TaskStatus.RanToCompletion);
+                listenerWithW3CHeaders.OnActivityStop(new HttpResponseMessage(HttpStatusCode.OK), requestMsg, TaskStatus.RanToCompletion);
 
                 var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
+                Assert.IsNotNull(telemetry);
+                Assert.IsTrue(telemetry.Properties.ContainsKey(W3CConstants.LegacyRequestIdProperty));
+                Assert.AreEqual(activity.Id, telemetry.Properties[W3CConstants.LegacyRequestIdProperty]);
+
+                Assert.IsTrue(telemetry.Properties.ContainsKey(W3CConstants.LegacyRootIdProperty));
+                Assert.AreEqual(activity.RootId, telemetry.Properties[W3CConstants.LegacyRootIdProperty]);
+            }
+        }
+
+        /// <summary>
+        /// Tests that OnStartActivity injects W3C headers.
+        /// </summary>
+        [TestMethod]
+        public void OnActivityStartInjectsW3CHeadersAndTracksLegacyIdWhenActivityIsNullInStop()
+        {
+            var listenerWithW3CHeaders = new HttpCoreDiagnosticSourceListener(
+                this.configuration,
+                setComponentCorrelationHttpHeaders: true,
+                correlationDomainExclusionList: new string[0],
+                injectLegacyHeaders: false,
+                injectW3CHeaders: true);
+
+            this.configuration.TelemetryInitializers.Add(new W3COperationCorrelationTelemetryInitializer());
+            using (listenerWithW3CHeaders)
+            {
+                var activity = new Activity("System.Net.Http.HttpRequestOut").SetParentId("foo").Start();
+
+                HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+                listenerWithW3CHeaders.OnActivityStart(requestMsg);
+
+                // simulate Request-Id injection by .NET
+                requestMsg.Headers.Add(RequestResponseHeaders.RequestIdHeader, activity.Id);
+
+                activity.Stop();
+                Assert.IsNull(Activity.Current);
+                listenerWithW3CHeaders.OnActivityStop(new HttpResponseMessage(HttpStatusCode.OK), requestMsg, TaskStatus.RanToCompletion);
+
+                var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
+                Assert.IsNotNull(telemetry);
                 Assert.IsTrue(telemetry.Properties.ContainsKey(W3CConstants.LegacyRequestIdProperty));
                 Assert.AreEqual(activity.Id, telemetry.Properties[W3CConstants.LegacyRequestIdProperty]);
 
@@ -148,23 +187,26 @@ namespace Microsoft.ApplicationInsights.Tests
         /// Tests that OnStopActivity tracks telemetry.
         /// </summary>
         [TestMethod]
-        public void OnActivityStopTracksTelemetry()
+        public async Task OnActivityStopTracksTelemetry()
         {
-            var activity = new Activity("System.Net.Http.HttpRequestOut");
-            activity.AddBaggage("k", "v");
-            var startTime = DateTime.UtcNow.AddSeconds(-1);
-            activity.SetStartTime(startTime);
-            activity.Start();
+            var activity = new Activity("System.Net.Http.HttpRequestOut")
+                .AddBaggage("k", "v")
+                .Start();
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnActivityStart(request);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
 
+            var approxStartTime = DateTime.UtcNow;
             activity = Activity.Current;
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
-            this.listener.OnActivityStop(response, request, TaskStatus.RanToCompletion);
+
+            await Task.Delay(10);
+
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK);
+            this.listener.OnActivityStop(responseMsg, requestMsg, TaskStatus.RanToCompletion);
 
             var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
 
+            Assert.IsNotNull(telemetry);
             Assert.AreEqual("POST /", telemetry.Name);
             Assert.AreEqual(RequestUrl, telemetry.Target);
             Assert.AreEqual(RemoteDependencyConstants.HTTP, telemetry.Type);
@@ -172,9 +214,8 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual("200", telemetry.ResultCode);
             Assert.AreEqual(true, telemetry.Success);
 
-            Assert.AreEqual(activity.StartTimeUtc, telemetry.Timestamp);
-            Assert.IsTrue(1 <= telemetry.Duration.TotalSeconds);
-            Assert.IsTrue(2 > telemetry.Duration.TotalSeconds);
+            Assert.IsTrue(Math.Abs((telemetry.Timestamp - approxStartTime).TotalMilliseconds) < 100);
+            Assert.IsTrue(telemetry.Duration.TotalMilliseconds > 10);
 
             Assert.AreEqual(activity.RootId, telemetry.Context.Operation.Id);
             Assert.AreEqual(activity.ParentId, telemetry.Context.Operation.ParentId);
@@ -186,7 +227,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
         }
 
         /// <summary>
@@ -201,16 +242,16 @@ namespace Microsoft.ApplicationInsights.Tests
             activity.SetStartTime(startTime);
             activity.Start();
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnActivityStart(request);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
 
-            activity = Activity.Current;
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
-            this.listener.OnActivityStop(response, request, TaskStatus.RanToCompletion);
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK);
+            this.listener.OnActivityStop(responseMsg, requestMsg, TaskStatus.RanToCompletion);
 
             var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
 
             // W3C compatible-Id ( should go away when W3C is implemented in .NET https://github.com/dotnet/corefx/issues/30331 TODO)
+            Assert.IsNotNull(telemetry);
             Assert.AreEqual(32, telemetry.Context.Operation.Id.Length);
             Assert.IsTrue(Regex.Match(telemetry.Context.Operation.Id, @"[a-z][0-9]").Success);
             // end of workaround test
@@ -222,18 +263,19 @@ namespace Microsoft.ApplicationInsights.Tests
         [TestMethod]
         public void OnActivityWithParentId()
         {
-            var activity = new Activity("System.Net.Http.HttpRequestOut")
+            new Activity("System.Net.Http.HttpRequestOut")
                 .SetParentId("parent")
                 .Start();
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnActivityStart(request);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
-            this.listener.OnActivityStop(response, request, TaskStatus.RanToCompletion);
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK);
+            this.listener.OnActivityStop(responseMsg, requestMsg, TaskStatus.RanToCompletion);
 
             var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
 
+            Assert.IsNotNull(telemetry);
             Assert.AreEqual("parent", telemetry.Context.Operation.Id);
             Assert.AreEqual("parent", telemetry.Context.Operation.ParentId);
         }
@@ -245,16 +287,17 @@ namespace Microsoft.ApplicationInsights.Tests
         public void OnActivityWithParent()
         {
             var parent = new Activity("dummy").Start();
-            var activity = new Activity("System.Net.Http.HttpRequestOut").Start();
+            new Activity("System.Net.Http.HttpRequestOut").Start();
  
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnActivityStart(request);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
-            this.listener.OnActivityStop(response, request, TaskStatus.RanToCompletion);
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK);
+            this.listener.OnActivityStop(responseMsg, requestMsg, TaskStatus.RanToCompletion);
 
             var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
 
+            Assert.IsNotNull(telemetry);
             Assert.AreEqual(parent.RootId, telemetry.Context.Operation.Id);
             Assert.AreEqual(parent.Id, telemetry.Context.Operation.ParentId);
         }
@@ -271,14 +314,15 @@ namespace Microsoft.ApplicationInsights.Tests
 
             var activity = new Activity("System.Net.Http.HttpRequestOut").Start();
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnActivityStart(request);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
-            this.listener.OnActivityStop(response, request, TaskStatus.RanToCompletion);
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK);
+            this.listener.OnActivityStop(responseMsg, requestMsg, TaskStatus.RanToCompletion);
 
             var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
 
+            Assert.IsNotNull(telemetry);
             Assert.AreEqual(parent.RootId, telemetry.Context.Operation.Id);
             Assert.AreEqual(parent.Id, telemetry.Context.Operation.ParentId);
             Assert.AreEqual(activity.Id, telemetry.Id);
@@ -289,7 +333,7 @@ namespace Microsoft.ApplicationInsights.Tests
             Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
         }
 
         /// <summary>
@@ -301,18 +345,19 @@ namespace Microsoft.ApplicationInsights.Tests
             var activity = new Activity("System.Net.Http.HttpRequestOut");
             activity.Start();
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnActivityStart(request);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
 
-            this.listener.OnActivityStop(null, request, TaskStatus.Canceled);
+            this.listener.OnActivityStop(null, requestMsg, TaskStatus.Canceled);
 
             var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
 
+            Assert.IsNotNull(telemetry);
             Assert.AreEqual("Canceled", telemetry.ResultCode);
             Assert.AreEqual(false, telemetry.Success);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry, responseExpected: false);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry, responseExpected: false);
         }
 
         /// <summary>
@@ -324,18 +369,19 @@ namespace Microsoft.ApplicationInsights.Tests
             var activity = new Activity("System.Net.Http.HttpRequestOut");
             activity.Start();
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnActivityStart(request);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
 
-            this.listener.OnActivityStop(null, request, TaskStatus.Faulted);
+            this.listener.OnActivityStop(null, requestMsg, TaskStatus.Faulted);
 
             var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
 
+            Assert.IsNotNull(telemetry);
             Assert.AreEqual("Faulted", telemetry.ResultCode);
             Assert.AreEqual(false, telemetry.Success);
 
             // Check the operation details
-            this.ValidateOperationDetails(telemetry, responseExpected: false);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry, responseExpected: false);
         }
 
         /// <summary>
@@ -347,24 +393,26 @@ namespace Microsoft.ApplicationInsights.Tests
             var activity = new Activity("System.Net.Http.HttpRequestOut");
             activity.Start();
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
-            this.listener.OnActivityStart(request);
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
 
             var exception = new HttpRequestException("message", new Exception("The server name or address could not be resolved"));
-            this.listener.OnException(exception, request);
-            this.listener.OnActivityStop(null, request, TaskStatus.Faulted);
+            this.listener.OnException(exception, requestMsg);
+            this.listener.OnActivityStop(null, requestMsg, TaskStatus.Faulted);
 
             var dependencyTelemetry = this.sentTelemetry.Single(t => t is DependencyTelemetry) as DependencyTelemetry;
             var exceptionTelemetry = this.sentTelemetry.Single(t => t is ExceptionTelemetry) as ExceptionTelemetry;
 
             Assert.AreEqual(2, this.sentTelemetry.Count);
+            Assert.IsNotNull(exceptionTelemetry);
+            Assert.IsNotNull(dependencyTelemetry);
             Assert.AreEqual(exception, exceptionTelemetry.Exception);
             Assert.AreEqual(exceptionTelemetry.Context.Operation.Id, dependencyTelemetry.Context.Operation.Id);
             Assert.AreEqual(exceptionTelemetry.Context.Operation.ParentId, dependencyTelemetry.Id);
             Assert.AreEqual("The server name or address could not be resolved", dependencyTelemetry.Properties["Error"]);
 
             // Check the operation details
-            this.ValidateOperationDetails(dependencyTelemetry, responseExpected: false);
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(dependencyTelemetry, responseExpected: false);
         }
 
         /// <summary>
@@ -377,16 +425,16 @@ namespace Microsoft.ApplicationInsights.Tests
             activity.Start();
 
             var appInsightsUrl = TelemetryConfiguration.Active.TelemetryChannel.EndpointAddress;
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, appInsightsUrl);
-            this.listener.OnActivityStart(request);
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.RequestContextCorrelationSourceKey));
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.RequestIdHeader));
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.StandardParentIdHeader));
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.StandardRootIdHeader));
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Get, appInsightsUrl);
+            this.listener.OnActivityStart(requestMsg);
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.RequestIdHeader));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.StandardParentIdHeader));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.StandardRootIdHeader));
 
             var exception = new HttpRequestException("message", new Exception("The server name or address could not be resolved"));
-            this.listener.OnException(exception, request);
-            this.listener.OnActivityStop(null, request, TaskStatus.Faulted);
+            this.listener.OnException(exception, requestMsg);
+            this.listener.OnActivityStop(null, requestMsg, TaskStatus.Faulted);
 
             Assert.IsFalse(this.sentTelemetry.Any());
         }
@@ -397,12 +445,98 @@ namespace Microsoft.ApplicationInsights.Tests
         [TestMethod]
         public void OnStartActivityWithUriInExcludedDomainList()
         {
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "http://excluded.host.com/path/to/file.html");
-            this.listener.OnActivityStart(request);
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.RequestContextCorrelationSourceKey));
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.RequestIdHeader));
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.StandardParentIdHeader));
-            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(request.Headers, RequestResponseHeaders.StandardRootIdHeader));
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, "http://excluded.host.com/path/to/file.html");
+            this.listener.OnActivityStart(requestMsg);
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.RequestIdHeader));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.StandardParentIdHeader));
+            Assert.IsNull(HttpHeadersUtilities.GetRequestContextKeyValue(requestMsg.Headers, RequestResponseHeaders.StandardRootIdHeader));
+        }
+
+        /// <summary>
+        /// Tests that if OnStopActivity is called with null Activity, dependency is still tracked
+        /// </summary>
+        [TestMethod]
+        public async Task OnActivityStopWithNullActivityTracksDependency()
+        {
+            var activity = new Activity("System.Net.Http.HttpRequestOut")
+                .AddBaggage("k", "v")
+                .Start();
+
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
+
+            await Task.Delay(10);
+
+            activity = Activity.Current;
+            activity.Stop();
+
+            Assert.IsNull(Activity.Current);
+
+            HttpResponseMessage responseMsg = new HttpResponseMessage(HttpStatusCode.OK);
+            this.listener.OnActivityStop(responseMsg, requestMsg, TaskStatus.RanToCompletion);
+
+            var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
+
+            Assert.IsNotNull(telemetry);
+            Assert.AreEqual("POST /", telemetry.Name);
+            Assert.AreEqual(RequestUrl, telemetry.Target);
+            Assert.AreEqual(RemoteDependencyConstants.HTTP, telemetry.Type);
+            Assert.AreEqual(RequestUrlWithScheme, telemetry.Data);
+            Assert.AreEqual("200", telemetry.ResultCode);
+            Assert.AreEqual(true, telemetry.Success);
+
+            Assert.AreEqual(activity.RootId, telemetry.Context.Operation.Id);
+            Assert.AreEqual(activity.ParentId, telemetry.Context.Operation.ParentId);
+            Assert.AreEqual(activity.Id, telemetry.Id);
+            Assert.AreEqual("v", telemetry.Properties["k"]);
+
+            string expectedVersion =
+                SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), prefix: "rdddsc:");
+            Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
+
+            // Check the operation details
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry);
+        }
+
+        [TestMethod]
+        public async Task OnActivityStopWithNullActivityAndNoResponseTracksDependency()
+        {
+            var activity = new Activity("System.Net.Http.HttpRequestOut")
+                .Start();
+
+            HttpRequestMessage requestMsg = new HttpRequestMessage(HttpMethod.Post, RequestUrlWithScheme);
+            this.listener.OnActivityStart(requestMsg);
+
+            await Task.Delay(10);
+
+            activity = Activity.Current;
+            activity.Stop();
+
+            Assert.IsNull(Activity.Current);
+
+            this.listener.OnActivityStop(null, requestMsg, TaskStatus.Faulted);
+
+            var telemetry = this.sentTelemetry.Single() as DependencyTelemetry;
+
+            Assert.IsNotNull(telemetry);
+            Assert.AreEqual("POST /", telemetry.Name);
+            Assert.AreEqual(RequestUrl, telemetry.Target);
+            Assert.AreEqual(RemoteDependencyConstants.HTTP, telemetry.Type);
+            Assert.AreEqual(RequestUrlWithScheme, telemetry.Data);
+            Assert.AreEqual(false, telemetry.Success);
+            Assert.AreEqual("Faulted", telemetry.ResultCode);
+
+            Assert.AreEqual(activity.RootId, telemetry.Context.Operation.Id);
+            Assert.AreEqual(activity.ParentId, telemetry.Context.Operation.ParentId);
+            Assert.AreEqual(activity.Id, telemetry.Id);
+
+            string expectedVersion =
+                SdkVersionHelper.GetExpectedSdkVersion(typeof(DependencyTrackingTelemetryModule), prefix: "rdddsc:");
+            Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
+
+            // Check the operation details
+            this.operationDetailsInitializer.ValidateOperationDetailsCore(telemetry, responseExpected: false);
         }
     }
 }

--- a/Src/DependencyCollector/Shared.Tests/OperationDetailsInitializer.cs
+++ b/Src/DependencyCollector/Shared.Tests/OperationDetailsInitializer.cs
@@ -1,0 +1,92 @@
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Net;
+    using System.Net.Http;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    public class OperationDetailsInitializer : ITelemetryInitializer
+    {
+        private readonly ConcurrentDictionary<DependencyTelemetry, Tuple<object, object, object>> operationDetails =
+            new ConcurrentDictionary<DependencyTelemetry, Tuple<object, object, object>>();
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (telemetry is DependencyTelemetry dependency)
+            {
+                dependency.TryGetOperationDetail(RemoteDependencyConstants.HttpRequestOperationDetailName, out var request);
+                dependency.TryGetOperationDetail(RemoteDependencyConstants.HttpResponseOperationDetailName, out var response);
+                dependency.TryGetOperationDetail(RemoteDependencyConstants.HttpResponseHeadersOperationDetailName, out var responseHeaders);
+
+                var newDetails = new Tuple<object, object, object>(request, response, responseHeaders);
+                this.operationDetails.AddOrUpdate(dependency, newDetails, (d, o) => newDetails);
+            }
+        }
+
+        public void ValidateOperationDetailsCore(DependencyTelemetry telemetry, bool responseExpected = true)
+        {
+            Assert.IsTrue(this.TryGetDetails(telemetry, out var request, out var response, out var responseHeaders));
+
+            Assert.IsNotNull(request, "Request was not present and expected.");
+            Assert.IsNotNull(request as HttpRequestMessage, "Request was not the expected type.");
+            Assert.IsNull(responseHeaders, "Response headers were present and not expected.");
+            if (responseExpected)
+            {
+                Assert.IsNotNull(response, "Response was not present and expected.");
+                Assert.IsNotNull(response as HttpResponseMessage, "Response was not the expected type.");
+            }
+            else
+            {
+                Assert.IsNull(response, "Response was present and not expected.");
+            }
+        }
+
+        public void ValidateOperationDetailsDesktop(DependencyTelemetry telemetry, bool responseExpected = true, bool headersExpected = false)
+        {
+            Assert.IsTrue(this.TryGetDetails(telemetry, out var request, out var response, out var responseHeaders));
+
+            Assert.IsNotNull(request, "Request was not present and expected.");
+            Assert.IsNotNull(request as HttpWebRequest, "Request was not the expected type.");
+
+            if (responseExpected)
+            {
+                Assert.IsNotNull(response, "Response was not present and expected.");
+                Assert.IsNotNull(response as HttpWebResponse, "Response was not the expected type.");
+            }
+            else
+            {
+                Assert.IsNull(response, "Response was present and not expected.");
+            }
+
+            if (headersExpected)
+            {
+                Assert.IsNotNull(responseHeaders, "Response headers were not present and expected.");
+                Assert.IsNotNull(responseHeaders as WebHeaderCollection, "Response headers were not the expected type.");
+            }
+            else
+            {
+                Assert.IsNull(responseHeaders, "Response headers were present and not expected.");
+            }
+        }
+
+        private bool TryGetDetails(DependencyTelemetry depednency, out object request, out object response,
+            out object responseHeaders)
+        {
+            request = response = responseHeaders = null;
+            if (this.operationDetails.TryGetValue(depednency, out var tuple))
+            {
+                request = tuple.Item1;
+                response = tuple.Item2;
+                responseHeaders = tuple.Item3;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
While working on #https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1010 I found some issues with tests for setting operation details on telemetry:

- details were set implicitly
- names of the instance variables conflicted with local names

The #1010 was abandoned, but I still think test improvements make sense. 