### PR TITLE
Add WEBSITE_RESOURCE_GROUP to hearbeat properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [Prevent duplicate dependency collection in multi-host apps](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/621)
 - [Fix missing transactions Sql dependencies](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1031)
 - [Fix: Do not stop Activity in the Stop events, set end time instead](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1038)
+- [Fix: Add appSrv_ResourceGroup field to heartbeat properties from App Service](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1046)
 
 ## Version 2.8.0-beta2
 - [LiveMetrics (QuickPulse) TelemetryProcessor added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/987)

--- a/Src/WindowsServer/WindowsServer.Shared/AppServicesHeartbeatTelemetryModule.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/AppServicesHeartbeatTelemetryModule.cs
@@ -22,7 +22,8 @@
             new KeyValuePair<string, string>("appSrv_SlotName", "WEBSITE_SLOT_NAME"),
             new KeyValuePair<string, string>("appSrv_wsStamp", "WEBSITE_HOME_STAMPNAME"),
             new KeyValuePair<string, string>("appSrv_wsHost", "WEBSITE_HOSTNAME"),
-            new KeyValuePair<string, string>("appSrv_wsOwner", "WEBSITE_OWNER_NAME")
+            new KeyValuePair<string, string>("appSrv_wsOwner", "WEBSITE_OWNER_NAME"),
+            new KeyValuePair<string, string>("appSrv_ResourceGroup", "WEBSITE_RESOURCE_GROUP")
         };
 
         // Cache the heartbeat property manager across updates. Note that tests can also override the heartbeat manager.

--- a/Src/WindowsServer/WindowsServer.Shared/Implementation/AppServiceEnvironmentVariableMonitor.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/Implementation/AppServiceEnvironmentVariableMonitor.cs
@@ -27,7 +27,8 @@
             "WEBSITE_SLOT_NAME",
             "WEBSITE_HOME_STAMPNAME",
             "WEBSITE_HOSTNAME",
-            "WEBSITE_OWNER_NAME"
+            "WEBSITE_OWNER_NAME",
+            "WEBSITE_RESOURCE_GROUP"
         };
 
         // singleton pattern, this is the one instance of this class allowed


### PR DESCRIPTION
Fix Issue #1046  .
App Services expose different variable that we should add to heartbeat payload and use it for resource group identification: WEBSITE_RESOURCE_GROUP

- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.