### PR TITLE
Fix MSB3030 warning

### DIFF
--- a/Src/DependencyCollector/DependencyCollector/Microsoft.ApplicationInsights.DependencyCollector.targets
+++ b/Src/DependencyCollector/DependencyCollector/Microsoft.ApplicationInsights.DependencyCollector.targets
@@ -6,6 +6,6 @@
           Workaround is to use this targets file to manually copy into output path."-->
 
     <Message Text="Microsoft.ApplicationInsights.DependencyCollector: Copying ApplicationInsights.config to $(OutputPath)" Importance="high" />
-    <Copy SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy Condition="Exists('ApplicationInsights.config')" SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 </Project>

--- a/Src/PerformanceCollector/PerformanceCollector/Microsoft.ApplicationInsights.PerfCounterCollector.targets
+++ b/Src/PerformanceCollector/PerformanceCollector/Microsoft.ApplicationInsights.PerfCounterCollector.targets
@@ -6,6 +6,6 @@
           Workaround is to use this targets file to manually copy into output path."-->
 
     <Message Text="Microsoft.ApplicationInsights.PerfCounterCollector: Copying ApplicationInsights.config to $(OutputPath)" Importance="high" />
-    <Copy SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy Condition="Exists('ApplicationInsights.config')" SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 </Project>

--- a/Src/Web/Web/Microsoft.ApplicationInsights.Web.targets
+++ b/Src/Web/Web/Microsoft.ApplicationInsights.Web.targets
@@ -6,6 +6,6 @@
         Workaround is to use this targets file to manually copy into output path."-->
 
     <Message Text="Microsoft.ApplicationInsights.Web: Copying ApplicationInsights.config to $(OutputPath)" Importance="high" />
-    <Copy SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy Condition="Exists('ApplicationInsights.config')" SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 </Project>

--- a/Src/WindowsServer/WindowsServer/Microsoft.ApplicationInsights.WindowsServer.targets
+++ b/Src/WindowsServer/WindowsServer/Microsoft.ApplicationInsights.WindowsServer.targets
@@ -6,6 +6,6 @@
           Workaround is to use this targets file to manually copy into output path."-->
 
     <Message Text="Microsoft.ApplicationInsights.WindowsServer: Copying ApplicationInsights.config to $(OutputPath)" Importance="high" />
-    <Copy SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy Condition="Exists('ApplicationInsights.config')" SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 </Project>


### PR DESCRIPTION
Fix [MSB303 warning](https://ci.appveyor.com/project/martincostello/website/builds/22256456#L435) introduced by #1119 if the project has no `ApplicationInsights.config` file.

```
C:\Users\appveyor\.nuget\packages\microsoft.applicationinsights.dependencycollector\2.9.1\build\Microsoft.ApplicationInsights.DependencyCollector.targets(9,5): warning MSB3030: Could not copy the file "ApplicationInsights.config" because it was not found. [C:\projects\website\src\Website\Website.csproj]
```