### PR TITLE
Do not prevent correlation headers injection on localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 2.9.0-beta3
+- [Fix: Correlation doesn't work for localhost](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1120). If you are upgrading and have previously opted into legacy header injection via `DependencyTrackingTelemetryModule.EnableLegacyCorrelationHeadersInjection` and run app locally with Azure Storage Emulator, make sure you manually exclude localhost from correlation headers injection in the `ExcludeComponentCorrelationHttpHeadersOnDomains` under `DependencyCollector`
+    ```xml
+        <Add>localhost</Add>
+        <Add>127.0.0.1</Add>
+    ```
+
 ## Version 2.9.0-beta1
 - [Prevent duplicate dependency collection in multi-host apps](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/621)
 - [Fix missing transactions Sql dependencies](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1031)

--- a/Src/DependencyCollector/DependencyCollector/ApplicationInsights.config.install.xdt
+++ b/Src/DependencyCollector/DependencyCollector/ApplicationInsights.config.install.xdt
@@ -14,8 +14,6 @@
         <Add>core.chinacloudapi.cn</Add>
         <Add>core.cloudapi.de</Add>
         <Add>core.usgovcloudapi.net</Add>
-        <Add>localhost</Add>
-        <Add>127.0.0.1</Add>
       </ExcludeComponentCorrelationHttpHeadersOnDomains>
       <IncludeDiagnosticSourceActivities>
         <Add>Microsoft.Azure.EventHubs</Add>


### PR DESCRIPTION
Fix Issue Microsoft/ApplicationInsights-dotnet-server#1120

We added localhost and 127.0.0.1 to the list of domains for which we don't inject correlation headers because of legacy (x-ms* headers). Injecting them into the request breaks Azure Storage SDK auth mechanism and causes errors on the emulator. https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/640

However, these headers are opt-in sinceDepCollector 2.6.0 and we can safely add correlation headers on localhost.  https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/901

This change removes localhost and 127.0.0.1 from the excluded list by default.

## Please read this if you are opted into the legacy (x-ms*) header injection:
Users are expected to manually add localhost and 127.0.0.1 if they are opted into legacy headers via
`DependencyTrackingTelemetryModule.EnableLegacyCorrelationHeadersInjection = true` (or similar line in the config file), so that DependencyCollector secion in the config should look like

```xml
<Add Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector">
	<ExcludeComponentCorrelationHttpHeadersOnDomains>
		<Add>core.windows.net</Add>
		<Add>core.chinacloudapi.cn</Add>
		<Add>core.cloudapi.de</Add>
		<Add>core.usgovcloudapi.net</Add>
		<Add>localhost</Add>
		<Add>127.0.0.1</Add>
	</ExcludeComponentCorrelationHttpHeadersOnDomains>
       ....
</Add>
```

<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.