### PR TITLE
remove reference to TelemetryCorrelation package from DependencyCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.9.0
+- [Fix: remove unused reference to Microsoft.AspNet.TelemetryCorrelation package from DependencyCollector](https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1136)
+
 ## Version 2.9.0-beta3
 - Update Base SDK to version 2.9.0-beta3
 - [Fix: Correlation doesn't work for localhost](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1120). If you are upgrading and have previously opted into legacy header injection via `DependencyTrackingTelemetryModule.EnableLegacyCorrelationHeadersInjection` and run app locally with Azure Storage Emulator, make sure you manually exclude localhost from correlation headers injection in the `ExcludeComponentCorrelationHttpHeadersOnDomains` under `DependencyCollector`

--- a/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
+++ b/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Product.props" />
 
   <PropertyGroup>
@@ -41,7 +41,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept" Version="2.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Reference was added by accident in https://github.com/Microsoft/ApplicationInsights-dotnet-server/commit/fed761e3710f39089d201a85da1300030becd82d

DepednencyCollector does not use anything from the Microsoft.AspNet.TelemetryCorrelation package.