### PR TITLE
[WIP]test fix for build server

### DIFF
--- a/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
+++ b/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F05EB480-B209-47DD-90E3-1DDC47EFC579}</ProjectGuid>

--- a/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
+++ b/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
@@ -105,4 +105,5 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.targets'))\Common.targets" />
   <Import Project="..\..\TestFramework\Shared\TestFramework.Shared.projitems" Label="Shared" />
   <Import Project="..\WindowsServer.Shared.Tests\WindowsServer.Shared.Tests.projitems" Label="Shared" />
+  <RuntimeIdentifier>win</RuntimeIdentifier>
 </Project>


### PR DESCRIPTION
test to fix error:

```
Done Building Project "E:\A\_work\237\s\Src\WindowsServer\WindowsServer\WindowsServer.csproj" (default targets).
##[debug]Processed: ##vso[task.logdetail id=43ae1583-8b45-4a25-a4ea-b41cabb7d549;parentid=;name=Microsoft.NuGet.targets;type=Build;starttime=2018-09-28T22:49:37.2140020Z;state=InProgress;]
##[error]C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets(186,5): Error : Your project file doesn't list 'win' as a "RuntimeIdentifier". You should add 'win' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.
##[debug]Processed: ##vso[task.logissue type=Error;sourcepath=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets;linenumber=186;columnnumber=5;code=;]Your project file doesn't list 'win' as a "RuntimeIdentifier". You should add 'win' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.
##[debug]Processed: ##vso[task.logdetail id=43ae1583-8b45-4a25-a4ea-b41cabb7d549;parentid=;type=Build;result=Failed;finishtime=2018-09-28T22:49:37.2170021Z;progress=100;state=Completed;parentid=;name=;]
C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets(186,5): error : Your project file doesn't list 'win' as a "RuntimeIdentifier". You should add 'win' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore. [E:\A\_work\237\s\Src\WindowsServer\WindowsServer.Net45.Tests\WindowsServer.Net45.Tests.csproj]
Done Building Project "E:\A\_work\237\s\Src\WindowsServer\WindowsServer.Net45.Tests\WindowsServer.Net45.Tests.csproj" (default targets) -- FAILED.
```