### PR TITLE
Fix counter name in EventCounter

### DIFF
--- a/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
+++ b/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
@@ -156,21 +156,23 @@
                 double actualValue = 0.0;
                 double actualInterval = 0.0;
                 int actualCount = 0;
+                string counterName = string.Empty;
+                string counterDisplayName = string.Empty;
                 foreach (KeyValuePair<string, object> payload in eventPayload)
                 {
                     var key = payload.Key;
                     if (key.Equals("Name", StringComparison.OrdinalIgnoreCase))
                     {
-                        var counterName = payload.Value.ToString();
-                        if (this.countersToCollect[eventSourceName].Contains(counterName))
-                        {
-                            metricTelemetry.Name = eventSourceName + "|" + counterName;
-                        }
-                        else
+                        counterName = payload.Value.ToString();
+                        if (!this.countersToCollect[eventSourceName].Contains(counterName))                        
                         {
                             EventCounterCollectorEventSource.Log.IgnoreEventWrittenAsCounterNotInConfiguredList(eventSourceName, counterName);
                             return;
                         }
+                    }
+                    else if (key.Equals("DisplayName ", StringComparison.OrdinalIgnoreCase))
+                    {
+                        counterDisplayName = payload.Value.ToString();
                     }
                     else if (key.Equals("Mean", StringComparison.OrdinalIgnoreCase))
                     {
@@ -214,6 +216,10 @@
                 {
                     metricTelemetry.Sum = actualValue;
                 }
+
+                // DisplayName is the recommended name. We fallback to counterName is DisplayName not available.
+                var name = string.IsNullOrEmpty(counterDisplayName) ? counterName : counterDisplayName;
+                metricTelemetry.Name = eventSourceName + "|" + name;
 
                 // This will make the counter appear under PerformanceCounter as opposed to CustomMetrics in Application Insights Analytics(Kusto) tables.
                 metricTelemetry.Properties.Add("CustomPerfCounter", "true");

--- a/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
+++ b/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
@@ -170,7 +170,7 @@
                             return;
                         }
                     }
-                    else if (key.Equals("DisplayName ", StringComparison.OrdinalIgnoreCase))
+                    else if (key.Equals("DisplayName", StringComparison.OrdinalIgnoreCase))
                     {
                         counterDisplayName = payload.Value.ToString();
                     }


### PR DESCRIPTION
Partial Fix Issue #1226 .
We are not yet allowing user to supply 'ReportAs' for counters. We are evaluating the potential billing impact if non standard names are used.

follow up to https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1224

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.