### PR TITLE
Fix missing port in the target on corefx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.9.0-beta3
+- [Fix: Non-default port is not included into the target ofor Http dependencies on .NEt Core](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1121)
+
 ## Version 2.9.0-beta1
 - [Prevent duplicate dependency collection in multi-host apps](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/621)
 - [Fix missing transactions Sql dependencies](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1031)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Version 2.9.0-beta3
-- [Fix: Non-default port is not included into the target ofor Http dependencies on .NEt Core](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1121)
+- [Fix: Non-default port is not included into the target for Http dependencies on .NET Core](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1121)
 - [When Activity has root id compatible with W3C trace Id, use it as trace id](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1107)
 
 ## Version 2.9.0-beta1

--- a/Src/DependencyCollector/NetCore.Tests/DependencyTrackingTelemetryModuleTestNetCore.cs
+++ b/Src/DependencyCollector/NetCore.Tests/DependencyTrackingTelemetryModuleTestNetCore.cs
@@ -351,7 +351,7 @@
         private void ValidateTelemetryForDiagnosticSource(DependencyTelemetry item, Uri url, HttpRequestMessage request, bool success, string resultCode, bool expectLegacyHeaders, Activity parent = null)
         {
             Assert.AreEqual(url, item.Data);
-            Assert.AreEqual(url.Host, item.Target);
+            Assert.AreEqual($"{url.Host}:{url.Port}", item.Target);
             Assert.AreEqual("GET " + url.AbsolutePath, item.Name);
             Assert.IsTrue(item.Duration > TimeSpan.FromMilliseconds(0), "Duration has to be positive");
             Assert.AreEqual(RemoteDependencyConstants.HTTP, item.Type, "HttpAny has to be dependency kind as it includes http and azure calls");

--- a/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs
@@ -388,7 +388,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
             telemetry.Timestamp = currentActivity.StartTimeUtc;
             telemetry.Name = resourceName;
-            telemetry.Target = requestUri.Host;
+            telemetry.Target = DependencyTargetNameHelper.GetDependencyTargetName(requestUri);
             telemetry.Type = RemoteDependencyConstants.HTTP;
             telemetry.Data = requestUri.OriginalString;
             telemetry.Duration = currentActivity.Duration;
@@ -435,7 +435,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     this.client.StartOperation<DependencyTelemetry>(resourceName) :
                     this.client.StartOperation<DependencyTelemetry>(resourceName, StringUtilities.GenerateTraceId());
 
-                dependency.Telemetry.Target = requestUri.Host;
+                dependency.Telemetry.Target = DependencyTargetNameHelper.GetDependencyTargetName(requestUri);
                 dependency.Telemetry.Type = RemoteDependencyConstants.HTTP;
                 dependency.Telemetry.Data = requestUri.OriginalString;
                 dependency.Telemetry.SetOperationDetail(RemoteDependencyConstants.HttpRequestOperationDetailName, request);


### PR DESCRIPTION
Fix Issue #1121 .

Port was missing on Http dependency target on .NET Core listeners. 
It was always set on .NET Fx.

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.