### PR TITLE
Modified w3c classes to have diff namespaces depending on the project…

### DIFF
--- a/Src/Common/HeadersUtilities.cs
+++ b/Src/Common/HeadersUtilities.cs
@@ -4,6 +4,11 @@
     using System.Globalization;
     using System.Linq;
     using System.Text.RegularExpressions;
+#if DEPENDENCY_COLLECTOR
+    using Microsoft.ApplicationInsights.Common;
+#else
+    using Microsoft.ApplicationInsights.Common.Internal;
+#endif
 
     /// <summary>
     /// Generic functions that can be used to get and set Http headers.

--- a/Src/Common/InjectionGuardConstants.cs
+++ b/Src/Common/InjectionGuardConstants.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.ApplicationInsights.Common
+﻿#if DEPENDENCY_COLLECTOR
+    namespace Microsoft.ApplicationInsights.Common
+#else
+namespace Microsoft.ApplicationInsights.Common.Internal
+#endif
 {
     /// <summary>
     /// These values are listed to guard against malicious injections by limiting the max size allowed in an HTTP Response.

--- a/Src/Common/InjectionGuardConstants.cs
+++ b/Src/Common/InjectionGuardConstants.cs
@@ -5,7 +5,12 @@
     /// These max limits are intentionally exaggerated to allow for unexpected responses, while still guarding against unreasonably large responses.
     /// Example: While a 32 character response may be expected, 50 characters may be permitted while a 10,000 character response would be unreasonable and malicious.
     /// </summary>
-    internal static class InjectionGuardConstants
+#if DEPENDENCY_COLLECTOR
+    public 
+#else
+    internal
+#endif
+    static class InjectionGuardConstants
     {
         /// <summary>
         /// Max length of AppId allowed in response from Breeze.

--- a/Src/Common/StringUtilities.cs
+++ b/Src/Common/StringUtilities.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.ApplicationInsights.Common
+﻿#if DEPENDENCY_COLLECTOR
+    namespace Microsoft.ApplicationInsights.Common
+#else
+    namespace Microsoft.ApplicationInsights.Common.Internal
+#endif
 {
     using System;
     using System.Diagnostics;

--- a/Src/Common/StringUtilities.cs
+++ b/Src/Common/StringUtilities.cs
@@ -3,12 +3,21 @@
     using System;
     using System.Diagnostics;
     using System.Globalization;
-    using Microsoft.ApplicationInsights.W3C;
+#if DEPENDENCY_COLLECTOR
+    using Microsoft.ApplicationInsights.W3C;        
+#else
+    using Microsoft.ApplicationInsights.W3C.Internal;
+#endif
 
     /// <summary>
     /// Generic functions to perform common operations on a string.
     /// </summary>
-    internal static class StringUtilities
+#if DEPENDENCY_COLLECTOR
+    public 
+#else
+    internal
+#endif
+    static class StringUtilities
     {
         private static readonly uint[] Lookup32 = CreateLookup32();
 

--- a/Src/Common/W3C/W3CActivityExtensions.cs
+++ b/Src/Common/W3C/W3CActivityExtensions.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.ApplicationInsights.W3C
+﻿#if DEPENDENCY_COLLECTOR
+    namespace Microsoft.ApplicationInsights.W3C
+#else
+    namespace Microsoft.ApplicationInsights.W3C.Internal
+#endif
 {
     using System;
     using System.ComponentModel;
@@ -13,7 +17,12 @@
     /// </summary>
     [Obsolete("Not ready for public consumption.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal static class W3CActivityExtensions
+#if DEPENDENCY_COLLECTOR
+    public 
+#else
+    internal
+#endif
+    static class W3CActivityExtensions
     {
         private static readonly Regex TraceIdRegex = new Regex("^[a-f0-9]{32}$", RegexOptions.Compiled);
         private static readonly Regex SpanIdRegex = new Regex("^[a-f0-9]{16}$", RegexOptions.Compiled);

--- a/Src/Common/W3C/W3CActivityExtensions.cs
+++ b/Src/Common/W3C/W3CActivityExtensions.cs
@@ -10,7 +10,11 @@
     using System.Globalization;
     using System.Linq;
     using System.Text.RegularExpressions;
+#if DEPENDENCY_COLLECTOR
     using Microsoft.ApplicationInsights.Common;
+#else
+    using Microsoft.ApplicationInsights.Common.Internal;
+#endif
 
     /// <summary>
     /// Extends Activity to support W3C distributed tracing standard.

--- a/Src/Common/W3C/W3CConstants.cs
+++ b/Src/Common/W3C/W3CConstants.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.ApplicationInsights.W3C
+﻿#if DEPENDENCY_COLLECTOR
+    namespace Microsoft.ApplicationInsights.W3C
+#else
+namespace Microsoft.ApplicationInsights.W3C.Internal
+#endif
 {
     using System;
     using System.ComponentModel;
@@ -8,7 +12,12 @@
     /// </summary>
     [Obsolete("Not ready for public consumption.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal static class W3CConstants
+#if DEPENDENCY_COLLECTOR
+    public 
+#else
+    internal
+#endif
+    static class W3CConstants
     {
         /// <summary>
         /// W3C traceparent header name.

--- a/Src/Common/W3C/W3COperationCorrelationTelemetryInitializer.cs
+++ b/Src/Common/W3C/W3COperationCorrelationTelemetryInitializer.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.ApplicationInsights.W3C
+﻿#if DEPENDENCY_COLLECTOR
+namespace Microsoft.ApplicationInsights.W3C
+#else
+namespace Microsoft.ApplicationInsights.W3C.Internal
+#endif
 {
     using System;
     using System.ComponentModel;
@@ -17,7 +21,12 @@
     [Obsolete("Not ready for public consumption.")]
     [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "TelemetryInitializers are intended to be instatiated by the framework when added to a config.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal class W3COperationCorrelationTelemetryInitializer : ITelemetryInitializer
+#if DEPENDENCY_COLLECTOR
+    public 
+#else
+    internal
+#endif
+    class W3COperationCorrelationTelemetryInitializer : ITelemetryInitializer
     {
         private const string RddDiagnosticSourcePrefix = "rdddsc";
         private const string SqlRemoteDependencyType = "SQL";

--- a/Src/Common/W3C/W3COperationCorrelationTelemetryInitializer.cs
+++ b/Src/Common/W3C/W3COperationCorrelationTelemetryInitializer.cs
@@ -9,11 +9,15 @@ namespace Microsoft.ApplicationInsights.W3C.Internal
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
-    using Microsoft.ApplicationInsights.Channel;
-    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.ApplicationInsights.Channel;    
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
+#if DEPENDENCY_COLLECTOR
+    using Microsoft.ApplicationInsights.Common;
+#else
+    using Microsoft.ApplicationInsights.Common.Internal;
+#endif
 
     /// <summary>
     /// Telemetry Initializer that sets correlation ids for W3C.

--- a/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
+++ b/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
@@ -11,7 +11,7 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.W3C;
+    using Microsoft.ApplicationInsights.W3C.Internal;
     using Microsoft.ApplicationInsights.Web;
     using Microsoft.ApplicationInsights.Web.Helpers;
     using Microsoft.ApplicationInsights.Web.TestFramework;

--- a/Src/Web/Web.Net45.Tests/RequestTrackingTelemetryModuleTest.Net45.cs
+++ b/Src/Web/Web.Net45.Tests/RequestTrackingTelemetryModuleTest.Net45.cs
@@ -10,7 +10,7 @@
 
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.W3C;
+    using Microsoft.ApplicationInsights.W3C.Internal;
     using Microsoft.ApplicationInsights.Web.Helpers;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/RequestTrackingTelemetryModuleTest.cs
@@ -14,7 +14,7 @@
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.TestFramework;
-    using Microsoft.ApplicationInsights.W3C;
+    using Microsoft.ApplicationInsights.W3C.Internal;
     using Microsoft.ApplicationInsights.Web.Helpers;
     using Microsoft.ApplicationInsights.Web.Implementation;
     using Microsoft.ApplicationInsights.Web.TestFramework;

--- a/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
@@ -6,7 +6,11 @@
     using System.Web;
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.W3C;
+#if DEPENDENCY_COLLECTOR
+    using Microsoft.ApplicationInsights.W3C;        
+#else
+    using Microsoft.ApplicationInsights.W3C.Internal;
+#endif
     using Microsoft.AspNet.TelemetryCorrelation;
 
 #pragma warning disable 612, 618

--- a/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
@@ -6,11 +6,7 @@
     using System.Web;
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
-#if DEPENDENCY_COLLECTOR
-    using Microsoft.ApplicationInsights.W3C;        
-#else
     using Microsoft.ApplicationInsights.W3C.Internal;
-#endif
     using Microsoft.AspNet.TelemetryCorrelation;
 
 #pragma warning disable 612, 618


### PR DESCRIPTION
… and also reverted the w3c TI to be public in dependencycollector to restore original behavior and stil avoiding the confict

Fix Issue # .
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.