### PR TITLE
Modifies check for IsAzureWebApp to exclude WebApp for PremiumContain…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Version 2.11.0-beta1
  - [Defer populating RequestTelemetry properties.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1173)
+ - [Azure Web App for Windows Containers to use regular PerfCounter mechanism.](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1167)
+ - [Support for Process CPU and Process Memory perf counters in all platforms including Linux.](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1189)
 
 ## Version 2.10.0
 - Updated Base SDK to 2.10.0

--- a/Src/PerformanceCollector/Perf.Shared.Tests/PerformanceCounterUtilityTestsCommon.cs
+++ b/Src/PerformanceCollector/Perf.Shared.Tests/PerformanceCounterUtilityTestsCommon.cs
@@ -89,5 +89,45 @@
             }
 #endif
         }
+
+        [TestMethod]
+        public void IsWebAppReturnsTrueOnRegularWebApp()
+        {
+            try
+            {
+                PerformanceCounterUtility.isAzureWebApp = null;
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "something");
+                Environment.SetEnvironmentVariable("WEBSITE_ISOLATION", "nothyperv");
+                var actual = PerformanceCounterUtility.IsWebAppRunningInAzure();
+                Assert.IsTrue(actual);
+            }
+            finally
+            {
+                PerformanceCounterUtility.isAzureWebApp = null;
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", string.Empty);
+                Environment.SetEnvironmentVariable("WEBSITE_ISOLATION", string.Empty);
+                Task.Delay(1000).Wait();
+            }
+        }
+
+        [TestMethod]
+        public void IsWebAppReturnsFalseOnPremiumContainerWebApp()
+        {
+            try
+            {
+                PerformanceCounterUtility.isAzureWebApp = null;
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "something");
+                Environment.SetEnvironmentVariable("WEBSITE_ISOLATION", "hyperv");
+                var actual = PerformanceCounterUtility.IsWebAppRunningInAzure();
+                Assert.IsFalse(actual);
+            }
+            finally
+            {
+                PerformanceCounterUtility.isAzureWebApp = null;
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", string.Empty);
+                Environment.SetEnvironmentVariable("WEBSITE_ISOLATION", string.Empty);
+                Task.Delay(1000).Wait();
+            }
+        }
     }
 }

--- a/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
+++ b/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
@@ -46,7 +46,8 @@
         private const string AzureWebAppCoreSdkVersionPrefix = "azwapccore:";
 
         private const string WebSiteEnvironmentVariable = "WEBSITE_SITE_NAME";
-        private const string ProcessorsCountEnvironmentVariable = "NUMBER_OF_PROCESSORS";
+        private const string WebSiteIsolationEnvironmentVariable = "WEBSITE_ISOLATION";
+        private const string WebSiteIsolationHyperV = "hyperv";
 
         private static readonly ConcurrentDictionary<string, string> PlaceholderCache =
             new ConcurrentDictionary<string, string>();
@@ -165,16 +166,21 @@
         }
 
         /// <summary>
-        /// Searches for the environment variable specific to Azure web applications and confirms if the current application is a web application or not.
+        /// Searches for the environment variable specific to Azure Web App.
         /// </summary>
-        /// <returns>Boolean, which is true if the current application is an Azure web application.</returns>
+        /// <returns>Boolean, which is true if the current application is an Azure Web App.</returns>
         public static bool IsWebAppRunningInAzure()
         {
             if (!isAzureWebApp.HasValue)
             {
                 try
                 {
-                    isAzureWebApp = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebSiteEnvironmentVariable));
+                    // Presence of "WEBSITE_SITE_NAME" indicate web apps.
+                    // "WEBSITE_ISOLATION"!="hyperv" indicate premium containers. In this case, perf counters
+                    // can be read using regular mechanism and hence this method retuns false for
+                    // premium containers.
+                    isAzureWebApp = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebSiteEnvironmentVariable)) &&
+                                    Environment.GetEnvironmentVariable(WebSiteIsolationEnvironmentVariable) != WebSiteIsolationHyperV;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
…ers as they can use regular perf counter

This is same as:
https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1167

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.