### PR TITLE
OnEndExceptionAsyncDoesNotSendTelemetryIfSuccess_1ArgumentOverride: Async test should not verify duration

### DIFF
--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
@@ -580,7 +580,8 @@
                 expectedName: GetResourceNameForStoredProcedure(command),
                 expectedSuccess: true,
                 expectedResultCode: string.Empty,
-                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds);
+                timeBetweenBeginEndInMs: stopwatch.Elapsed.TotalMilliseconds,
+                async: true);
         }
 
         [TestMethod]


### PR DESCRIPTION
Similar to #1200 