### PR TITLE
Performance: mikp's new class "PostSamplingTelemetryProcessor" for attach scenarios

### DIFF
--- a/Src/Web/Web.Shared.Net/PostSamplingTelemetryProcessor.cs
+++ b/Src/Web/Web.Shared.Net/PostSamplingTelemetryProcessor.cs
@@ -1,0 +1,77 @@
+﻿namespace Microsoft.ApplicationInsights.Web
+{
+    using System;
+
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.Web.Implementation;
+
+    /// <summary>
+    /// PostSamplingTelemetry processor which ensures that the RequestTelemetry.Url is initialized
+    /// in the context of HttpContext.Current.Request
+    /// </summary>
+    public class PostSamplingTelemetryProcessor : ITelemetryProcessor
+    {
+        private readonly ITelemetryProcessor nextProcessorInPipeline;
+        private TelemetryConfiguration telemetryConfiguration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostSamplingTelemetryProcessor"/> class.
+        /// </summary>
+        /// <param name="nextProcessorInPipeline">The next TelemetryProcessor in the chain.</param>
+        public PostSamplingTelemetryProcessor(ITelemetryProcessor nextProcessorInPipeline)
+        {
+            this.nextProcessorInPipeline = nextProcessorInPipeline;
+        }
+
+        private TelemetryConfiguration TelemetryConfiguration => this.telemetryConfiguration ?? (this.telemetryConfiguration = TelemetryConfiguration.Active);
+
+        /// <inheritdoc />
+        public void Process(ITelemetry item)
+        {
+            if (item is RequestTelemetry requestTelemetry)
+            {
+                var context = System.Web.HttpContext.Current;
+                if (requestTelemetry.Url == null)
+                {
+                    requestTelemetry.Url = context.Request.UnvalidatedGetUrl();
+                }
+
+                var headers = context.Request.UnvalidatedGetHeaders();
+                if (string.IsNullOrEmpty(requestTelemetry.Source) && headers != null)
+                {
+                    string sourceAppId = null;
+
+                    try
+                    {
+                        sourceAppId = headers.GetNameValueHeaderValue(
+                            RequestResponseHeaders.RequestContextHeader,
+                            RequestResponseHeaders.RequestContextCorrelationSourceKey);
+                    }
+                    catch (Exception ex)
+                    {
+                        AppMapCorrelationEventSource.Log.GetCrossComponentCorrelationHeaderFailed(ex.ToInvariantString());
+                    }
+
+                    string currentComponentAppId = null;
+                    if (!string.IsNullOrEmpty(requestTelemetry.Context.InstrumentationKey)
+                        && (this.TelemetryConfiguration?.ApplicationIdProvider?.TryGetApplicationId(requestTelemetry.Context.InstrumentationKey, out currentComponentAppId) ?? false))
+                    {
+                        // If the source header is present on the incoming request,
+                        // and it is an external component (not the same ikey as the one used by the current component),
+                        // then populate the source field.
+                        if (!string.IsNullOrEmpty(sourceAppId) && sourceAppId != currentComponentAppId)
+                        {
+                            requestTelemetry.Source = sourceAppId;
+                        }
+                    }
+                }
+            }
+
+            this.nextProcessorInPipeline?.Process(item);
+        }
+    }
+}

--- a/Src/Web/Web.Shared.Net/Web.Shared.Net.projitems
+++ b/Src/Web/Web.Shared.Net/Web.Shared.Net.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WebTelemetryInitializerBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WebTelemetryModuleBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OperationCorrelationTelemetryInitializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PostSamplingTelemetryProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ClientIpHeaderTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionTrackingTelemetryModule.cs" />


### PR DESCRIPTION
The private fork of our SDK is causing me some issues.
I'm trying to get as many of these changes into the actual SDK as possible.

- introduces new telemetry processor: `PostSamplingTelemetryProcessor`
  - if RequestTelemetry.Url is null, set to context.Request's unvalidated url.
  - will set Request.Source to the source's appId.
  - Both of these behaviors exist in 'RequestTrackingTelemetryModule.cs', but have been disabled in favor of being applied after sampling
- This class will **not** be added to the default SDK and will not affect SDK customers.
- This class will **only** be used by attach scenarios.



May be more appropriate to rename this class `PostSamplingRequestTrackingTelemetryProcessor` because it specifically deferrs behavior from the `RequestTrackingTelemetryModule` to execute after Sampling.