### PR TITLE
Fix type mismatch for different events on SqlClient listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.9.0-beta1
 - [Prevent duplicate dependency collection in multi-host apps](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/621)
+- [Fix missing transactions Sql dependencies](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1031)
 
 ## Version 2.8.0-beta2
 - [LiveMetrics (QuickPulse) TelemetryProcessor added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/987)

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticFetcherTypes.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticFetcherTypes.cs
@@ -57,7 +57,7 @@
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
         }
 
-        /// <summary> Fetchers for transaction commit/rollback before events. </summary>
+        /// <summary> Fetchers for transaction commit before events. </summary>
         internal static class TransactionCommitBefore
         {
             public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
@@ -67,7 +67,7 @@
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
         }
 
-        /// <summary> Fetchers for transaction commit before events. </summary>
+        /// <summary> Fetchers for transaction rollback before events. </summary>
         internal static class TransactionRollbackBefore
         {
             public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
@@ -78,16 +78,34 @@
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
         }
 
-        /// <summary> Fetchers for transaction commit/rollback after events. </summary>
-        internal static class TransactionAfter
+        /// <summary> Fetchers for transaction rollback after events. </summary>
+        internal static class TransactionRollbackAfter
         {
             public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
         }
 
-        /// <summary> Fetchers for transaction commit/rollback error events. </summary>
-        internal static class TransactionError
+        /// <summary> Fetchers for transaction commit after events. </summary>
+        internal static class TransactionCommitAfter
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+        /// <summary> Fetchers for transaction rollback error events. </summary>
+        internal static class TransactionRollbackError
+        {
+            public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
+            public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+        }
+
+
+        /// <summary> Fetchers for transaction commit error events. </summary>
+        internal static class TransactionCommitError
         {
             public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));


### PR DESCRIPTION
Fix issue on the internal telemetry

![image](https://user-images.githubusercontent.com/2347409/46447268-a463d400-c735-11e8-8c3f-6a7c39d181c7.png)

This prevents some SQL dependencies from being tracked

<Short description of the fix.>

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [x] Changes in public surface reviewed
- [ ] Design discussion issue #
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [x] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.