### PR TITLE
fix MSBuild3030 warning. 

### DIFF
--- a/Src/DependencyCollector/DependencyCollector/Microsoft.ApplicationInsights.DependencyCollector.targets
+++ b/Src/DependencyCollector/DependencyCollector/Microsoft.ApplicationInsights.DependencyCollector.targets
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" >
+  <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" Condition="Exists('ApplicationInsights.config')" >
     <!--Currently we cannot set the config's "Copy to Output Directory" property to "PreserveNewest.
           Workaround is to use this targets file to manually copy into output path."-->
 
     <Message Text="Microsoft.ApplicationInsights.DependencyCollector: Copying ApplicationInsights.config to $(OutputPath)" Importance="high" />
-    <Copy Condition="Exists('ApplicationInsights.config')" SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 </Project>

--- a/Src/PerformanceCollector/PerformanceCollector/Microsoft.ApplicationInsights.PerfCounterCollector.targets
+++ b/Src/PerformanceCollector/PerformanceCollector/Microsoft.ApplicationInsights.PerfCounterCollector.targets
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" >
+  <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" Condition="Exists('ApplicationInsights.config')" >
     <!--Currently we cannot set the config's "Copy to Output Directory" property to "PreserveNewest.
           Workaround is to use this targets file to manually copy into output path."-->
 
     <Message Text="Microsoft.ApplicationInsights.PerfCounterCollector: Copying ApplicationInsights.config to $(OutputPath)" Importance="high" />
-    <Copy Condition="Exists('ApplicationInsights.config')" SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 </Project>

--- a/Src/Web/Web/Microsoft.ApplicationInsights.Web.targets
+++ b/Src/Web/Web/Microsoft.ApplicationInsights.Web.targets
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
-  <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" >
+  <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" Condition="Exists('ApplicationInsights.config')" >
       <!--Currently we cannot set the config's "Copy to Output Directory" property to "PreserveNewest.
         Workaround is to use this targets file to manually copy into output path."-->
 
     <Message Text="Microsoft.ApplicationInsights.Web: Copying ApplicationInsights.config to $(OutputPath)" Importance="high" />
-    <Copy Condition="Exists('ApplicationInsights.config')" SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 </Project>

--- a/Src/WindowsServer/WindowsServer/Microsoft.ApplicationInsights.WindowsServer.targets
+++ b/Src/WindowsServer/WindowsServer/Microsoft.ApplicationInsights.WindowsServer.targets
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" >
+  <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" Condition="Exists('ApplicationInsights.config')" >
     <!--Currently we cannot set the config's "Copy to Output Directory" property to "PreserveNewest.
           Workaround is to use this targets file to manually copy into output path."-->
 
     <Message Text="Microsoft.ApplicationInsights.WindowsServer: Copying ApplicationInsights.config to $(OutputPath)" Importance="high" />
-    <Copy Condition="Exists('ApplicationInsights.config')" SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy SourceFiles="ApplicationInsights.config" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 </Project>


### PR DESCRIPTION
Fix https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1085

should ignore target to skip both the message and copy task