### PR TITLE
Parse correlation context in absence of reuqest-id or traceparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - [QuickPulse/LiveMetrics background thread safeguards added to never throw unhandled exception.](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1088)
  - [Make QuickPulse server id configurable to distinguish multiple role instances running on the same host](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1253)
  - [Switch W3C Trace-Context on by default and leverage implementation from .NET in requests and depedencies collectors](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1252)
+ - [Support correlation-context in absence of Request-Id or traceparent](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1215)
 
 ## Version 2.11.0-beta1
  - [Add support for Event Counter collection.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1222)

--- a/Src/Common/HeadersUtilities.cs
+++ b/Src/Common/HeadersUtilities.cs
@@ -41,10 +41,11 @@
 
         public static IDictionary<string, string> GetHeaderDictionary(IEnumerable<string> headerValues)
         {
-            IDictionary<string, string> result = new Dictionary<string, string>();
+            IDictionary<string, string> result = null;
 
             if (headerValues != null)
             {
+                result = new Dictionary<string, string>();
                 foreach (string keyNameValue in headerValues)
                 {
                     string[] keyNameValueParts = keyNameValue.Trim().Split('=');
@@ -61,9 +62,9 @@
                 }
             }
 
-            if (!result.Any())
+            if (result == null || !result.Any())
             {
-                result = null;
+                return null;
             }
 
             return result;

--- a/Src/Common/WebHeaderCollectionExtensions.cs
+++ b/Src/Common/WebHeaderCollectionExtensions.cs
@@ -128,8 +128,8 @@
 
         public static void ReadActivityBaggage(this NameValueCollection headers, Activity activity)
         {
-            Debug.Assert(headers != null);
-            Debug.Assert(activity != null);
+            Debug.Assert(headers != null, "Headers must not be null");
+            Debug.Assert(activity != null, "Activity must not be null");
 
             int itemsCount = 0;
             var correlationContexts = headers.GetValues(RequestResponseHeaders.CorrelationContextHeader);
@@ -180,7 +180,8 @@
                     }
 
                     currentLength += nextComma + 1;
-                } while (itemsCount < CorrelationContextMaxPairs && currentLength < initialLength);
+                }
+                while (itemsCount < CorrelationContextMaxPairs && currentLength < initialLength);
             }
         }
 

--- a/Src/Common/WebHeaderCollectionExtensions.cs
+++ b/Src/Common/WebHeaderCollectionExtensions.cs
@@ -138,12 +138,13 @@
                 return;
             }
 
+            int overallLength = 0;
             foreach (var cc in correlationContexts)
             {
                 var headerValue = cc.AsSpan();
                 int currentLength = 0;
                 int initialLength = headerValue.Length;
-                do
+                while (itemsCount < CorrelationContextMaxPairs && currentLength < initialLength)
                 {
                     var nextSegment = headerValue.Slice(currentLength);
                     var nextComma = nextSegment.IndexOf(',');
@@ -155,11 +156,12 @@
 
                     if (nextComma == 0)
                     {
-                        currentLength += nextComma + 1;
+                        currentLength += 1;
+                        overallLength += 1;
                         continue;
                     }
 
-                    if (currentLength + nextComma >= CorrelationContextHeaderMaxLength)
+                    if (overallLength + nextComma >= CorrelationContextHeaderMaxLength)
                     {
                         return;
                     }
@@ -180,8 +182,8 @@
                     }
 
                     currentLength += nextComma + 1;
+                    overallLength += nextComma + 1;
                 }
-                while (itemsCount < CorrelationContextMaxPairs && currentLength < initialLength);
             }
         }
 

--- a/Src/DependencyCollector/Shared.Tests/HeaderCollectionManipulationTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/HeaderCollectionManipulationTests.cs
@@ -177,29 +177,40 @@
             Assert.AreEqual("k2=v2", values.Last());
         }
 
