### PR TITLE
Add DependencyCollector, PerfCounter, ServerChannel as dependency to …

### DIFF
--- a/Src/WindowsServer/WindowsServer/WindowsServer.csproj
+++ b/Src/WindowsServer/WindowsServer/WindowsServer.csproj
@@ -37,7 +37,8 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0-beta1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.9.0-beta1" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.9.0-beta1">
-      <ExcludeAssets>All</ExcludeAssets>
+      <!--This is needed only in runtime as no code in WindowsServer package has compile time dependency on DependencyCollector-->
+      <IncludeAssets>runtime</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.9.0-beta1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />

--- a/Src/WindowsServer/WindowsServer/WindowsServer.csproj
+++ b/Src/WindowsServer/WindowsServer/WindowsServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Product.props" />
 
   <PropertyGroup>
@@ -35,6 +35,11 @@
   <ItemGroup>
     <!--Common Dependencies-->
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0-beta1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.9.0-beta1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.9.0-beta1">
+      <ExcludeAssets>All</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.9.0-beta1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
…WindowsServer package. DependencyCollector is made runtime reference only to avoid conflict.

Fix Issue # .
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.