### PR TITLE
Package reference fixes.

### DIFF
--- a/Src/Common/InjectionGuardConstants.cs
+++ b/Src/Common/InjectionGuardConstants.cs
@@ -5,12 +5,7 @@
     /// These max limits are intentionally exaggerated to allow for unexpected responses, while still guarding against unreasonably large responses.
     /// Example: While a 32 character response may be expected, 50 characters may be permitted while a 10,000 character response would be unreasonable and malicious.
     /// </summary>
-#if DEPENDENCY_COLLECTOR
-    public
-#else
-    internal
-#endif
-    static class InjectionGuardConstants
+    internal static class InjectionGuardConstants
     {
         /// <summary>
         /// Max length of AppId allowed in response from Breeze.

--- a/Src/Common/StringUtilities.cs
+++ b/Src/Common/StringUtilities.cs
@@ -8,12 +8,7 @@
     /// <summary>
     /// Generic functions to perform common operations on a string.
     /// </summary>
-#if DEPENDENCY_COLLECTOR
-    public
-#else
-    internal
-#endif
-    static class StringUtilities
+    internal static class StringUtilities
     {
         private static readonly uint[] Lookup32 = CreateLookup32();
 

--- a/Src/Common/W3C/W3CActivityExtensions.cs
+++ b/Src/Common/W3C/W3CActivityExtensions.cs
@@ -13,12 +13,7 @@
     /// </summary>
     [Obsolete("Not ready for public consumption.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#if DEPENDENCY_COLLECTOR
-    public
-#else
-    internal
-#endif
-    static class W3CActivityExtensions
+    internal static class W3CActivityExtensions
     {
         private static readonly Regex TraceIdRegex = new Regex("^[a-f0-9]{32}$", RegexOptions.Compiled);
         private static readonly Regex SpanIdRegex = new Regex("^[a-f0-9]{16}$", RegexOptions.Compiled);

--- a/Src/Common/W3C/W3CConstants.cs
+++ b/Src/Common/W3C/W3CConstants.cs
@@ -8,12 +8,7 @@
     /// </summary>
     [Obsolete("Not ready for public consumption.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#if DEPENDENCY_COLLECTOR
-    public
-#else
-    internal
-#endif
-    static class W3CConstants
+    internal static class W3CConstants
     {
         /// <summary>
         /// W3C traceparent header name.

--- a/Src/Common/W3C/W3COperationCorrelationTelemetryInitializer.cs
+++ b/Src/Common/W3C/W3COperationCorrelationTelemetryInitializer.cs
@@ -17,12 +17,7 @@
     [Obsolete("Not ready for public consumption.")]
     [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "TelemetryInitializers are intended to be instatiated by the framework when added to a config.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#if DEPENDENCY_COLLECTOR
-    public
-#else
-    internal
-#endif
-    class W3COperationCorrelationTelemetryInitializer : ITelemetryInitializer
+    internal class W3COperationCorrelationTelemetryInitializer : ITelemetryInitializer
     {
         private const string RddDiagnosticSourcePrefix = "rdddsc";
         private const string SqlRemoteDependencyType = "SQL";

--- a/Src/Web/Web/Web.csproj
+++ b/Src/Web/Web/Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Product.props" />
 
   <PropertyGroup>
@@ -44,6 +44,10 @@
   <ItemGroup>
     <!--Nuget Transforms (install.xdt, uninstall.xdt, config.transform): "nupkg\content\<framework>\*.*-->
     <Content Include="net45\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WindowsServer\WindowsServer\WindowsServer.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Src/WindowsServer/WindowsServer/WindowsServer.csproj
+++ b/Src/WindowsServer/WindowsServer/WindowsServer.csproj
@@ -36,11 +36,6 @@
     <!--Common Dependencies-->
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0-beta1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.9.0-beta1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.9.0-beta1">
-      <!--This is needed only in runtime as no code in WindowsServer package has compile time dependency on DependencyCollector-->
-      <IncludeAssets>runtime</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.9.0-beta1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
   </ItemGroup>
 
@@ -57,9 +52,14 @@
     <Content Include="ApplicationInsights.config.uninstall.xdt" />
   </ItemGroup>
   
-  <ItemGroup  Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <!--Framework References-->    
     <Reference Include="System.Management" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\DependencyCollector\DependencyCollector\DependencyCollector.csproj" />
+    <ProjectReference Include="..\..\PerformanceCollector\PerformanceCollector\Perf.csproj" />
   </ItemGroup>
   
   <Import Project="..\WindowsServer.Shared\WindowsServer.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
Fixed a bug which caused Web to not refer to WindowsServer.
Modified WindowsServer dependencies as project references instead of PackageReferences (otherwise we cannot build it, as the expected version is not going to be available when building test projects)

Make common classes internal - this is done to avoid ambiguity. These classes were public so that asp.net core sdk can access it - currently exploring copying the common classes to asp.net core repo as well unless a more elegant solution can be found.

W3COperationCorrelationTelemetryInitializer need to be public - so fixing that will be a follow up PR to this one..

Fix Issue # .
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.