### PR TITLE
consolidate test dependencies

### DIFF
--- a/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
+++ b/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
@@ -52,9 +52,6 @@
    </ItemGroup>
    -->
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
@@ -111,6 +108,9 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="$(SolutionDir)\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="replacecontainernamewithip.ps1">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -147,4 +147,5 @@
     <Error Condition="!Exists('..\..\..\..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
   <Import Project="..\..\..\..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\..\..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="$(SolutionDir)\Test.Common.Sdk.Net45.targets" />
 </Project>

--- a/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
+++ b/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
@@ -108,7 +108,7 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="$(SolutionDir)\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
     <None Include="replacecontainernamewithip.ps1">

--- a/Test/E2ETests/E2ETests/packages.config
+++ b/Test/E2ETests/E2ETests/packages.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net47" />
   <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net47" />
   <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net47" />

--- a/Test/E2ETests/Test.Common.Sdk.Net45.targets
+++ b/Test/E2ETests/Test.Common.Sdk.Net45.targets
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<ItemGroup>
-		<Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-		</Reference>
-		<Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-		</Reference>
-	</ItemGroup>
+	<Import Project="$(SolutionDir)\..\Test.Common.Dependencies.Net45.targets" />
 
 	<ItemGroup>
 		<Reference Include="Microsoft.AI.DependencyCollector">

--- a/Test/E2ETests/Test.Common.Sdk.Net45.targets
+++ b/Test/E2ETests/Test.Common.Sdk.Net45.targets
@@ -2,6 +2,15 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<ItemGroup>
+		<Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+		</Reference>
+		<Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+
+	<ItemGroup>
 		<Reference Include="Microsoft.AI.DependencyCollector">
 			<HintPath>$(BinRoot)\$(Configuration)\Src\DependencyCollector\DependencyCollector\Net45\Microsoft.AI.DependencyCollector.dll</HintPath>
 		</Reference>

--- a/Test/E2ETests/Test.Common.Sdk.Net45.targets
+++ b/Test/E2ETests/Test.Common.Sdk.Net45.targets
@@ -3,10 +3,10 @@
 
 	<ItemGroup>
 		<Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
 		</Reference>
 		<Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
@@ -52,12 +52,6 @@
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
@@ -278,6 +272,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
+    <None Include="$(SolutionDir)\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="Scripts\jquery-1.10.2.min.map" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
@@ -272,7 +272,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
-    <None Include="$(SolutionDir)\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
     <Content Include="Scripts\jquery-1.10.2.min.map" />

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/packages.config
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/packages.config
@@ -5,8 +5,6 @@
   <package id="AspNet.ScriptManager.jQuery" version="1.10.2" targetFramework="net452" />
   <package id="bootstrap" version="3.0.0" targetFramework="net452" />
   <package id="jQuery" version="1.10.2" targetFramework="net452" />
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net452" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net452" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net452" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net452" />
   <package id="Microsoft.AspNet.ScriptManager.MSAjax" version="5.0.0" targetFramework="net452" />

--- a/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
+++ b/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
@@ -48,12 +48,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
@@ -257,6 +251,9 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="$(SolutionDir)\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Scripts\jquery-1.10.2.min.map" />

--- a/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
+++ b/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
@@ -251,7 +251,7 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="$(SolutionDir)\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/Test/E2ETests/TestApps/Net452/E2ETestWebApi/packages.config
+++ b/Test/E2ETests/TestApps/Net452/E2ETestWebApi/packages.config
@@ -3,8 +3,6 @@
   <package id="Antlr" version="3.4.1.9004" targetFramework="net452" />
   <package id="bootstrap" version="3.0.0" targetFramework="net452" />
   <package id="jQuery" version="1.10.2" targetFramework="net452" />
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net452" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net452" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net452" />

--- a/Test/E2ETests/test.common.packages.config
+++ b/Test/E2ETests/test.common.packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
-</packages>

--- a/Test/E2ETests/test.common.packages.config
+++ b/Test/E2ETests/test.common.packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
+</packages>

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
@@ -115,7 +115,7 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="$(SolutionDir)\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
     <Content Include="ApplicationInsights.config">

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
@@ -41,15 +41,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="Newtonsoft.Json">
@@ -124,6 +115,9 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="$(SolutionDir)\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="ApplicationInsights.config">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/packages.config
+++ b/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/packages.config
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net451" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />

--- a/Test/PerformanceCollector/Test.Common.Sdk.Net45.targets
+++ b/Test/PerformanceCollector/Test.Common.Sdk.Net45.targets
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	
+	<ItemGroup>
+		<Reference Include="Microsoft.AI.ServerTelemetryChannel">
+			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+			<Private>True</Private>
+		</Reference>
+		<Reference Include="Microsoft.ApplicationInsights">
+			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+			<Private>True</Private>
+		</Reference>
+	</ItemGroup>
 
 	<ItemGroup>
 		<Reference Include="Microsoft.ApplicationInsights">

