### PR TITLE
Mikp/asp net telemetry correlation1 0 5

### DIFF
--- a/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
+++ b/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.4" />
+    <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept" Version="2.4.0" />
   </ItemGroup>
 

--- a/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -31,8 +31,8 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0-beta3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>

--- a/Src/Web/Web.Net45.Tests/packages.config
+++ b/Src/Web/Web.Net45.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.4" targetFramework="net451" />
   <package id="Microsoft.AspNet.Razor" version="3.2.4" targetFramework="net451" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net451" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.4" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net451" />

--- a/Src/Web/Web/Web.csproj
+++ b/Src/Web/Web/Web.csproj
@@ -38,7 +38,7 @@
     <!--Common Dependencies-->
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0-beta3" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
-    <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.4" />
+    <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
@@ -58,8 +58,8 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0-beta3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>

--- a/Test/E2ETests/TestApps/Net452/E2ETestApp/packages.config
+++ b/Test/E2ETests/TestApps/Net452/E2ETestApp/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net452" />
   <package id="Microsoft.AspNet.ScriptManager.MSAjax" version="5.0.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.ScriptManager.WebForms" version="5.0.0" targetFramework="net452" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net452" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net452" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Web.Optimization.WebForms" version="1.1.3" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />

--- a/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
+++ b/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
@@ -54,8 +54,8 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0-beta3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/Test/E2ETests/TestApps/Net452/E2ETestWebApi/packages.config
+++ b/Test/E2ETests/TestApps/Net452/E2ETestWebApi/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.9.0-beta3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net452" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net452" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.AspNet.Providers.Core" version="1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.ScriptManager.MSAjax" version="5.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.ScriptManager.WebForms" version="5.0.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net45" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization.WebForms" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
@@ -50,8 +50,8 @@
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Test/Web/FunctionalTests/TestApps/Aspx45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Aspx45/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.AspNet.Membership.OpenAuth" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Providers.Core" version="1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Providers.LocalDB" version="1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net45" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
@@ -66,8 +66,8 @@
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net45" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="4.0.30506.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.0.0" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
@@ -55,8 +55,8 @@
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Test/Web/FunctionalTests/TestApps/Wa45Aspx/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Wa45Aspx/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.9.0-beta3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net45" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
+++ b/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
@@ -56,8 +56,8 @@
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Test/Web/FunctionalTests/TestApps/Wcf45Tests/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/Wcf45Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.9.0-beta3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net45" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
@@ -59,8 +59,8 @@
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.9.0-beta3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net451" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
@@ -59,8 +59,8 @@
       <HintPath>..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">

--- a/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
+++ b/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net451" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.9.0-beta3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net451" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />


### PR DESCRIPTION
Fix Issue # .
Update AspNet.TelemetryCorrelation package to 1.0.5 which allows opt-out from Headers parsing (perf optimizations)

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [x] Changes in public surface reviewed
- [-] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [x] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.