### PR TITLE
Add unit test for netstandard20 PerfCounter

### DIFF
--- a/Src/Microsoft.ApplicationInsights.Web.sln
+++ b/Src/Microsoft.ApplicationInsights.Web.sln
@@ -86,11 +86,11 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Perf.Shared.NetStandard20",
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Perf.Shared.NetStandard.Stubs", "PerformanceCollector\Perf.Shared.NetStandard.Stubs\Perf.Shared.NetStandard.Stubs.shproj", "{30A45441-0849-48FE-AD37-5D29D0E3068A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perf-NetCore20.Tests", "PerformanceCollector\NetCore20.Tests\Perf-NetCore20.Tests\Perf-NetCore20.Tests.csproj", "{AC7D8533-C823-4E93-B008-51B3C4744E2E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		PerformanceCollector\Perf.Shared.NetStandard20\Perf.Shared.NetStandard20.projitems*{054c25dc-e545-4712-95c4-81f30cf65ce8}*SharedItemsImports = 13
-		DependencyCollector\Shared.Tests\DependencyCollector.Shared.Tests.projitems*{257fce5a-0779-45a5-b541-0ce43d79d009}*SharedItemsImports = 4
-		TestFramework\Shared\TestFramework.Shared.projitems*{257fce5a-0779-45a5-b541-0ce43d79d009}*SharedItemsImports = 4
 		PerformanceCollector\Perf.Shared.NetStandard.Stubs\Perf.Shared.NetStandard.Stubs.projitems*{30a45441-0849-48fe-ad37-5d29d0e3068a}*SharedItemsImports = 13
 		Web\Web.Shared.Net\Web.Shared.Net.projitems*{395e03bb-d061-4c9d-9d47-18676566444d}*SharedItemsImports = 13
 		PerformanceCollector\Filtering.Shared\Filtering.Shared.projitems*{568aeb4f-ba4c-47a5-9fa3-68f06cd11fed}*SharedItemsImports = 13
@@ -106,12 +106,8 @@ Global
 		DependencyCollector\Shared.Tests\DependencyCollector.Shared.Tests.projitems*{ace58393-3419-4fca-87cc-c33eb756c7e4}*SharedItemsImports = 13
 		Common\Common.projitems*{ccab7a34-8dc5-4a6f-b637-46ceba93c687}*SharedItemsImports = 13
 		PerformanceCollector\Perf.Shared.NetStandard\Perf.Shared.NetStandard.projitems*{d13c3ec7-b300-4158-9054-216156b203be}*SharedItemsImports = 13
-		TestFramework\Shared\TestFramework.Shared.projitems*{f05eb480-b209-47dd-90e3-1ddc47efc579}*SharedItemsImports = 4
-		WindowsServer\WindowsServer.Shared.Tests\WindowsServer.Shared.Tests.projitems*{f05eb480-b209-47dd-90e3-1ddc47efc579}*SharedItemsImports = 4
 		PerformanceCollector\Perf.Shared.Tests\Perf.Shared.Tests.projitems*{f254d4fb-428d-408e-8251-39bca7b4b5ce}*SharedItemsImports = 4
 		TestFramework\Shared\TestFramework.Shared.projitems*{f254d4fb-428d-408e-8251-39bca7b4b5ce}*SharedItemsImports = 4
-		TestFramework\Shared\TestFramework.Shared.projitems*{f71138bb-b3f8-4767-b394-857b0776038e}*SharedItemsImports = 4
-		Web\Web.Shared.Net.Tests\Web.Shared.Net.Tests.projitems*{f71138bb-b3f8-4767-b394-857b0776038e}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -232,6 +228,14 @@ Global
 		{00BF736C-B562-4251-9836-EF80282956AF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{00BF736C-B562-4251-9836-EF80282956AF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{00BF736C-B562-4251-9836-EF80282956AF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{AC7D8533-C823-4E93-B008-51B3C4744E2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC7D8533-C823-4E93-B008-51B3C4744E2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC7D8533-C823-4E93-B008-51B3C4744E2E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{AC7D8533-C823-4E93-B008-51B3C4744E2E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{AC7D8533-C823-4E93-B008-51B3C4744E2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC7D8533-C823-4E93-B008-51B3C4744E2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC7D8533-C823-4E93-B008-51B3C4744E2E}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{AC7D8533-C823-4E93-B008-51B3C4744E2E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -266,6 +270,7 @@ Global
 		{00BF736C-B562-4251-9836-EF80282956AF} = {A318CC6C-51C8-4BD6-BC85-2B4F35123BE7}
 		{054C25DC-E545-4712-95C4-81F30CF65CE8} = {A318CC6C-51C8-4BD6-BC85-2B4F35123BE7}
 		{30A45441-0849-48FE-AD37-5D29D0E3068A} = {A318CC6C-51C8-4BD6-BC85-2B4F35123BE7}
+		{AC7D8533-C823-4E93-B008-51B3C4744E2E} = {A318CC6C-51C8-4BD6-BC85-2B4F35123BE7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F99E0A07-C363-49BF-BFA7-C748391CE38E}

--- a/Src/PerformanceCollector/NetCore20.Tests/Perf-NetCore20.Tests/Perf-NetCore20.Tests.csproj
+++ b/Src/PerformanceCollector/NetCore20.Tests/Perf-NetCore20.Tests/Perf-NetCore20.Tests.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NetCore.props))\NetCore.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Microsoft.AI.PerformanceCollector.NetCore20.Tests</AssemblyName>
+    <PackageId>Microsoft.AI.PerformanceCollector.Tests</PackageId>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>    
+    <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1705;1591;8002</NoWarn>
+    <DefineConstants>TRACE;DEBUG;NETCORE;NETCOREAPP2_0</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1705;1591;8002</NoWarn>
+    <DefineConstants>TRACE;RELEASE;NETCORE;NETCOREAPP2_0</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />    
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\PerformanceCollector\Perf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <Import Project="..\..\Perf.Shared.Tests\Perf.Shared.Tests.projitems" Label="Shared" />
+</Project>

--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -126,8 +126,8 @@
 
             Uri serviceEndpoint = new Uri(string.Format(CultureInfo.InvariantCulture, "http://localhost:{0}", port));
             this.TestContext.Properties[ServiceEndpointPropertyName] = serviceEndpoint;
-        
-#if NETCORE
+            
+#if NETCOREAPP1_0
             this.Listener = new HttpListener(IPAddress.Loopback, port);
 #else
             this.Listener = new HttpListener();
@@ -136,7 +136,7 @@
 #endif
 
             this.Listener.Start();
-
+            
             this.AssertionSync = new SemaphoreSlim(0);
 
             var eventListenerReady = new AutoResetEvent(false);
@@ -2010,7 +2010,11 @@
                 try
                 {
                     ev.Set();
+#if NETCOREAPP1_0
                     HttpListenerContext context = listener.GetContextAsync().GetAwaiter().GetResult();
+#else
+                    HttpListenerContext context = listener.GetContext();
+#endif
 
                     var request = context.Request;
 

--- a/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -126,7 +126,7 @@
 
             Uri serviceEndpoint = new Uri(string.Format(CultureInfo.InvariantCulture, "http://localhost:{0}", port));
             this.TestContext.Properties[ServiceEndpointPropertyName] = serviceEndpoint;
-            
+
 #if NETCOREAPP1_0
             this.Listener = new HttpListener(IPAddress.Loopback, port);
 #else
@@ -136,7 +136,7 @@
 #endif
 
             this.Listener.Start();
-            
+
             this.AssertionSync = new SemaphoreSlim(0);
 
             var eventListenerReady = new AutoResetEvent(false);

--- a/Src/PerformanceCollector/Perf.Shared/AssemblyInfo.cs
+++ b/Src/PerformanceCollector/Perf.Shared/AssemblyInfo.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("TestApp45, PublicKey=" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.AI.PerformanceCollector.NetFull.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.AI.PerformanceCollector.NetCore.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.AI.PerformanceCollector.NetCore20.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
 
 internal static class AssemblyInfo
 {


### PR DESCRIPTION
The following PRs added NetStandard2.0 for PerfCollector, but unit tests were not target it yet. This adds a new unit test targeting 2.0 to ensure proper coverage.
https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1157
https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1148