-        [Xunit.Theory]
-        [Xunit.InlineData(12)] // k1=v1,k2=v2,".Length
-        [Xunit.InlineData(11)] // k1=v1,k2=v2".Length
-        [Xunit.InlineData(15)] // k1=v1,k2=v2,k3=".Length
-        [Xunit.InlineData(13)] // k1=v1,k2=v2,k".Length
-        public void GetHeaderValueMaxLenTruncatesEnd(int maxLength)
+        [TestMethod]
+        public void GetHeaderValueMaxLenTruncatesEnd_Test1()
         {
-            WebHeaderCollection headers = new WebHeaderCollection { [W3C.W3CConstants.TraceStateHeader] = "k1=v1,k2=v2,k3=v3,k4=v4" };
-            var values = headers.GetHeaderValue(W3C.W3CConstants.TraceStateHeader, maxLength)?.ToList();
-            Assert.IsNotNull(values);
-            Assert.AreEqual(2, values.Count);
-            Assert.AreEqual("k1=v1", values.First());
-            Assert.AreEqual("k2=v2", values.Last());
+            this.GetHeaderValueMaxLenTruncatesEnd("k1=v1,k2=v2,".Length);
         }
 
-        [Xunit.Theory]
-        [Xunit.InlineData(0)]
-        [Xunit.InlineData(3)]
-        public void GetHeaderValueMaxLenTruncatesEndInvalid(int maxLength)
+        [TestMethod]
+        public void GetHeaderValueMaxLenTruncatesEnd_Test2()
         {
-            WebHeaderCollection headers = new WebHeaderCollection { [W3C.W3CConstants.TraceStateHeader] = "k1=v1,k2=v2" };
-            var values = headers.GetHeaderValue(W3C.W3CConstants.TraceStateHeader, maxLength)?.ToList();
-            Assert.IsNull(values);
+            this.GetHeaderValueMaxLenTruncatesEnd("k1=v1,k2=v2".Length);
+        }
+
+        [TestMethod]
+        public void GetHeaderValueMaxLenTruncatesEnd_Test3()
+        {
+            this.GetHeaderValueMaxLenTruncatesEnd("k1=v1,k2=v2,k3=".Length);
+        }
+
+        [TestMethod]
+        public void GetHeaderValueMaxLenTruncatesEnd_Test4()
+        {
+            this.GetHeaderValueMaxLenTruncatesEnd("k1=v1,k2=v2,k".Length);
+        }
+
+        [TestMethod]
+        public void GetHeaderValueMaxLenTruncatesEndInvalid_Test1()
+        {
+            this.GetHeaderValueMaxLenTruncatesEndInvalid(0);
+        }
+
+        [TestMethod]
+        public void GetHeaderValueMaxLenTruncatesEndInvalid_Test2()
+        {
+            this.GetHeaderValueMaxLenTruncatesEndInvalid(3);
         }
 
         [TestMethod]
@@ -213,41 +224,82 @@
             Assert.AreEqual("k2=v2", values.Last());
         }
 
-        [Xunit.Theory]
-        [Xunit.InlineData("k1=v1,k2=v2")]
-        [Xunit.InlineData(" k1= v1 , k2 =v2 ,")]
-        [Xunit.InlineData(", , k1=v1,,k2=v2,,")]
-        [Xunit.InlineData(",123, k1=v1,,k2=v2,, 456")]
-        [Xunit.InlineData("123=,k1=v1,k2=v2,=456")]
-        [Xunit.InlineData("123= ,k1=v1,k2=v2, =456")]
-        public void ReadCorrelationContextBasicParsing(string correlationContext)
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsing_Test1()
         {
-            WebHeaderCollection headers = new WebHeaderCollection { [RequestResponseHeaders.CorrelationContextHeader] = correlationContext };
-
-            var activity = new Activity("foo");
-            headers.ReadActivityBaggage(activity);
-
-            var baggage = activity.Baggage.ToArray();
-            Assert.AreEqual(2, baggage.Length);
-            Assert.IsNotNull(baggage.SingleOrDefault(i => i.Key == "k1" && i.Value == "v1"));
-            Assert.IsNotNull(baggage.SingleOrDefault(i => i.Key == "k2" && i.Value == "v2"));
+            this.ReadCorrelationContextBasicParsing("k1=v1,k2=v2");
         }
 
