### PR TITLE
Adding Performance counter collector support to Web App for Windows Containers

### DIFF
--- a/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
@@ -33,6 +33,8 @@
         private const string AzureWebAppCoreSdkVersionPrefix = "azwapccore:";
 
         private const string WebSiteEnvironmentVariable = "WEBSITE_SITE_NAME";
+        private const string WebSiteSkuEnvironmentVariable = "WEBSITE_SKU";
+        private const string WebSiteSkuPremiumContainer = "PremiumContainer";
         private const string ProcessorsCountEnvironmentVariable = "NUMBER_OF_PROCESSORS";
 
         private static readonly ConcurrentDictionary<string, string> PlaceholderCache = new ConcurrentDictionary<string, string>();
@@ -77,7 +79,8 @@
             {
                 try
                 {
-                    isAzureWebApp = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebSiteEnvironmentVariable));
+                    isAzureWebApp = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebSiteEnvironmentVariable)) &&
+                        Environment.GetEnvironmentVariable(WebSiteSkuEnvironmentVariable) != WebSiteSkuPremiumContainer;
                 }
                 catch (Exception ex)
                 {

--- a/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
@@ -33,8 +33,8 @@
         private const string AzureWebAppCoreSdkVersionPrefix = "azwapccore:";
 
         private const string WebSiteEnvironmentVariable = "WEBSITE_SITE_NAME";
-        private const string WebSiteSkuEnvironmentVariable = "WEBSITE_SKU";
-        private const string WebSiteSkuPremiumContainer = "PremiumContainer";
+        private const string WebSiteIsolationEnvironmentVariable = "WEBSITE_ISOLATION";
+        private const string WebSiteIsolationHyperV = "hyperv";
         private const string ProcessorsCountEnvironmentVariable = "NUMBER_OF_PROCESSORS";
 
         private static readonly ConcurrentDictionary<string, string> PlaceholderCache = new ConcurrentDictionary<string, string>();
@@ -80,7 +80,7 @@
                 try
                 {
                     isAzureWebApp = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebSiteEnvironmentVariable)) &&
-                        Environment.GetEnvironmentVariable(WebSiteSkuEnvironmentVariable) != WebSiteSkuPremiumContainer;
+                        Environment.GetEnvironmentVariable(WebSiteIsolationEnvironmentVariable) != WebSiteIsolationHyperV;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Fix Issue #676
Fixed the problem that performance counters are not collected in Web App for Windows Containers.

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.