### PR TITLE
quick pulse endpoint config improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.12.0-beta1
+ - [Enhancement to how QuickPulseTelemetryModule shares its ServiceEndpoint with QuickPulseTelemetryProcessor.](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1266)
+
 ## Version 2.11.0-beta2
  - Updated Base SDK to 2.11.0-beta2
  - [Add NetStandard2.0 Target for WindowsServerPackage](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1212)

--- a/Src/PerformanceCollector/NetCore.Tests/Perf.NetCore.Tests.csproj
+++ b/Src/PerformanceCollector/NetCore.Tests/Perf.NetCore.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NetCore.props))\NetCore.props" />  
 
@@ -39,4 +39,6 @@
   </ItemGroup>
 
   <Import Project="..\Perf.Shared.Tests\Perf.Shared.Tests.projitems" Label="Shared" />
+
+  <Import Project="..\..\TestFramework\Shared\TestFramework.Shared.projitems" Label="Shared" />
 </Project>

--- a/Src/PerformanceCollector/NetCore20.Tests/Perf-NetCore20.Tests/Perf-NetCore20.Tests.csproj
+++ b/Src/PerformanceCollector/NetCore20.Tests/Perf-NetCore20.Tests/Perf-NetCore20.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NetCore.props))\NetCore.props" />
 
@@ -37,4 +37,6 @@
   </ItemGroup>
 
   <Import Project="..\..\Perf.Shared.Tests\Perf.Shared.Tests.projitems" Label="Shared" />
+
+  <Import Project="..\..\..\TestFramework\Shared\TestFramework.Shared.projitems" Label="Shared" />
 </Project>

--- a/Src/PerformanceCollector/Perf.Shared/IQuickPulseTelemetryProcessor.cs
+++ b/Src/PerformanceCollector/Perf.Shared/IQuickPulseTelemetryProcessor.cs
@@ -9,5 +9,7 @@
         void StartCollection(IQuickPulseDataAccumulatorManager accumulatorManager, Uri serviceEndpoint, TelemetryConfiguration configuration, bool disableFullTelemetryItems = false);
 
         void StopCollection();
+
+        Uri ServiceEndpoint { get; set; }
     }
 }

--- a/Src/PerformanceCollector/Perf.Shared/QuickPulseTelemetryModule.cs
+++ b/Src/PerformanceCollector/Perf.Shared/QuickPulseTelemetryModule.cs
@@ -375,6 +375,12 @@
                 isWebApp,
                 processorCount ?? 0);
 
