### PR TITLE
Fix flacky OnEndExceptionAsyncDoesNotSendTelemetryIfSuccess_2ArgumentsOverride

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
@@ -614,7 +614,8 @@
                 expectedName: GetResourceNameForStoredProcedure(command),
                 expectedSuccess: true,
                 expectedResultCode: string.Empty,
-                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);
+                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds,
+                async: true);
         }
 
         [TestMethod]


### PR DESCRIPTION
Async callbacks cannot be used to verify duration
https://dev.azure.com/mseng/AppInsights/_build/results?buildId=9529202&view=logs&j=238e8bd2-a405-568b-6af4-baad8728563f