--- a/Test/PerformanceCollector/Test.Common.Sdk.Net45.targets
+++ b/Test/PerformanceCollector/Test.Common.Sdk.Net45.targets
@@ -1,16 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	
-	<ItemGroup>
-		<Reference Include="Microsoft.AI.ServerTelemetryChannel">
-			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-			<Private>True</Private>
-		</Reference>
-		<Reference Include="Microsoft.ApplicationInsights">
-			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-			<Private>True</Private>
-		</Reference>
-	</ItemGroup>
+	<Import Project="$(SolutionDir)\..\Test.Common.Dependencies.Net45.targets" />
 
 	<ItemGroup>
 		<Reference Include="Microsoft.ApplicationInsights">

--- a/Test/PerformanceCollector/Test.Common.Sdk.Net45.targets
+++ b/Test/PerformanceCollector/Test.Common.Sdk.Net45.targets
@@ -3,11 +3,11 @@
 	
 	<ItemGroup>
 		<Reference Include="Microsoft.AI.ServerTelemetryChannel">
-			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
 			<Private>True</Private>
 		</Reference>
 		<Reference Include="Microsoft.ApplicationInsights">
-			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
 			<Private>True</Private>
 		</Reference>
 	</ItemGroup>

--- a/Test/PerformanceCollector/test.common.packages.config
+++ b/Test/PerformanceCollector/test.common.packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
-</packages>

--- a/Test/PerformanceCollector/test.common.packages.config
+++ b/Test/PerformanceCollector/test.common.packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
+</packages>

--- a/Test/Test.Common.Dependencies.Net45.targets
+++ b/Test/Test.Common.Dependencies.Net45.targets
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	
+	<ItemGroup>
+		<Reference Include="Microsoft.AI.ServerTelemetryChannel">
+			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+			<Private>True</Private>
+		</Reference>
+		<Reference Include="Microsoft.ApplicationInsights">
+			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+			<Private>True</Private>
+		</Reference>
+	</ItemGroup>
+
+</Project>

--- a/Test/Web/FunctionalTests/Test.Common.Sdk.Net45.targets
+++ b/Test/Web/FunctionalTests/Test.Common.Sdk.Net45.targets
@@ -3,10 +3,10 @@
 
 	<ItemGroup>
 		<Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
 		</Reference>
 		<Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
 			<Private>True</Private>
 		</Reference>
 	</ItemGroup>

--- a/Test/Web/FunctionalTests/Test.Common.Sdk.Net45.targets
+++ b/Test/Web/FunctionalTests/Test.Common.Sdk.Net45.targets
@@ -2,6 +2,16 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<ItemGroup>
+		<Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+		</Reference>
+		<Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+			<HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+			<Private>True</Private>
+		</Reference>
+	</ItemGroup>
+
+	<ItemGroup>
 		<Reference Include="Microsoft.ApplicationInsights">
             <HintPath>$(BinRoot)\$(Configuration)\Src\Web\Web\Net45\Microsoft.ApplicationInsights.dll</HintPath>
         </Reference>

--- a/Test/Web/FunctionalTests/Test.Common.Sdk.Net45.targets
+++ b/Test/Web/FunctionalTests/Test.Common.Sdk.Net45.targets
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<ItemGroup>
-		<Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-		</Reference>
-		<Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-			<HintPath>$(SolutionDir)\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-			<Private>True</Private>
-		</Reference>
-	</ItemGroup>
+	<Import Project="$(SolutionDir)\..\Test.Common.Dependencies.Net45.targets" />
 
 	<ItemGroup>
 		<Reference Include="Microsoft.ApplicationInsights">

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
@@ -174,7 +174,7 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
     <Content Include="fonts\glyphicons-halflings-regular.woff" />

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
@@ -21,7 +21,7 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <UseGlobalApplicationHostFile />
-    <Use64BitIISExpress />
+	<Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,13 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
@@ -181,6 +174,9 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="fonts\glyphicons-halflings-regular.woff" />
     <Content Include="fonts\glyphicons-halflings-regular.ttf" />
     <Content Include="fonts\glyphicons-halflings-regular.eot" />

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
@@ -6,8 +6,6 @@
   <package id="bootstrap" version="3.0.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.0" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.0.0" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
@@ -208,7 +208,7 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
     <Content Include="ApplicationInsights.config">

--- a/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
@@ -21,7 +21,7 @@
     <IISExpressUseClassicPipelineMode>true</IISExpressUseClassicPipelineMode>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <UseGlobalApplicationHostFile />
-    <NuGetPackageImportStamp>
+	<NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
   </PropertyGroup>
@@ -43,13 +43,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
@@ -215,6 +208,9 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="ApplicationInsights.config">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Test/Web/FunctionalTests/TestApps/Aspx45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Aspx45/packages.config
@@ -11,8 +11,6 @@
   <package id="EntityFramework" version="6.1.0" targetFramework="net45" />
   <package id="jQuery" version="1.8.2" targetFramework="net45" />
   <package id="jQuery.UI.Combined" version="1.8.24" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Membership.OpenAuth" version="1.0.2" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/ConsoleAppFW45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/ConsoleAppFW45.csproj
