### PR TITLE
Move ActiveSubscriptionManager to common namespace

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/ActiveSubsciptionManagerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/ActiveSubsciptionManagerTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Tests
 {
     using System;
-    using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
+    using Microsoft.ApplicationInsights.Common;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]

--- a/Src/DependencyCollector/Shared/Implementation/ActiveSubsciptionManager.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ActiveSubsciptionManager.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+﻿namespace Microsoft.ApplicationInsights.Common
 {
     using System.Collections.Generic;
     using System.ComponentModel;

--- a/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCollectorEventSource.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCollectorEventSource.cs
@@ -28,7 +28,6 @@
         [Event(1, Level = EventLevel.Informational, Message = @"Performance counter infrastructure is being initialized. {0}")]
         public void ModuleIsBeingInitializedEvent(
             string message,
-            string dummy = "dummy",
             string applicationName = "dummy")
         {
             this.WriteEvent(1, message, this.applicationNameProvider.Name);

--- a/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCollectorEventSource.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCollectorEventSource.cs
@@ -8,22 +8,15 @@
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
     internal sealed class PerformanceCollectorEventSource : EventSource
     {
-        private static readonly PerformanceCollectorEventSource Logger = new PerformanceCollectorEventSource();
         private readonly ApplicationNameProvider applicationNameProvider = new ApplicationNameProvider();
 
         private PerformanceCollectorEventSource()
         {
         }
 
-        public static PerformanceCollectorEventSource Log
-        {
-            get
-            {
-                return Logger;
-            }
-        }
+        public static PerformanceCollectorEventSource Log { get; } = new PerformanceCollectorEventSource();
 
-#region Infra init - success
+        #region Infra init - success
 
         [Event(1, Level = EventLevel.Informational, Message = @"Performance counter infrastructure is being initialized. {0}")]
         public void ModuleIsBeingInitializedEvent(

--- a/Src/PerformanceCollector/Perf.Shared/PerformanceCollectorModule.cs
+++ b/Src/PerformanceCollector/Perf.Shared/PerformanceCollectorModule.cs
@@ -144,7 +144,7 @@
                             string.Format(
                                 CultureInfo.InvariantCulture,
                                 "Custom counters count: '{0}'",
-                                this.Counters != null ? this.Counters.Count : 0));
+                                Counters?.Count ?? 0));
 
                         if (configuration == null)
                         {


### PR DESCRIPTION
Played with #1013 in AspNetCore and 

1. ActiveSubscriptionMananger is user there for request telemetry deduplication. It's confusing to have it DependencyCollector namespace

2. Noticed some error for EventSource: `AI (Internal): Event 1 was called with 2 argument(s), but it is defined with 3 parameter(s).`:   PerformanceEventSource Event 1 is under suspicion.


- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.