### PR TITLE
Replace non-threadsafe HashSet with ConcurrentDictionary in RequestTrackingTelemetryModule.IsHandlerToFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## vNext
+- [Fix: Replaced non-threadsafe HashSet with ConcurrentDictionary in RequestTrackingTelemetryModule.IsHandlerToFilter](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1211)
+
 ## Version 2.11.0-beta1
  - [Defer populating RequestTelemetry properties.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1173)
 

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -28,11 +28,9 @@
         private TelemetryConfiguration telemetryConfiguration;
         private bool initializationErrorReported;
         private ChildRequestTrackingSuppressionModule childRequestTrackingSuppressionModule = null;
-
-        /// <summary>
-        /// Handler types that are not TransferHandlers will be included in request tracking.
-        /// </summary>
-        private HashSet<Type> requestHandlerTypesDoNotFilter = new HashSet<Type>();
+        
+        /// <summary>Tracks if given type should be included in telemetry. ConcurrentDictionary is used as a concurrent hashset.</summary>
+        private ConcurrentDictionary<Type, bool> includedHttpHandlerTypes = new ConcurrentDictionary<Type, bool>();
 
         /// <summary>
         /// Gets or sets a value indicating whether child request suppression is enabled or disabled. 
@@ -371,7 +369,7 @@
             if (handler != null)
             {
                 var handlerType = handler.GetType();
-                if (!this.requestHandlerTypesDoNotFilter.Contains(handlerType))
+                if (!this.includedHttpHandlerTypes.ContainsKey(handlerType))
                 {
                     var handlerName = handlerType.FullName;
                     foreach (var h in this.Handlers)
@@ -383,7 +381,7 @@
                         }
                     }
 
-                    this.requestHandlerTypesDoNotFilter.Add(handlerType);
+                    this.includedHttpHandlerTypes.TryAdd(handlerType, true);
                 }
             }
 

--- a/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
+++ b/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs
@@ -24,14 +24,14 @@
         // if HttpApplicaiton.OnRequestExecute is available, we don't attempt to detect any correlation issues
         private static bool correlationIssuesDetectionComplete = typeof(HttpApplication).GetMethod("OnExecuteRequestStep") != null;
 
+        /// <summary>Tracks if given type should be included in telemetry. ConcurrentDictionary is used as a concurrent hashset.</summary>
+        private readonly ConcurrentDictionary<Type, bool> includedHttpHandlerTypes = new ConcurrentDictionary<Type, bool>();
+
         private TelemetryClient telemetryClient;
         private TelemetryConfiguration telemetryConfiguration;
         private bool initializationErrorReported;
         private ChildRequestTrackingSuppressionModule childRequestTrackingSuppressionModule = null;
         
-        /// <summary>Tracks if given type should be included in telemetry. ConcurrentDictionary is used as a concurrent hashset.</summary>
-        private ConcurrentDictionary<Type, bool> includedHttpHandlerTypes = new ConcurrentDictionary<Type, bool>();
-
         /// <summary>
         /// Gets or sets a value indicating whether child request suppression is enabled or disabled. 
         /// True by default.


### PR DESCRIPTION
Fix Issue # .
Fixes IndexOutOfRangeException:
WAC FrontEnd unhandled exception [0] [ExceptionType:System.IndexOutOfRangeException]
System.IndexOutOfRangeException: Index was outside the bounds of the array.
at System.Collections.Generic.HashSet`1.AddIfNotPresent(T value)
at Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule.IsHandlerToFilter(IHttpHandler handler)
at Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule.NeedProcessRequest(HttpContext httpContext)
...
- [x] I ran Unit Tests locally.