@@ -64,7 +64,7 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/ConsoleAppFW45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/ConsoleAppFW45.csproj
@@ -33,13 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
@@ -69,6 +62,9 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/packages.config
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
@@ -29,7 +29,7 @@
     </UpgradeBackupLocation>
     <OldToolsVersion>12.0</OldToolsVersion>
     <UseGlobalApplicationHostFile />
-    <NuGetPackageImportStamp>
+	<NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
   </PropertyGroup>
@@ -56,15 +56,6 @@
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
@@ -356,6 +347,9 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
@@ -347,7 +347,7 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/packages.config
@@ -11,8 +11,6 @@
   <package id="jQuery.UI.Combined" version="1.8.24" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.10.0" targetFramework="net45" />
   <package id="knockoutjs" version="2.2.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
@@ -48,13 +48,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
@@ -96,6 +89,9 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="RandomIdPage.aspx" />
     <Content Include="SkipOnResolveCachePage.aspx" />
     <Content Include="SyncExceptionWebForm.aspx" />

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
@@ -89,7 +89,7 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
     <Content Include="RandomIdPage.aspx" />

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/packages.config
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
@@ -49,13 +49,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
@@ -111,6 +104,9 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
@@ -104,7 +104,7 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
     <None Include="Web.Debug.config">

--- a/Test/Web/FunctionalTests/TestApps/Wcf45Tests/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Wcf45Tests/packages.config
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
@@ -52,13 +52,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
@@ -146,6 +139,9 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="ApplicationInsights.config">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
@@ -139,7 +139,7 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
     <Content Include="ApplicationInsights.config">

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net451" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net451" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
@@ -22,7 +22,6 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <WcfConfigValidationEnabled>True</WcfConfigValidationEnabled>
     <TargetFrameworkProfile />
-    <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
@@ -120,6 +119,9 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="ApplicationInsights.config">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
@@ -112,7 +112,7 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="$(SolutionDir)\FunctionalTests\test.common.packages.config">
+    <None Include="$(SolutionDir)\..\test.common.packages.config">
       <SubType>Designer</SubType>
     </None>
     <Content Include="ApplicationInsights.config">

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
@@ -51,13 +51,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.0-beta2, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.8.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net451" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net451" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/test.common.packages.config
+++ b/Test/Web/FunctionalTests/test.common.packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
-</packages>

--- a/Test/Web/FunctionalTests/test.common.packages.config
+++ b/Test/Web/FunctionalTests/test.common.packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
+</packages>

--- a/Test/test.common.packages.config
+++ b/Test/test.common.packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta3" targetFramework="net45" />
+</packages>

--- a/Test/test.common.packages.config
+++ b/Test/test.common.packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta3" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.8.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.0-beta2" targetFramework="net45" />
 </packages>

--- a/upgradeVersion.ps1
+++ b/upgradeVersion.ps1
@@ -36,7 +36,7 @@ foreach-object {
   Set-Content $_.FullName
 }
   
-Get-ChildItem -Path $directory -Filter *.props -Recurse | 
+Get-ChildItem -Path $directory -Filter Directory.Build.props -Recurse | 
 foreach-object {
   (Get-Content $_.FullName) | 
   Foreach-Object {$_ -replace $oldVersion, $newVersion} | 

--- a/upgradeVersion.ps1
+++ b/upgradeVersion.ps1
@@ -15,7 +15,14 @@ $newVersion = "2.8.0-beta2"
 Write-Host "New Version: $newVersion";
 
 
-Get-ChildItem -Path $directory -Filter packages.config -Recurse | 
+Get-ChildItem -Path $directory -Filter *packages.config -Recurse | 
+foreach-object {
+  (Get-Content $_.FullName) | 
+  Foreach-Object {$_ -replace $oldVersion, $newVersion} | 
+  Set-Content $_.FullName
+}
+
+Get-ChildItem -Path $directory -Filter Test.Common.Sdk.Net45.targets -Recurse | 
 foreach-object {
   (Get-Content $_.FullName) | 
   Foreach-Object {$_ -replace $oldVersion, $newVersion} | 

--- a/upgradeVersion.ps1
+++ b/upgradeVersion.ps1
@@ -22,7 +22,7 @@ foreach-object {
   Set-Content $_.FullName
 }
 
-Get-ChildItem -Path $directory -Filter Test.Common.Sdk.Net45.targets -Recurse | 
+Get-ChildItem -Path $directory -Filter Test.Common.Dependencies.Net45.targets -Recurse | 
 foreach-object {
   (Get-Content $_.FullName) | 
   Foreach-Object {$_ -replace $oldVersion, $newVersion} | 


### PR DESCRIPTION
I'm consolidating the dependencies of our functional tests.
Moving all the references to the BaseSDK to single files will simplify the updates necessary for monthly releases.


to validate these changes, i want to see that the # of passed tests match that of the develop branch