-        [Xunit.Theory]
-        [Xunit.InlineData("")]
-        [Xunit.InlineData(null)]
-        [Xunit.InlineData(", , ,,")]
-        [Xunit.InlineData(",123,    , 456")]
-        [Xunit.InlineData("=,=,")]
-        public void ReadCorrelationContextBasicParsingGarbage(string correlationContext)
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsing_Test2()
         {
-            WebHeaderCollection headers = new WebHeaderCollection { [RequestResponseHeaders.CorrelationContextHeader] = correlationContext };
+            this.ReadCorrelationContextBasicParsing(" k1= v1 , k2 =v2 ,");
+        }
 
-            var activity = new Activity("foo");
-            headers.ReadActivityBaggage(activity);
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsing_Test3()
+        {
+            this.ReadCorrelationContextBasicParsing(", , k1=v1,,k2=v2,,");
+        }
 
-            var baggage = activity.Baggage.ToArray();
-            Assert.AreEqual(0, baggage.Length);
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsing_Test4()
+        {
+            this.ReadCorrelationContextBasicParsing(",123, k1=v1,,k2=v2,, 456");
+        }
+
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsing_Test5()
+        {
+            this.ReadCorrelationContextBasicParsing("123=,k1=v1,k2=v2,=456");
+        }
+
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsing_Test6()
+        {
+            this.ReadCorrelationContextBasicParsing("123= ,k1=v1,k2=v2, =456");
+        }
+
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsing_Test7()
+        {
+            this.ReadCorrelationContextBasicParsing("k1=v1,k2=v2,k3==v3,k4=1=2");
+        }
+
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsingGarbage_Test1()
+        {
+            this.ReadCorrelationContextBasicParsingGarbage(string.Empty);
+        }
+
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsingGarbage_Test2()
+        {
+            this.ReadCorrelationContextBasicParsingGarbage(null);
+        }
+
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsingGarbage_Test3()
+        {
+            this.ReadCorrelationContextBasicParsingGarbage(", , ,,");
+        }
+
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsingGarbage_Test4()
+        {
+            this.ReadCorrelationContextBasicParsingGarbage(",123,    , 456");
+        }
+
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsingGarbage_Test5()
+        {
+            this.ReadCorrelationContextBasicParsingGarbage("=,=,");
+        }
+
+        [TestMethod]
+        public void ReadCorrelationContextBasicParsingGarbage_Test6()
+        {
+            this.ReadCorrelationContextBasicParsingGarbage("==,");
         }
 
         [TestMethod]
