### PR TITLE
Update base SDK to latest build 

### DIFF
--- a/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
+++ b/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -28,8 +28,8 @@
     <RootNamespace>Microsoft.ApplicationInsights.DependencyCollector</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0-beta3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3-build22323\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />

--- a/Src/DependencyCollector/Net45.Tests/packages.config
+++ b/Src/DependencyCollector/Net45.Tests/packages.config
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3-build22323" targetFramework="net451" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net451" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />

--- a/Src/HostingStartup/HostingStartup.Net45.Tests/HostingStartup.Net45.Tests.csproj
+++ b/Src/HostingStartup/HostingStartup.Net45.Tests/HostingStartup.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -24,8 +24,8 @@
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0-beta3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3-build22323\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>fakesAssemblyForBuild\Microsoft.QualityTools.Testing.Fakes.dll</HintPath>

--- a/Src/HostingStartup/HostingStartup.Net45.Tests/packages.config
+++ b/Src/HostingStartup/HostingStartup.Net45.Tests/packages.config
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.3.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3-build22323" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Src/PerformanceCollector/Perf.NetFull.Tests/Perf.NetFull.Tests.csproj
+++ b/Src/PerformanceCollector/Perf.NetFull.Tests/Perf.NetFull.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -37,8 +37,8 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0-beta3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3-build22323\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />

--- a/Src/PerformanceCollector/Perf.NetFull.Tests/packages.config
+++ b/Src/PerformanceCollector/Perf.NetFull.Tests/packages.config
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3-build22323" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />

--- a/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -28,8 +28,8 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0-beta3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3-build22323\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>

--- a/Src/Web/Web.Net45.Tests/packages.config
+++ b/Src/Web/Web.Net45.Tests/packages.config
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net451" />
-  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3-build22323" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.4" targetFramework="net451" />
   <package id="Microsoft.AspNet.Razor" version="3.2.4" targetFramework="net451" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net451" />

--- a/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
+++ b/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <PropertyGroup>
@@ -25,8 +25,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0-beta3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.9.0-beta3-build22323\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Src/WindowsServer/WindowsServer.Net45.Tests/packages.config
+++ b/Src/WindowsServer/WindowsServer.Net45.Tests/packages.config
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.9.0-beta3-build22323" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
To pick up changes from https://github.com/Microsoft/ApplicationInsights-dotnet/pull/1064 (W3C classes move to base)