### PR TITLE
Fix sql activity not stopped by EventSource Sql listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Fix missing transactions Sql dependencies](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1031)
 - [Fix: Do not stop Activity in the Stop events, set end time instead](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1038)
 - [Fix: Add appSrv_ResourceGroup field to heartbeat properties from App Service](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1046)
+- [Fix: Sql dependency tracking broken in 2.8.0+. Dependency operation is not stopped and becomes parent of subsequent operations](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1090)
 
 ## Version 2.8.0-beta2
 - [LiveMetrics (QuickPulse) TelemetryProcessor added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/987)

--- a/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkSqlProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkSqlProcessingTest.cs
@@ -4,8 +4,6 @@
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
-    using System.Linq;
-    using System.Reflection;
     using System.Threading;
 
     using Microsoft.ApplicationInsights.Channel;
@@ -68,6 +66,7 @@
             this.sqlProcessingFramework.OnEndExecuteCallback(id: 1111, success: true, sqlExceptionNumber: 0);
             stopwatch.Stop();
 
+            Assert.IsNull(Activity.Current);
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             ValidateTelemetryPacket(
                 this.sendItems[0] as DependencyTelemetry,
@@ -96,7 +95,7 @@
 
             this.sqlProcessingFramework.OnEndExecuteCallback(id: 1111, success: true, sqlExceptionNumber: 0);
             stopwatch.Stop();
-
+            Assert.IsNull(Activity.Current);
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             ValidateTelemetryPacket(
                 this.sendItems[0] as DependencyTelemetry,
@@ -126,6 +125,7 @@
             this.sqlProcessingFramework.OnEndExecuteCallback(id: 1111, success: false, sqlExceptionNumber: 1);
             stopwatch.Stop();
 
+            Assert.IsNull(Activity.Current);
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             ValidateTelemetryPacket(
                 this.sendItems[0] as DependencyTelemetry,
@@ -155,7 +155,7 @@
             this.sqlProcessingFramework.OnEndExecuteCallback(id: 1111, success: true, sqlExceptionNumber: 0);
 
             stopwatch.Stop();
-
+            Assert.IsNull(Activity.Current);
             Assert.AreEqual(1, this.sendItems.Count, "Only one telemetry item should be sent");
             ValidateTelemetryPacket(
                 this.sendItems[0] as DependencyTelemetry,

--- a/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkSqlProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkSqlProcessingTest.cs
@@ -29,10 +29,11 @@
         [TestInitialize]
         public void TestInitialize()
         {
-             this.configuration = new TelemetryConfiguration();
+            this.configuration = new TelemetryConfiguration();
             this.sendItems = new List<ITelemetry>(); 
             this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
+            this.configuration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
             this.sqlProcessingFramework = new FrameworkSqlProcessing(this.configuration, new CacheBasedOperationHolder("testCache", 100 * 1000));
         }
 
@@ -76,6 +77,47 @@
                 true,
                 stopwatch.Elapsed.TotalMilliseconds,
                 string.Empty);
+        }
+
+        /// <summary>
+        /// Validates SQLProcessingFramework sends correct telemetry for non stored procedure in async call.
+        /// </summary>
+        [TestMethod]
+        [Description("Validates SQLProcessingFramework sends correct telemetry for non stored procedure in async call.")]
+        public void RddTestSqlProcessingFrameworkSendsCorrectTelemetryMultipleItems()
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+
+            var parent = new Activity("parent").Start();
+
+            for (int i = 0; i < 10; i++)
+            {
+                this.sqlProcessingFramework.OnBeginExecuteCallback(
+                    id: i,
+                    database: "mydatabase",
+                    dataSource: "ourdatabase.database.windows.net",
+                    commandText: string.Empty);
+                Thread.Sleep(SleepTimeMsecBetweenBeginAndEnd);
+
+                this.sqlProcessingFramework.OnEndExecuteCallback(id: i, success: true, sqlExceptionNumber: 0);
+                stopwatch.Stop();
+
+                Assert.AreEqual(parent, Activity.Current);
+                Assert.AreEqual(i + 1, this.sendItems.Count, "Only one telemetry item should be sent");
+
+                var dependencyTelemetry = this.sendItems[0] as DependencyTelemetry;
+                ValidateTelemetryPacket(
+                    dependencyTelemetry,
+                    "ourdatabase.database.windows.net | mydatabase",
+                    "ourdatabase.database.windows.net | mydatabase",
+                    RemoteDependencyConstants.SQL,
+                    true,
+                    stopwatch.Elapsed.TotalMilliseconds,
+                    string.Empty);
+
+                Assert.AreEqual(parent.Id, dependencyTelemetry.Context.Operation.ParentId);
+                Assert.AreEqual(parent.RootId, dependencyTelemetry.Context.Operation.Id);
+            }
         }
 
         /// <summary>

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkSqlProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkSqlProcessing.cs
@@ -1,8 +1,7 @@
-﻿using System.Diagnostics;
-
-namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
+    using System.Diagnostics;
     using System.Globalization;
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -13,7 +12,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     internal sealed class FrameworkSqlProcessing
     {
         internal CacheBasedOperationHolder TelemetryTable;
-        private TelemetryClient telemetryClient;
+        private readonly TelemetryClient telemetryClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FrameworkSqlProcessing"/> class.
@@ -61,13 +60,12 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 var telemetryTuple = this.TelemetryTable.Get(id);
                 if (telemetryTuple == null)
                 {
-                    bool isCustomCreated = false;
                     var telemetry = ClientServerDependencyTracker.BeginTracking(this.telemetryClient);
                     telemetry.Name = resourceName;
                     telemetry.Target = string.Join(" | ", dataSource, database);
                     telemetry.Type = RemoteDependencyConstants.SQL;
                     telemetry.Data = commandText;
-                    this.TelemetryTable.Store(id, new Tuple<DependencyTelemetry, bool>(telemetry, isCustomCreated));
+                    this.TelemetryTable.Store(id, new Tuple<DependencyTelemetry, bool>(telemetry, false));
                 }
             }
             catch (Exception exception)
@@ -105,7 +103,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             if (!telemetryTuple.Item2)
             {
                 this.TelemetryTable.Remove(id);
-                var telemetry = telemetryTuple.Item1 as DependencyTelemetry;
+                var telemetry = telemetryTuple.Item1;
                 telemetry.Success = success;
                 telemetry.ResultCode = sqlExceptionNumber != 0 ? sqlExceptionNumber.ToString(CultureInfo.InvariantCulture) : string.Empty;
                 DependencyCollectorEventSource.Log.AutoTrackingDependencyItem(telemetry.Name);

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkSqlProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkSqlProcessing.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+﻿using System.Diagnostics;
+
+namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
     using System.Globalization;
@@ -71,6 +73,14 @@
             catch (Exception exception)
             {
                 DependencyCollectorEventSource.Log.CallbackError(id, "OnBeginSql", exception);
+            }
+            finally
+            {
+                Activity current = Activity.Current;
+                if (current?.OperationName == ClientServerDependencyTracker.DependencyActivityName)
+                {
+                    current.Stop();
+                }
             }
         }
 


### PR DESCRIPTION
Fix Issue #1090 .


- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.