### PR TITLE
LiveMetrics background thread safeguards added to never throw unhandled exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.11.0-beta2
  - [Add NetStandard2.0 Target for WindowsServerPackage](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1212)
  - [Add NetStandard2.0 Target for DependencyCollector](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1212)
+ - [QuickPulse/LiveMetrics background thread safeguards added to never throw unhandled exception.](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1088)
 
 ## Version 2.11.0-beta1
  - [Add support for Event Counter collection.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1222)

--- a/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/Helpers/QuickPulseThreadModuleScheduler.cs
+++ b/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/Helpers/QuickPulseThreadModuleScheduler.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse.Helpers
 {
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using System;
     using System.Threading;
 
@@ -47,7 +48,23 @@
 
             private void Worker(object state)
             {
-                (state as Action<CancellationToken>)?.Invoke(this.cancellationTokenSource.Token);
+                try
+                {
+                    (state as Action<CancellationToken>)?.Invoke(this.cancellationTokenSource.Token);
+                }
+                catch(Exception ex)
+                {
+                    // This is a Thread, and we don't want any exception thrown ever from this part as this would cause application crash.
+                    try
+                    {
+                        QuickPulseEventSource.Log.UnknownErrorEvent(ex.ToInvariantString());
+                    }
+                    catch (Exception)
+                    {
+                        // Intentionally empty. If EventSource writing itself is failing as well, there is nothing more to be done here.
+                        // The best that can be done is atleast prevent application crash due to unhandledexception from Thread.
+                    }
+                }
             }
         }
     }

--- a/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/Helpers/QuickPulseThreadModuleScheduler.cs
+++ b/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/Helpers/QuickPulseThreadModuleScheduler.cs
@@ -1,8 +1,8 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse.Helpers
 {
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using System;
     using System.Threading;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     internal class QuickPulseThreadModuleScheduler : IQuickPulseModuleScheduler
     {
@@ -52,7 +52,7 @@
                 {
                     (state as Action<CancellationToken>)?.Invoke(this.cancellationTokenSource.Token);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     // This is a Thread, and we don't want any exception thrown ever from this part as this would cause application crash.
                     try


### PR DESCRIPTION
Throwing unhandled exception crashes the app,.
Fix Issue #1088  
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.