@@ -333,8 +385,49 @@
         {
             NameValueCollection headers = new NameValueCollection
             {
-                [RequestResponseHeaders.CorrelationContextHeader] = new string('x', 8193)
+                [RequestResponseHeaders.CorrelationContextHeader] = new string('x', 8190) + '=' + "123"
             };
+
+            var activity = new Activity("foo");
+            headers.ReadActivityBaggage(activity);
+
+            var baggage = activity.Baggage.ToArray();
+            Assert.AreEqual(0, baggage.Length);
+        }
+
+        public void GetHeaderValueMaxLenTruncatesEnd(int maxLength)
+        {
+            WebHeaderCollection headers = new WebHeaderCollection { [W3C.W3CConstants.TraceStateHeader] = "k1=v1,k2=v2,k3=v3,k4=v4" };
+            var values = headers.GetHeaderValue(W3C.W3CConstants.TraceStateHeader, maxLength)?.ToList();
+            Assert.IsNotNull(values);
+            Assert.AreEqual(2, values.Count);
+            Assert.AreEqual("k1=v1", values.First());
+            Assert.AreEqual("k2=v2", values.Last());
+        }
+
+        private void GetHeaderValueMaxLenTruncatesEndInvalid(int maxLength)
+        {
+            WebHeaderCollection headers = new WebHeaderCollection { ["header"] = "k1=v1,k2=v2" };
+            var values = headers.GetHeaderValue("header", maxLength)?.ToList();
+            Assert.IsNull(values);
+        }
+
+        private void ReadCorrelationContextBasicParsing(string correlationContext)
+        {
+            WebHeaderCollection headers = new WebHeaderCollection { [RequestResponseHeaders.CorrelationContextHeader] = correlationContext };
+
+            var activity = new Activity("foo");
+            headers.ReadActivityBaggage(activity);
+
+            var baggage = activity.Baggage.ToArray();
+            Assert.AreEqual(2, baggage.Length);
+            Assert.IsNotNull(baggage.SingleOrDefault(i => i.Key == "k1" && i.Value == "v1"));
+            Assert.IsNotNull(baggage.SingleOrDefault(i => i.Key == "k2" && i.Value == "v2"));
+        }
+
+        private void ReadCorrelationContextBasicParsingGarbage(string correlationContext)
+        {
+            WebHeaderCollection headers = new WebHeaderCollection { [RequestResponseHeaders.CorrelationContextHeader] = correlationContext };
 
             var activity = new Activity("foo");
             headers.ReadActivityBaggage(activity);

--- a/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
@@ -44,7 +44,7 @@
                     if (ActivityHelpers.ParentOperationIdHeaderName != null &&
                         ActivityHelpers.RootOperationIdHeaderName != null)
                     {
-                        legacyRootId = StringUtilities.EnforceMaxLength(                            platformContext.Request.UnvalidatedGetHeader(ActivityHelpers.RootOperationIdHeaderName),
+                        legacyRootId = StringUtilities.EnforceMaxLength(platformContext.Request.UnvalidatedGetHeader(ActivityHelpers.RootOperationIdHeaderName),
                             InjectionGuardConstants.RequestHeaderMaxLength);
                         legacyParentId = StringUtilities.EnforceMaxLength(
                             platformContext.Request.UnvalidatedGetHeader(ActivityHelpers.ParentOperationIdHeaderName),
@@ -54,6 +54,7 @@
 
                     headers.ReadActivityBaggage(currentActivity);
                 }
+
                 currentActivity.Start();
             }
 

--- a/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
@@ -26,6 +26,7 @@
             string legacyParentId = null;
             string legacyRootId = null;
 
+            var headers = platformContext.Request.Unvalidated.Headers;
             if (currentActivity == null)
             {
                 // if there was no BeginRequest, ASP.NET HttpModule did not have a chance to set current activity yet
@@ -38,15 +39,21 @@
                 // Here we simply maintaining backward compatibility with this behavior...
 
                 currentActivity = new Activity(ActivityHelpers.RequestActivityItemName);
-                if (!currentActivity.Extract(platformContext.Request.Headers) &&
-                    ActivityHelpers.ParentOperationIdHeaderName != null &&
-                    ActivityHelpers.RootOperationIdHeaderName != null)
+                if (!currentActivity.Extract(headers))
                 {
-                    legacyRootId = StringUtilities.EnforceMaxLength(platformContext.Request.UnvalidatedGetHeader(ActivityHelpers.RootOperationIdHeaderName), InjectionGuardConstants.RequestHeaderMaxLength);
-                    legacyParentId = StringUtilities.EnforceMaxLength(platformContext.Request.UnvalidatedGetHeader(ActivityHelpers.ParentOperationIdHeaderName), InjectionGuardConstants.RequestHeaderMaxLength);
-                    currentActivity.SetParentId(legacyRootId);
-                }
+                    if (ActivityHelpers.ParentOperationIdHeaderName != null &&
+                        ActivityHelpers.RootOperationIdHeaderName != null)
+                    {
+                        legacyRootId = StringUtilities.EnforceMaxLength(                            platformContext.Request.UnvalidatedGetHeader(ActivityHelpers.RootOperationIdHeaderName),
+                            InjectionGuardConstants.RequestHeaderMaxLength);
+                        legacyParentId = StringUtilities.EnforceMaxLength(
+                            platformContext.Request.UnvalidatedGetHeader(ActivityHelpers.ParentOperationIdHeaderName),
+                            InjectionGuardConstants.RequestHeaderMaxLength);
+                        currentActivity.SetParentId(legacyRootId);
+                    }
 
+                    headers.ReadActivityBaggage(currentActivity);
+                }
                 currentActivity.Start();
             }
 

--- a/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -488,6 +488,18 @@
                 this.applicationNameProvider.Name);
         }
 
+        [Event(50,
+            Keywords = Keywords.Diagnostics,
+            Message = "Unknown error, message {0}",
+            Level = EventLevel.Error)]
+        public void UnknownError(string message, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                50,
+                message,
+                this.applicationNameProvider.Name);
+        }
+
         /// <summary>
         /// Keywords for the PlatformEventSource. Those keywords should match keywords in Core.
         /// </summary>


### PR DESCRIPTION
Fix Issue #1215 .