+            // TelemetryConfigurationFactory will initialize Modules after Processors. Need to update the processor with the correct service endpoint.
+            foreach (var processor in this.TelemetryProcessors)
+            {
+                processor.ServiceEndpoint = serviceEndpointUri;
+            }
+
             QuickPulseEventSource.Log.TroubleshootingMessageEvent(
                 string.Format(
                     CultureInfo.InvariantCulture,

--- a/Src/PerformanceCollector/Perf.Shared/QuickPulseTelemetryProcessor.cs
+++ b/Src/PerformanceCollector/Perf.Shared/QuickPulseTelemetryProcessor.cs
@@ -48,9 +48,16 @@
         private IQuickPulseDataAccumulatorManager dataAccumulatorManager = null;
 
         /// <summary>
-        /// This is set from the QuickPulseTelemetryModule and is compared against telemetry to remove our requests from customer telemetry.
+        /// Gets or sets an endpoint that is compared against telemetry to remove our requests from customer telemetry.
         /// </summary>
-        Uri IQuickPulseTelemetryProcessor.ServiceEndpoint { get { return this.serviceEndpoint; } set { this.serviceEndpoint = value; } }
+        /// <remarks>
+        /// This is set from the QuickPulseTelemetryModule. 
+        /// </remarks>
+        Uri IQuickPulseTelemetryProcessor.ServiceEndpoint
+        {
+            get { return this.serviceEndpoint; }
+            set { this.serviceEndpoint = value; }
+        }
 
         private Uri serviceEndpoint = QuickPulseDefaults.ServiceEndpoint;
 

--- a/Src/PerformanceCollector/Perf.Shared/QuickPulseTelemetryProcessor.cs
+++ b/Src/PerformanceCollector/Perf.Shared/QuickPulseTelemetryProcessor.cs
@@ -2,11 +2,9 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Threading;
-
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.Common.Internal;
@@ -49,6 +47,11 @@
 
         private IQuickPulseDataAccumulatorManager dataAccumulatorManager = null;
 
+        /// <summary>
+        /// This is set from the QuickPulseTelemetryModule and is compared against telemetry to remove our requests from customer telemetry.
+        /// </summary>
+        Uri IQuickPulseTelemetryProcessor.ServiceEndpoint { get { return this.serviceEndpoint; } set { this.serviceEndpoint = value; } }
+
         private Uri serviceEndpoint = QuickPulseDefaults.ServiceEndpoint;
 
         private TelemetryConfiguration config = null;
@@ -81,14 +84,9 @@
             float? maxGlobalTelemetryQuota = null,
             float? initialGlobalTelemetryQuota = null)
         {
-            if (next == null)
-            {
-                throw new ArgumentNullException(nameof(next));
-            }
+            this.Next = next ?? throw new ArgumentNullException(nameof(next));
 
-            this.Register();
-
-            this.Next = next;
+            this.RegisterSelfWithQuickPulseTelemetryModule();
 
             this.globalQuotaTracker = new QuickPulseQuotaTracker(
                 timeProvider,
@@ -118,7 +116,7 @@
 
             this.EvaluateDisabledTrackingProperties = configuration.EvaluateExperimentalFeature(ExperimentalConstants.DeferRequestTrackingProperties);
 
-            this.Register();
+            this.RegisterSelfWithQuickPulseTelemetryModule();
         }
 
         void IQuickPulseTelemetryProcessor.StartCollection(
@@ -707,10 +705,15 @@
             }
         }
 
-        private void Register()
+        private void RegisterSelfWithQuickPulseTelemetryModule()
         {
             var module = TelemetryModules.Instance.Modules.OfType<QuickPulseTelemetryModule>().SingleOrDefault();
-            module?.RegisterTelemetryProcessor(this);
+
+            if (module != null)
+            {
+                module.RegisterTelemetryProcessor(this);
+                this.serviceEndpoint = module.ServiceClient?.ServiceUri ?? QuickPulseDefaults.ServiceEndpoint;
+            }
         }
     }
 }

