### PR TITLE
 A telemetry initializer that will gather configuration information.

### DIFF
--- a/Src/WindowsServer/WindowsServer.Shared.Tests/ConfigurationTelemetryInitializerTest.cs
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/ConfigurationTelemetryInitializerTest.cs
@@ -1,0 +1,196 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer
+{
+    using System;
+    using System.Globalization;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+#if !NETCORE
+    using Microsoft.ApplicationInsights.WindowsServer.Azure;
+    using Microsoft.ApplicationInsights.WindowsServer.Azure.Emulation;
+#endif
+    using Microsoft.ApplicationInsights.WindowsServer.Implementation;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Assert = Xunit.Assert;
+
+    [TestClass]
+    public class ConfigurationTelemetryInitializerTest
+    {
+        private const string TestRoleName = nameof(TestRoleName);
+        private const string TestRoleInstance = nameof(TestRoleInstance);
+
+        [TestMethod]
+        public void ConfigurationTelemetryInitializerSetsRoleName()
+        {
+            var telemetryItem = new EventTelemetry();
+
+            var initializer = new ConfigurationTelemetryInitializer
+            {
+                RoleName = TestRoleName,
+            };
+
+            initializer.Initialize(telemetryItem);
+
+            Assert.Equal(TestRoleName, telemetryItem.Context.Cloud.RoleName);
+        }
+
+        [TestMethod]
+        public void ConfigurationTelemetryInitializerSetsRoleNameFromEnvironmentVariable()
+        {
+            string roleNameTestVarName, roleInstanceTestVarName;
+            GetAndInitializeEnvironment(out roleNameTestVarName, out roleInstanceTestVarName);
+
+            var telemetryItem = new EventTelemetry();
+
+            var initializer = new ConfigurationTelemetryInitializer
+            {
+                RoleName = $"%{roleNameTestVarName}%",
+            };
+
+            initializer.Initialize(telemetryItem);
+
+            Assert.Equal(TestRoleName, telemetryItem.Context.Cloud.RoleName);
+
+            ClearEnvironmentVariables(roleNameTestVarName, roleInstanceTestVarName);
+        }
+
+        [TestMethod]
+        public void ConfigurationTelemetryInitializerSetsRoleInstanceNameAndNodeName()
+        {
+            string roleNameTestVarName, roleInstanceTestVarName;
+            GetAndInitializeEnvironment(out roleNameTestVarName, out roleInstanceTestVarName);
+
+            var telemetryItem = new EventTelemetry();
+
+            var initializer = new ConfigurationTelemetryInitializer
+            {
+                RoleInstance = TestRoleInstance,
+            };
+
+            initializer.Initialize(telemetryItem);
+
+            Assert.Equal(TestRoleInstance, telemetryItem.Context.Cloud.RoleInstance);
+            Assert.Equal(TestRoleInstance, telemetryItem.Context.GetInternalContext().NodeName);
+
+            ClearEnvironmentVariables(roleNameTestVarName, roleInstanceTestVarName);
+        }
+
+        [TestMethod]
+        public void ConfigurationTelemetryInitializerSetsRoleInstanceNameAndNodeNameFromEnvironmentVariable()
+        {
+            string roleNameTestVarName, roleInstanceTestVarName;
+            GetAndInitializeEnvironment(out roleNameTestVarName, out roleInstanceTestVarName);
+
+            var telemetryItem = new EventTelemetry();
+
+            var initializer = new ConfigurationTelemetryInitializer
+            {
+                RoleInstance = $"%{roleInstanceTestVarName}%",
+            };
+
+            initializer.Initialize(telemetryItem);
+
+            Assert.Equal(TestRoleInstance, telemetryItem.Context.Cloud.RoleInstance);
+            Assert.Equal(TestRoleInstance, telemetryItem.Context.GetInternalContext().NodeName);
+
+            ClearEnvironmentVariables(roleNameTestVarName, roleInstanceTestVarName);
+        }
+
+        [TestMethod]
+        public void ConfigurationTelemetryInitializerDoesNotOverrideRoleName()
+        {
+            const string TestValue = "Test";
+
+            var telemetryItem = new EventTelemetry();
+            telemetryItem.Context.Cloud.RoleName = TestValue;
+
+            var initializer = new ConfigurationTelemetryInitializer
+            {
+                RoleName = TestRoleName,
+                RoleInstance = TestRoleInstance,
+            };
+
+            initializer.Initialize(telemetryItem);
+
+            Assert.Equal(TestValue, telemetryItem.Context.Cloud.RoleName);
+            Assert.Equal(TestRoleInstance, telemetryItem.Context.Cloud.RoleInstance);
+            Assert.Equal(TestRoleInstance, telemetryItem.Context.GetInternalContext().NodeName);
+        }
+
+        [TestMethod]
+        public void ConfigurationTelemetryInitializerDoesNotOverrideRoleInstance()
+        {
+            const string TestValue = "Test";
+
+            var telemetryItem = new EventTelemetry();
+            telemetryItem.Context.Cloud.RoleInstance = TestValue;
+
+            var initializer = new ConfigurationTelemetryInitializer
+            {
+                RoleName = TestRoleName,
+                RoleInstance = TestRoleInstance,
+            };
+
+            initializer.Initialize(telemetryItem);
+
+            Assert.Equal(TestRoleName, telemetryItem.Context.Cloud.RoleName);
+            Assert.Equal(TestValue, telemetryItem.Context.Cloud.RoleInstance);
+            Assert.Equal(TestRoleInstance, telemetryItem.Context.GetInternalContext().NodeName);
+        }
+
+        [TestMethod]
+        public void ConfigurationTelemetryInitializerDoesNotOverrideNodeName()
+        {
+            const string TestValue = "Test";
+
+            var telemetryItem = new EventTelemetry();
+            telemetryItem.Context.GetInternalContext().NodeName = TestValue;
+
+            var initializer = new ConfigurationTelemetryInitializer
+            {
+                RoleName = TestRoleName,
+                RoleInstance = TestRoleInstance,
+            };
+
+            initializer.Initialize(telemetryItem);
+
+            Assert.Equal(TestRoleName, telemetryItem.Context.Cloud.RoleName);
+            Assert.Equal(TestRoleInstance, telemetryItem.Context.Cloud.RoleInstance);
+            Assert.Equal(TestValue, telemetryItem.Context.GetInternalContext().NodeName);
+        }
+
+        [TestMethod]
+        public void ConfigurationTelemetryInitializerEmptyVariable()
+        {
+            string roleNameTestVarName, roleInstanceTestVarName;
+            GetAndInitializeEnvironment(out roleNameTestVarName, out roleInstanceTestVarName);
+            ClearEnvironmentVariables(roleNameTestVarName, roleInstanceTestVarName);
+
+            var telemetryItem = new EventTelemetry();
+
+            var initializer = new ConfigurationTelemetryInitializer();
+
+            initializer.Initialize(telemetryItem);
+
+            Assert.Null(telemetryItem.Context.Cloud.RoleName);
+            Assert.Null(telemetryItem.Context.Cloud.RoleInstance);
+            Assert.Null(telemetryItem.Context.GetInternalContext().NodeName);
+        }
+
+        private static void GetAndInitializeEnvironment(out string roleNameTestVarName, out string roleInstanceTestVarName)
+        {
+            roleNameTestVarName = "ROLE_NAME_" + Guid.NewGuid().ToString();
+            Environment.SetEnvironmentVariable(roleNameTestVarName, TestRoleName);
+
+            roleInstanceTestVarName = "ROLE_INSTANCE_" + Guid.NewGuid().ToString();
+            Environment.SetEnvironmentVariable(roleInstanceTestVarName, TestRoleInstance);
+        }
+
+        private static void ClearEnvironmentVariables(string roleNameTestVarName, string roleInstanceTestVarName)
+        {
+            Environment.SetEnvironmentVariable(roleNameTestVarName, null);
+
+            Environment.SetEnvironmentVariable(roleInstanceTestVarName, null);
+        }
+    }
+}

