### PR TITLE
fix internal error: "Failed to handle {}, id {}, error {}"

### DIFF
--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -446,11 +446,11 @@
         [Event(
             43,
             Keywords = Keywords.RddEventKeywords,
-            Message = "Failed to handle {0} event, id = '{1}', error = '{2}' ",
+            Message = "Failed to handle {0} event, error = '{2}' ",
             Level = EventLevel.Error)]
-        public void TelemetryDiagnosticSourceCallbackException(string eventName, string id, string error, string appDomainName = "Incorrect")
+        public void TelemetryDiagnosticSourceCallbackException(string eventName, string error, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(43, eventName, id, error, this.applicationNameProvider.Name);
+            this.WriteEvent(43, eventName, error, this.applicationNameProvider.Name);
         }
 
         [Event(

--- a/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -446,7 +446,7 @@
         [Event(
             43,
             Keywords = Keywords.RddEventKeywords,
-            Message = "Failed to handle {0} event, error = '{2}' ",
+            Message = "Failed to handle {0} event, error = '{1}' ",
             Level = EventLevel.Error)]
         public void TelemetryDiagnosticSourceCallbackException(string eventName, string error, string appDomainName = "Incorrect")
         {

--- a/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
+++ b/Src/DependencyCollector/Shared/Implementation/DiagnosticSourceListenerBase.cs
@@ -226,7 +226,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     }
                     catch (Exception ex)
                     {
-                        DependencyCollectorEventSource.Log.TelemetryDiagnosticSourceCallbackException(evnt.Key, currentActivity.Id, ex.ToInvariantString());
+                        DependencyCollectorEventSource.Log.TelemetryDiagnosticSourceCallbackException(evnt.Key, ex.ToInvariantString());
                     }
                 }
             }

--- a/Src/TestFramework/Shared/EventSourceTest.cs
+++ b/Src/TestFramework/Shared/EventSourceTest.cs
@@ -104,7 +104,13 @@ namespace Microsoft.ApplicationInsights.Web.TestFramework
         {
             if (!expected.Equals(actual))
             {
-                throw new Exception($"{methodName} Failed: expected: '{expected}' actual: '{actual}'");
+                var errorMessage = string.Format(
+                    CultureInfo.InvariantCulture, 
+                    "{0} Failed: expected: '{1}' actual: '{2}'", 
+                    methodName, 
+                    expected, 
+                    actual);
+                throw new Exception(errorMessage);
             }
         }
 

--- a/Src/TestFramework/Shared/EventSourceTest.cs
+++ b/Src/TestFramework/Shared/EventSourceTest.cs
@@ -38,7 +38,9 @@ namespace Microsoft.ApplicationInsights.Web.TestFramework
                 }
                 catch (Exception e)
                 {
-                    throw new Exception(eventMethod.Name + " is implemented incorrectly: " + e.Message, e);
+                    var name = eventMethod.DeclaringType.Name + "." + eventMethod.Name;
+
+                    throw new Exception("Method '" + name + "' is implemented incorrectly.", e);
                 }
             }
         }
@@ -67,19 +69,19 @@ namespace Microsoft.ApplicationInsights.Web.TestFramework
                 return Activator.CreateInstance(parameter.ParameterType);
             }
 
-            throw new NotSupportedException("Complex types are not suppored");
+            throw new NotSupportedException("Complex types are not supported");
         }
 
         private static void VerifyEventId(MethodInfo eventMethod, EventWrittenEventArgs actualEvent)
         {
             int expectedEventId = GetEventAttribute(eventMethod).EventId;
-            AssertEqual(expectedEventId, actualEvent.EventId, "EventId");
+            AssertEqual(nameof(VerifyEventId), expectedEventId, actualEvent.EventId);
         }
 
         private static void VerifyEventLevel(MethodInfo eventMethod, EventWrittenEventArgs actualEvent)
         {
             EventLevel expectedLevel = GetEventAttribute(eventMethod).Level;
-            AssertEqual(expectedLevel, actualEvent.Level, "Level");
+            AssertEqual(nameof(VerifyEventLevel), expectedLevel, actualEvent.Level);
         }
 
         private static void VerifyEventMessage(MethodInfo eventMethod, EventWrittenEventArgs actualEvent, object[] eventArguments)
@@ -88,27 +90,21 @@ namespace Microsoft.ApplicationInsights.Web.TestFramework
                 ? GetEventAttribute(eventMethod).Message
                 : string.Format(CultureInfo.InvariantCulture, GetEventAttribute(eventMethod).Message, eventArguments);
             string actualMessage = string.Format(CultureInfo.InvariantCulture, actualEvent.Message, actualEvent.Payload.ToArray());
-            AssertEqual(expectedMessage, actualMessage, "Message");
+            AssertEqual(nameof(VerifyEventMessage), expectedMessage, actualMessage);
         }
 
         private static void VerifyEventApplicationName(MethodInfo eventMethod, EventWrittenEventArgs actualEvent)
         {
             string expectedApplicationName = AppDomain.CurrentDomain.FriendlyName;
             string actualApplicationName = actualEvent.Payload.Last().ToString();
-            AssertEqual(expectedApplicationName, actualApplicationName, "Application Name");
+            AssertEqual(nameof(VerifyEventApplicationName), expectedApplicationName, actualApplicationName);
         }
 
-        private static void AssertEqual<T>(T expected, T actual, string message)
+        private static void AssertEqual<T>(string methodName, T expected, T actual)
         {
             if (!expected.Equals(actual))
             {
-                string errorMessage = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "{0}. expected: '{1}', actual: '{2}'",
-                    message,
-                    expected,
-                    actual);
-                throw new Exception(errorMessage);
+                throw new Exception($"{methodName} Failed: expected: '{expected}' actual: '{actual}'");
             }
         }
 


### PR DESCRIPTION
Our internal telemetry is getting flooded by errors with unique ids.
This change is to remove this id from the error message.



```
AI (Internal): [Microsoft-ApplicationInsights-Extensibility-DependencyCollector] 
Failed to handle Microsoft.Azure.ServiceBus.Process.Stop event, 
id = '##################', 
error = 'System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.SamplingTelemetryProcessor.Process(ITelemetry item)
   at Microsoft.ApplicationInsights.TelemetryClient.Track(ITelemetry telemetry)
   at Microsoft.ApplicationInsights.TelemetryClient.TrackRequest(RequestTelemetry request)
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.EventHandlers.ServiceBusDiagnosticsEventHandler.OnRequest(String name, Object payload, Activity activity)
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.EventHandlers.ServiceBusDiagnosticsEventHandler.OnEvent(KeyValuePair`2 evnt, DiagnosticListener ignored)
   at Microsoft.ApplicationInsights.DependencyCollector.Implementation.DiagnosticSourceListenerBase`1.IndividualDiagnosticSourceListener.OnNext(KeyValuePair`2 evnt)'
```


**TODO**
After merge to develop, need to cherry pick to master for release