### PR TITLE
When Activity has root id compatible with W3C Id, use it as trace id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.9.0-beta3
+- [When Activity has root id compatible with W3C trace Id, use it as trace id](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1107)
+
 ## Version 2.9.0-beta1
 - [Prevent duplicate dependency collection in multi-host apps](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/621)
 - [Fix missing transactions Sql dependencies](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1031)
@@ -9,7 +12,6 @@
 - [Fix: Sql dependency tracking broken in 2.8.0+. Dependency operation is not stopped and becomes parent of subsequent operations](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1090)
 - [Fix: Wrong parentId reported on the SqlClient dependency on .NET Core](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/778)
 - [Perf Fix - Replace TelemetryClient.Initialize() with TelemetryClient.InitializeInstrumentationKey() to avoid calling initializers more than once. ](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1094)
-- [When Activity has root id compatible with W3C trace Id, use it as trace id](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1107)
 
 ## Version 2.8.0-beta2
 - [LiveMetrics (QuickPulse) TelemetryProcessor added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/987)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Fix: Sql dependency tracking broken in 2.8.0+. Dependency operation is not stopped and becomes parent of subsequent operations](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1090)
 - [Fix: Wrong parentId reported on the SqlClient dependency on .NET Core](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/778)
 - [Perf Fix - Replace TelemetryClient.Initialize() with TelemetryClient.InitializeInstrumentationKey() to avoid calling initializers more than once. ](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1094)
+- [When Activity has root id compatible with W3C trace Id, use it as trace id](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1107)
 
 ## Version 2.8.0-beta2
 - [LiveMetrics (QuickPulse) TelemetryProcessor added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/987)

--- a/Src/Common/W3C/W3CActivityExtensions.cs
+++ b/Src/Common/W3C/W3CActivityExtensions.cs
@@ -35,7 +35,11 @@
             activity.SetVersion(W3CConstants.DefaultVersion);
             activity.SetSampled(W3CConstants.TraceFlagRecordedAndNotRequested);
             activity.SetSpanId(StringUtilities.GenerateSpanId());
-            activity.SetTraceId(StringUtilities.GenerateTraceId());
+
+            activity.SetTraceId(activity.RootId != null && TraceIdRegex.IsMatch(activity.RootId)
+                ? activity.RootId
+                : StringUtilities.GenerateTraceId());
+
             return activity;
         }
 

--- a/Src/DependencyCollector/Shared.Tests/W3C/W3CActiviityExtentionsTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/W3C/W3CActiviityExtentionsTests.cs
@@ -157,6 +157,45 @@
         }
 
         [TestMethod]
+        public void UpdateContextFromCompatibleRootId()
+        {
+            var a = new Activity("foo");
+            a.SetParentId(TraceId);
+
+            Assert.IsFalse(a.IsW3CActivity());
+
+            a.UpdateContextOnActivity();
+            Assert.IsTrue(a.IsW3CActivity());
+            Assert.AreEqual(TraceId, a.GetTraceId());
+            Assert.IsNotNull(a.GetSpanId());
+            Assert.IsNull(a.GetParentSpanId());
+            Assert.IsNotNull(a.GetSpanId());
+
+            Assert.AreEqual($"00-{a.GetTraceId()}-{a.GetSpanId()}-02", a.GetTraceparent());
+            Assert.IsNull(a.GetTracestate());
+        }
+
+        [TestMethod]
+        public void UpdateContextFromIncompatibleRootId()
+        {
+            var a = new Activity("foo");
+            a.SetParentId("abc");
+
+            Assert.IsFalse(a.IsW3CActivity());
+
+            a.UpdateContextOnActivity();
+            Assert.IsTrue(a.IsW3CActivity());
+            Assert.AreNotEqual("abc", a.GetTraceId());
+            Assert.IsNotNull(a.GetTraceId());
+            Assert.IsNotNull(a.GetSpanId());
+            Assert.IsNull(a.GetParentSpanId());
+            Assert.IsNotNull(a.GetSpanId());
+
+            Assert.AreEqual($"00-{a.GetTraceId()}-{a.GetSpanId()}-02", a.GetTraceparent());
+            Assert.IsNull(a.GetTracestate());
+        }
+
+        [TestMethod]
         public void UpdateContextWithParent()
         {
             var parent = new Activity("foo").Start();

--- a/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
+++ b/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
@@ -383,6 +383,7 @@
             Assert.AreEqual(32, request.Context.Operation.Id.Length);
             Assert.IsTrue(Regex.Match(request.Context.Operation.Id, @"[a-z][0-9]").Success);
 
+            Assert.AreEqual(request.Context.Operation.Id, activity.GetTraceId());
             Assert.AreEqual(request.Context.Operation.Id, activity.RootId);
             Assert.AreEqual(request.Context.Operation.ParentId, activity.GetParentSpanId());
             Assert.AreEqual(request.Id, $"|{activity.GetTraceId()}.{activity.GetSpanId()}.");


### PR DESCRIPTION
The transition to W3C standard in customer distributed system starts with frontend service. The first service should generate W3C compatible operation id that could be used downstream on all services whether they support W3C or not.

This change checks 
- if Request-Id is present
- if traceparent (w3c header) is not present
- if Request-Id root part (operation id) is valid w3c traceId

THEN is uses root id as traceid.

As a result when customer updates frontend to AppInsights 2.7+ and when it calls downstream service, it emits Request-Id = |traceId.1. and traceparent = 00-trace-id-spanId-00

This guarantees common operation id on all downstream services.