--- a/Src/WindowsServer/WindowsServer.Shared.Tests/WindowsServer.Shared.Tests.projitems
+++ b/Src/WindowsServer/WindowsServer.Shared.Tests/WindowsServer.Shared.Tests.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AppServicesHeartbeatTelemetryModuleTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ConfigurationTelemetryInitializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EnvironmentVariableMonitorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AzureInstanceMetadataEndToEndTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AzureWebAppRoleEnvironmentTelemetryInitializerTest.cs" />

--- a/Src/WindowsServer/WindowsServer.Shared/ConfigurationTelemetryInitializer.cs
+++ b/Src/WindowsServer/WindowsServer.Shared/ConfigurationTelemetryInitializer.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.ApplicationInsights.WindowsServer.Implementation;
+
+namespace Microsoft.ApplicationInsights.WindowsServer
+{
+    /// <summary>
+    /// A telemetry initializer that will gather configuration information.
+    /// </summary>
+    public class ConfigurationTelemetryInitializer : ITelemetryInitializer
+    {
+        private string roleName;
+        private string roleInstanceName;
+        private volatile bool updateEnvVars = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigurationTelemetryInitializer" /> class.
+        /// </summary>
+        public ConfigurationTelemetryInitializer()
+        {
+            WindowsServerEventSource.Log.TelemetryInitializerLoaded(this.GetType().FullName);
+            AppServiceEnvironmentVariableMonitor.Instance.MonitoredAppServiceEnvVarUpdatedEvent += this.UpdateEnvironmentValues;
+        }
+
+        /// <summary>
+        /// Gets or sets the <c>cloud_RoleName</c>.
+        /// </summary>
+        /// <value>The <c>cloud_RoleName</c>.</value>
+        /// <remarks>Supports environment variable expansion with <c>%VARIABLE_NAME%</c></remarks>
+        public string RoleName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <c>cloud_RoleInstance</c>.
+        /// </summary>
+        /// <value>The <c>cloud_RoleInstance</c>.</value>
+        /// <remarks>Supports environment variable expansion with <c>%VARIABLE_NAME%</c></remarks>
+        public string RoleInstance { get; set; }
+
+        /// <summary>
+        /// Initializes <see cref="ITelemetry" /> role and node context information.
+        /// </summary>
+        /// <param name="telemetry">The telemetry to initialize.</param>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (this.updateEnvVars)
+            {
+                this.roleName = this.GetRoleName();
+                this.roleInstanceName = this.GetRoleInstanceName();
+                this.updateEnvVars = false;
+            }
+
+            if (this.roleName is string && string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+            {
+                telemetry.Context.Cloud.RoleName = this.roleName;
+            }
+
+            if (this.roleInstanceName is string && string.IsNullOrEmpty(telemetry.Context.Cloud.RoleInstance))
+            {
+                telemetry.Context.Cloud.RoleInstance = this.roleInstanceName;
+            }
+
+            if (this.roleInstanceName is string && string.IsNullOrEmpty(telemetry.Context.GetInternalContext().NodeName))
+            {
+                telemetry.Context.GetInternalContext().NodeName = this.roleInstanceName;
+            }
+        }
+
+        /// <summary>
+        /// Remove our event handler from the environment variable monitor.
+        /// </summary>
+        public void Dispose()
+        {
+            AppServiceEnvironmentVariableMonitor.Instance.MonitoredAppServiceEnvVarUpdatedEvent -= this.UpdateEnvironmentValues;
+        }
+
+        private string GetRoleName() => ExpandEnvironmentVariables(this.RoleName);
+
+        private string GetRoleInstanceName() => ExpandEnvironmentVariables(this.RoleInstance);
+
+        private static string ExpandEnvironmentVariables(string definition)
+        {
+            if (string.IsNullOrWhiteSpace(definition))
+            {
+                return default(string);
+            }
+
+            var expandedDefinition = Regex.Replace(definition, @"(?<e>%%)|%(?<v>[^%]+)%", ExpandEnvironmentVariable, RegexOptions.ExplicitCapture);
+
+            return expandedDefinition;
+        }
+
+        private static string ExpandEnvironmentVariable(Match match)
+        {
+            var variableGroup = match.Groups["v"];
+
+            if (variableGroup.Success)
+            {
+                var value = default(string);
+                AppServiceEnvironmentVariableMonitor.Instance.GetCurrentEnvironmentVariableValue(variableGroup.Value, ref value);
+                return string.IsNullOrWhiteSpace(value) ? null : value;
+            }
+
+            return null;
+        }
+
+        private void UpdateEnvironmentValues()
+        {
+            this.updateEnvVars = true;
+        }
+    }
+}

--- a/Src/WindowsServer/WindowsServer.Shared/WindowsServer.Shared.projitems
+++ b/Src/WindowsServer/WindowsServer.Shared/WindowsServer.Shared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DeveloperModeWithDebuggerAttachedTelemetryModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DomainNameRoleInstanceTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AppServicesHeartbeatTelemetryModule.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ConfigurationTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\AppServiceEnvironmentVariableMonitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\AzureComputeMetadataHeartbeatPropertyProvider.cs" />


### PR DESCRIPTION
 A telemetry initializer that will gather configuration information.

- [X] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.