--- a/Src/TestFramework/Shared/TelemetryConfigurationFactoryHelper.cs
+++ b/Src/TestFramework/Shared/TelemetryConfigurationFactoryHelper.cs
@@ -1,0 +1,96 @@
+﻿namespace Microsoft.ApplicationInsights.TestFramework
+{
+    using System;
+    using System.Text;
+
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
+    public static class TelemetryConfigurationFactoryHelper
+    {
+        /// <summary>
+        /// TelemetryConfigurationFactory is an internal class in the BaseSDK.
+        /// This method using reflection to access the Initialize method.
+        /// This enables E2E testing using a sample config file.
+        /// </summary>
+        public static void Initialize(TelemetryConfiguration configuration, TelemetryModules modules, string serializedConfiguration)
+        {
+            // get the assembly qualified name using known public type:
+            var typeName = typeof(Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration).AssemblyQualifiedName
+                .Replace(
+                    "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration",
+                    "Microsoft.ApplicationInsights.Extensibility.Implementation.TelemetryConfigurationFactory");
+
+            var telemetryConfigurationFactoryT = Type.GetType(typeName);
+            if (telemetryConfigurationFactoryT == null)
+            {
+                throw new ArgumentException($"Microsoft.ApplicationInsights.Extensibility.Implementation.TelemetryConfigurationFactory type not found");
+            }
+
+            var telemetryConfigurationFactoryInstanceProperty = telemetryConfigurationFactoryT.GetProperty("Instance");
+            if (telemetryConfigurationFactoryInstanceProperty == null)
+            {
+                throw new ArgumentException($"Property 'Instance' not found in type {telemetryConfigurationFactoryT.FullName}");
+            }
+
+            var telemetryConfigurationFactoryInstance = telemetryConfigurationFactoryInstanceProperty.GetValue(null);
+            if (telemetryConfigurationFactoryInstance == null)
+            {
+                throw new ArgumentException($"Microsoft.ApplicationInsights.Extensibility.Implementation.TelemetryConfigurationFactory.Instance should not be null");
+            }
+
+            var initTypes = new[]
+                {
+                    typeof(Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration),
+                    typeof(Microsoft.ApplicationInsights.Extensibility.Implementation.TelemetryModules),
+                    typeof(string)
+                };
+            var initMethod = telemetryConfigurationFactoryInstance.GetType().GetMethod("Initialize", initTypes);
+            if (initMethod == null)
+            {
+                throw new ArgumentException($"Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.Initialize method not found");
+            }
+
+            // initialize the AppInsights using config string:
+            _ = initMethod.Invoke(telemetryConfigurationFactoryInstance, new object[] { configuration, modules, serializedConfiguration });
+        }
+
+        /// <summary>
+        /// Build a configuration xml string representing the contents of a config file.
+        /// All parameters are optional, allowing you to configure only what is needed for a specific test.
+        /// </summary>
+        public static string BuildConfiguration(string ikey = null, string connectionString = null, string module = null, string processor = null)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(@"<?xml version=""1.0"" encoding=""utf-8"" ?>");
+            sb.AppendLine(@"<ApplicationInsights xmlns=""http://schemas.microsoft.com/ApplicationInsights/2013/Settings"">");
+
+            if (ikey != null)
+            {
+                sb.AppendLine($"<InstrumentationKey>{ikey}</InstrumentationKey>");
+            }
+
+            if (connectionString != null)
+            {
+                sb.AppendLine($"<ConnectionString>{connectionString}</ConnectionString>");
+            }
+
+            if (module != null)
+            {
+                sb.AppendLine("<TelemetryModules>");
+                sb.AppendLine(module);
+                sb.AppendLine("</TelemetryModules>");
+            }
+
+            if (processor != null)
+            {
+                sb.AppendLine("<TelemetryProcessors>");
+                sb.AppendLine(processor);
+                sb.AppendLine("</TelemetryProcessors>");
+            }
+
+            sb.AppendLine("</ApplicationInsights>");
+            return sb.ToString();
+        }
+    }
+}

--- a/Src/TestFramework/Shared/TelemetryConfigurationFactoryHelper.cs
+++ b/Src/TestFramework/Shared/TelemetryConfigurationFactoryHelper.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.TestFramework
 {
     using System;
+    using System.Reflection;
     using System.Text;
 
     using Microsoft.ApplicationInsights.Extensibility;

--- a/Src/TestFramework/Shared/TestFramework.Shared.projitems
+++ b/Src/TestFramework/Shared/TestFramework.Shared.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)StubStream.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StubTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TaskExceptionObserver.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TelemetryConfigurationFactoryHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEventListener.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp1.0' ">


### PR DESCRIPTION
QuickPulse Endpoint is set on the `Module`. 
The same value is internally set on the `Processor`, but only after the module starts collecting events.
This makes it difficult to unit test because it's waiting for data to flow through these classes.

I made a change so that the 'Processor' endpoint is set during initialization methods.
But that was still sensitive to which order the module and endpoint are initialized.


**Summary**
- `QuickPulseTelemetryModule.Initialize()` will now push the endpoint to the Processor.
- `QuickPulseTelemetryProcessor.ctor()` will now pull the endpoint from the Module.
- added helper class to build a configuration from xml.



**Note**
These are edge cases discovered while working on connection strings. Connection String support will come in the next PR.