### PR TITLE
Fix Sql dependency tracking in .NET Core 3.0 which uses Microsoft.Data.SqlClient instead of System.Data.SqlClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.11.0
+- [Fix Sql dependency tracking in .NET Core 3.0 which uses Microsoft.Data.SqlClient instead of System.Data.SqlClient](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1263)
+
 ## Version 2.11.0-beta2
  - Updated Base SDK to 2.11.0-beta2
  - [Add NetStandard2.0 Target for WindowsServerPackage](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1212)

--- a/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
+++ b/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
@@ -24,11 +24,16 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
@@ -14,12 +14,11 @@ namespace Microsoft.ApplicationInsights.Tests
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Web.TestFramework;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Xunit;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-    [TestClass]
-    public class SqlClientDiagnosticSourceListenerTests
+    public class SqlClientDiagnosticSourceListenerTests : IDisposable
     {
         private const string TestConnectionString = "Data Source=(localdb)\\MSSQLLocalDB;Database=master";
         
@@ -29,8 +28,7 @@ namespace Microsoft.ApplicationInsights.Tests
         private FakeSqlClientDiagnosticSource fakeSqlClientDiagnosticSource;
         private SqlClientDiagnosticSourceListener sqlClientDiagnosticSourceListener;
 
-        [TestInitialize]
-        public void TestInit()
+        public SqlClientDiagnosticSourceListenerTests()
         {
             this.sendItems = new List<ITelemetry>();
             this.stubTelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
@@ -45,8 +43,7 @@ namespace Microsoft.ApplicationInsights.Tests
             this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(this.configuration);
         }
 
-        [TestCleanup]
-        public void Cleanup()
+        public void Dispose()
         {
             this.sqlClientDiagnosticSourceListener.Dispose();
             this.fakeSqlClientDiagnosticSource.Dispose();
@@ -59,8 +56,10 @@ namespace Microsoft.ApplicationInsights.Tests
             }
         }
 
-        [TestMethod]
-        public void InitializesTelemetryFromParentActivity()
+        [Theory]
+        [InlineData(SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand, SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand)]
+        [InlineData(SqlClientDiagnosticSourceListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticSourceListener.SqlMicrosoftAfterExecuteCommand)]
+        public void InitializesTelemetryFromParentActivity(string beforeEventName, string afterEventName)
         {
             var activity = new Activity("Current").AddBaggage("Stuff", "123");
             activity.Start();
@@ -78,7 +77,7 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,
+                beforeEventName,
                 beforeExecuteEventData);
 
             var afterExecuteEventData = new
@@ -89,18 +88,20 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
+                afterEventName,
                 afterExecuteEventData);
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(activity.RootId, dependencyTelemetry.Context.Operation.Id);
-            Assert.AreEqual(activity.Id, dependencyTelemetry.Context.Operation.ParentId);
-            Assert.AreEqual("123", dependencyTelemetry.Properties["Stuff"]);
+            Assert.Equal(activity.RootId, dependencyTelemetry.Context.Operation.Id);
+            Assert.Equal(activity.Id, dependencyTelemetry.Context.Operation.ParentId);
+            Assert.Equal("123", dependencyTelemetry.Properties["Stuff"]);
         }
 
-        [TestMethod]
-        public void TracksCommandExecuted()
+        [Theory]
+        [InlineData(SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand, SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand)]
+        [InlineData(SqlClientDiagnosticSourceListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticSourceListener.SqlMicrosoftAfterExecuteCommand)]
+        public void TracksCommandExecuted(string beforeCommand, string afterCommand)
         {
             var operationId = Guid.NewGuid();
             var sqlConnection = new SqlConnection(TestConnectionString);
@@ -115,7 +116,7 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,
+                beforeCommand,
                 beforeExecuteEventData);
             var start = DateTimeOffset.UtcNow;
 
@@ -127,24 +128,26 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
+                afterCommand,
                 afterExecuteEventData);
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(beforeExecuteEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
-            Assert.AreEqual(sqlCommand.CommandText, dependencyTelemetry.Data);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Name);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
-            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
-            Assert.IsTrue((bool)dependencyTelemetry.Success);
-            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
-            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
-            Assert.IsTrue(Math.Abs((start - dependencyTelemetry.Timestamp).TotalMilliseconds) <= 16);
+            Assert.Equal(beforeExecuteEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.Equal(sqlCommand.CommandText, dependencyTelemetry.Data);
+            Assert.Equal("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Name);
+            Assert.Equal("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.Equal(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.True((bool)dependencyTelemetry.Success);
+            Assert.True(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.True(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
+            Assert.True(Math.Abs((start - dependencyTelemetry.Timestamp).TotalMilliseconds) <= 16);
         }
 
-        [TestMethod]
-        public void TracksCommandExecutedWhenNoTimestamp()
+        [Theory]
+        [InlineData(SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand, SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand)]
+        [InlineData(SqlClientDiagnosticSourceListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticSourceListener.SqlMicrosoftAfterExecuteCommand)]
+        public void TracksCommandExecutedWhenNoTimestamp(string beforeCommand, string afterCommand)
         {
             var operationId = Guid.NewGuid();
             var sqlConnection = new SqlConnection(TestConnectionString);
@@ -159,7 +162,7 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,
+                beforeCommand,
                 beforeExecuteEventData);
 
             var afterExecuteEventData = new
@@ -170,23 +173,25 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
+                afterCommand,
                 afterExecuteEventData);
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(beforeExecuteEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
-            Assert.AreEqual(sqlCommand.CommandText, dependencyTelemetry.Data);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Name);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
-            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
-            Assert.IsTrue((bool)dependencyTelemetry.Success);
-            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
-            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
+            Assert.Equal(beforeExecuteEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.Equal(sqlCommand.CommandText, dependencyTelemetry.Data);
+            Assert.Equal("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Name);
+            Assert.Equal("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.Equal(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.True((bool)dependencyTelemetry.Success);
+            Assert.True(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.True(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
         }
 
-        [TestMethod]
-        public void TracksCommandError()
+        [Theory]
+        [InlineData(SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand, SqlClientDiagnosticSourceListener.SqlErrorExecuteCommand)]
+        [InlineData(SqlClientDiagnosticSourceListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticSourceListener.SqlMicrosoftErrorExecuteCommand)]
+        public void TracksCommandError(string beforeCommand, string errorCommand)
         {
             var operationId = Guid.NewGuid();
             var sqlConnection = new SqlConnection(TestConnectionString);
@@ -201,7 +206,7 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,
+                beforeCommand,
                 beforeExecuteEventData);
 
             var commandErrorEventData = new
@@ -213,16 +218,16 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.fakeSqlClientDiagnosticSource.Write(
-                SqlClientDiagnosticSourceListener.SqlErrorExecuteCommand,
+                errorCommand,
                 commandErrorEventData);
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(commandErrorEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
-            Assert.IsFalse(dependencyTelemetry.Success.Value);
+            Assert.Equal(commandErrorEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
+            Assert.False(dependencyTelemetry.Success.Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void TracksCommandErrorWhenSqlException()
         {
             var operationId = Guid.NewGuid();
@@ -293,12 +298,12 @@ namespace Microsoft.ApplicationInsights.Tests
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(commandErrorEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
-            Assert.IsFalse(dependencyTelemetry.Success.Value);
-            Assert.AreEqual("42", dependencyTelemetry.ResultCode);
+            Assert.Equal(commandErrorEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
+            Assert.False(dependencyTelemetry.Success.Value);
+            Assert.Equal("42", dependencyTelemetry.ResultCode);
         }
 
-        [TestMethod]
+        [Fact]
         public void TracksConnectionOpenedError()
         {
             var operationId = Guid.NewGuid();
@@ -332,20 +337,20 @@ namespace Microsoft.ApplicationInsights.Tests
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(beforeOpenEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
-            Assert.AreEqual(beforeOpenEventData.Operation, dependencyTelemetry.Data);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master | " + beforeOpenEventData.Operation, dependencyTelemetry.Name);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
-            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
-            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
-            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
-            Assert.IsTrue(Math.Abs((start - dependencyTelemetry.Timestamp).TotalMilliseconds) <= 16);
+            Assert.Equal(beforeOpenEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.Equal(beforeOpenEventData.Operation, dependencyTelemetry.Data);
+            Assert.Equal("(localdb)\\MSSQLLocalDB | master | " + beforeOpenEventData.Operation, dependencyTelemetry.Name);
+            Assert.Equal("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.Equal(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.True(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.True(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
+            Assert.True(Math.Abs((start - dependencyTelemetry.Timestamp).TotalMilliseconds) <= 16);
 
-            Assert.AreEqual(errorOpenEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
-            Assert.IsFalse(dependencyTelemetry.Success.Value);
+            Assert.Equal(errorOpenEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
+            Assert.False(dependencyTelemetry.Success.Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void DoesNotTrackConnectionOpened()
         {
             var operationId = Guid.NewGuid();
@@ -373,10 +378,10 @@ namespace Microsoft.ApplicationInsights.Tests
                 SqlClientDiagnosticSourceListener.SqlAfterOpenConnection,
                 afterOpenEventData);
 
-            Assert.AreEqual(0, this.sendItems.Count);
+            Assert.Equal(0, this.sendItems.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void DoesNotTrackConnectionCloseError()
         {
             var operationId = Guid.NewGuid();
@@ -406,10 +411,10 @@ namespace Microsoft.ApplicationInsights.Tests
                 SqlClientDiagnosticSourceListener.SqlErrorCloseConnection,
                 errorCloseEventData);
 
-            Assert.AreEqual(0, this.sendItems.Count);
+            Assert.Equal(0, this.sendItems.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void TracksTransactionCommitted()
         {
             var operationId = Guid.NewGuid();
@@ -443,20 +448,20 @@ namespace Microsoft.ApplicationInsights.Tests
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(beforeCommitEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
-            Assert.AreEqual(beforeCommitEventData.Operation, dependencyTelemetry.Data);
-            Assert.AreEqual(
+            Assert.Equal(beforeCommitEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.Equal(beforeCommitEventData.Operation, dependencyTelemetry.Data);
+            Assert.Equal(
                 "(localdb)\\MSSQLLocalDB | master | " + beforeCommitEventData.Operation + " | " + beforeCommitEventData.IsolationLevel, 
                 dependencyTelemetry.Name);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
-            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
-            Assert.IsTrue((bool)dependencyTelemetry.Success);
-            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
-            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
-            Assert.IsTrue(Math.Abs((start - dependencyTelemetry.Timestamp).TotalMilliseconds) <= 16);
+            Assert.Equal("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.Equal(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.True((bool)dependencyTelemetry.Success);
+            Assert.True(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.True(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
+            Assert.True(Math.Abs((start - dependencyTelemetry.Timestamp).TotalMilliseconds) <= 16);
         }
 
-        [TestMethod]
+        [Fact]
         public void TracksTransactionCommitError()
         {
             var operationId = Guid.NewGuid();
@@ -489,11 +494,11 @@ namespace Microsoft.ApplicationInsights.Tests
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(errorCommitEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
-            Assert.IsFalse(dependencyTelemetry.Success.Value);
+            Assert.Equal(errorCommitEventData.Exception.ToInvariantString(), dependencyTelemetry.Properties["Exception"]);
+            Assert.False(dependencyTelemetry.Success.Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void TracksTransactionRolledBack()
         {
             var operationId = Guid.NewGuid();
@@ -528,20 +533,20 @@ namespace Microsoft.ApplicationInsights.Tests
 
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
-            Assert.AreEqual(beforeRollbackEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
-            Assert.AreEqual(beforeRollbackEventData.Operation, dependencyTelemetry.Data);
-            Assert.AreEqual(
+            Assert.Equal(beforeRollbackEventData.OperationId.ToString("N"), dependencyTelemetry.Id);
+            Assert.Equal(beforeRollbackEventData.Operation, dependencyTelemetry.Data);
+            Assert.Equal(
                 "(localdb)\\MSSQLLocalDB | master | " + beforeRollbackEventData.Operation + " | " + beforeRollbackEventData.IsolationLevel,
                 dependencyTelemetry.Name);
-            Assert.AreEqual("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
-            Assert.AreEqual(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
-            Assert.IsTrue((bool)dependencyTelemetry.Success);
-            Assert.IsTrue(dependencyTelemetry.Duration > TimeSpan.Zero);
-            Assert.IsTrue(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
-            Assert.IsTrue(Math.Abs((start - dependencyTelemetry.Timestamp).TotalMilliseconds) <= 16);
+            Assert.Equal("(localdb)\\MSSQLLocalDB | master", dependencyTelemetry.Target);
+            Assert.Equal(RemoteDependencyConstants.SQL, dependencyTelemetry.Type);
+            Assert.True((bool)dependencyTelemetry.Success);
+            Assert.True(dependencyTelemetry.Duration > TimeSpan.Zero);
+            Assert.True(dependencyTelemetry.Duration < TimeSpan.FromMilliseconds(500));
+            Assert.True(Math.Abs((start - dependencyTelemetry.Timestamp).TotalMilliseconds) <= 16);
         }
 
-        [TestMethod]
+        [Fact]
         public void MultiHost_OneListenerIsActive()
         {
             var operationId = Guid.NewGuid();
@@ -573,11 +578,11 @@ namespace Microsoft.ApplicationInsights.Tests
                     SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
                     afterExecuteEventData);
 
-                Assert.AreEqual(1, this.sendItems.Count(t => t is DependencyTelemetry));
+                Assert.Equal(1, this.sendItems.Count(t => t is DependencyTelemetry));
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void MultiHost_OneListenerThenAnotherIsActive()
         {
             var operationId = Guid.NewGuid();
@@ -607,7 +612,7 @@ namespace Microsoft.ApplicationInsights.Tests
                 SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
                 afterExecuteEventData);
 
-            Assert.AreEqual(1, this.sendItems.Count(t => t is DependencyTelemetry));
+            Assert.Equal(1, this.sendItems.Count(t => t is DependencyTelemetry));
 
             this.sqlClientDiagnosticSourceListener.Dispose();
 
@@ -621,11 +626,11 @@ namespace Microsoft.ApplicationInsights.Tests
                     SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
                     afterExecuteEventData);
 
-                Assert.AreEqual(2, this.sendItems.Count(t => t is DependencyTelemetry));
+                Assert.Equal(2, this.sendItems.Count(t => t is DependencyTelemetry));
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void MultiHost_OneListnerIsActiveAfterDispose()
         {
             var operationId = Guid.NewGuid();
@@ -657,7 +662,7 @@ namespace Microsoft.ApplicationInsights.Tests
                     SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
                     afterExecuteEventData);
 
-                Assert.AreEqual(1, this.sendItems.Count(t => t is DependencyTelemetry));
+                Assert.Equal(1, this.sendItems.Count(t => t is DependencyTelemetry));
 
                 this.sqlClientDiagnosticSourceListener.Dispose();
 
@@ -669,7 +674,7 @@ namespace Microsoft.ApplicationInsights.Tests
                     SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
                     afterExecuteEventData);
 
-                Assert.AreEqual(2, this.sendItems.Count(t => t is DependencyTelemetry));
+                Assert.Equal(2, this.sendItems.Count(t => t is DependencyTelemetry));
             }
         }
 

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticFetcherTypes.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticFetcherTypes.cs
@@ -4,14 +4,22 @@
 
     internal static class SqlClientDiagnosticFetcherTypes
     {
-        //// These types map to the anonymous types defined here: System.Data.SqlClient.SqlClientDiagnosticListenerExtensions. 
+        //// These types map to the anonymous types defined here: 
+        //// System.Data.SqlClient.SqlClientDiagnosticListenerExtensions. 
+        //// and 
+        //// Microsoft.Data.SqlClient.SqlClientDiagnosticListenerExtensions. 
         //// http://github.com/dotnet/corefx/blob/master/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+        //// https://github.com/dotnet/SqlClient/blob/master/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
 
         /// <summary> Fetchers for execute command before event. </summary>
         internal static class CommandBefore
         {
             public static readonly PropertyFetcher OperationId = new PropertyFetcher(nameof(OperationId));
             public static readonly PropertyFetcher Command = new PropertyFetcher(nameof(Command));
+            public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher DataSource = new PropertyFetcher(nameof(DataSource));
+            public static readonly PropertyFetcher Database = new PropertyFetcher(nameof(Database));
+            public static readonly PropertyFetcher CommandType = new PropertyFetcher(nameof(CommandType));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
         }
 

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticFetcherTypes.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticFetcherTypes.cs
@@ -20,6 +20,7 @@
             public static readonly PropertyFetcher DataSource = new PropertyFetcher(nameof(DataSource));
             public static readonly PropertyFetcher Database = new PropertyFetcher(nameof(Database));
             public static readonly PropertyFetcher CommandType = new PropertyFetcher(nameof(CommandType));
+            public static readonly PropertyFetcher CommandText = new PropertyFetcher(nameof(CommandText));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
         }
 
@@ -47,6 +48,8 @@
             public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+            public static readonly PropertyFetcher DataSource = new PropertyFetcher(nameof(DataSource));
+            public static readonly PropertyFetcher Database = new PropertyFetcher(nameof(Database));
         }
 
         /// <summary> Fetchers for connection open/close after events. </summary>
@@ -72,6 +75,8 @@
             public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
             public static readonly PropertyFetcher IsolationLevel = new PropertyFetcher(nameof(IsolationLevel));
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher DataSource = new PropertyFetcher(nameof(DataSource));
+            public static readonly PropertyFetcher Database = new PropertyFetcher(nameof(Database));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
         }
 
@@ -82,6 +87,8 @@
             public static readonly PropertyFetcher Operation = new PropertyFetcher(nameof(Operation));
             public static readonly PropertyFetcher IsolationLevel = new PropertyFetcher(nameof(IsolationLevel));
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
+            public static readonly PropertyFetcher DataSource = new PropertyFetcher(nameof(DataSource));
+            public static readonly PropertyFetcher Database = new PropertyFetcher(nameof(Database));
             public static readonly PropertyFetcher TransactionName = new PropertyFetcher(nameof(TransactionName));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
         }

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
@@ -131,9 +131,9 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
                             {
                                 var dataSource = CommandBefore.DataSource.Fetch(con);
                                 var database = CommandBefore.Database.Fetch(con);
-                                target = string.Join(" | ", dataSource, database );
+                                target = string.Join(" | ", dataSource, database);
                                 
-                                var commandName = (CommandType) CommandBefore.CommandType.Fetch(command) == CommandType.StoredProcedure
+                                var commandName = (CommandType)CommandBefore.CommandType.Fetch(command) == CommandType.StoredProcedure
                                     ? commandText
                                     : string.Empty;
 
@@ -172,7 +172,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
 
                     case SqlAfterExecuteCommand:
                     case SqlMicrosoftAfterExecuteCommand:
-                        {
+                    {
                         var operationId = (Guid)CommandAfter.OperationId.Fetch(evnt.Value);
 
                         DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
@@ -202,7 +202,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
 
                     case SqlErrorExecuteCommand:
                     case SqlMicrosoftErrorExecuteCommand:
-                        {
+                    {
                         var operationId = (Guid)CommandError.OperationId.Fetch(evnt.Value);
 
                         DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
@@ -236,7 +236,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
                     
                     case SqlBeforeOpenConnection:
                     case SqlMicrosoftBeforeOpenConnection:
-                        {
+                    {
                         var operationId = (Guid)ConnectionBefore.OperationId.Fetch(evnt.Value);
 
                         DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
@@ -273,7 +273,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
 
                     case SqlAfterOpenConnection:
                     case SqlMicrosoftAfterOpenConnection:
-                        {
+                    {
                         var operationId = (Guid)ConnectionAfter.OperationId.Fetch(evnt.Value);
 
                         DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
@@ -295,7 +295,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
 
                     case SqlErrorOpenConnection:
                     case SqlMicrosoftErrorOpenConnection:
-                        {
+                    {
                         var operationId = (Guid)ConnectionError.OperationId.Fetch(evnt.Value);
 
                         DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
@@ -329,7 +329,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
 
                     case SqlBeforeCommitTransaction:
                     case SqlMicrosoftBeforeCommitTransaction:
-                        {
+                    {
                         var operationId = (Guid)TransactionCommitBefore.OperationId.Fetch(evnt.Value);
 
                         DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
@@ -368,7 +368,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
 
                     case SqlBeforeRollbackTransaction:
                     case SqlMicrosoftBeforeRollbackTransaction:
-                        {
+                    {
                         var operationId = (Guid)TransactionRollbackBefore.OperationId.Fetch(evnt.Value);
 
                         DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId, evnt.Key);
@@ -407,7 +407,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
 
                     case SqlAfterCommitTransaction:
                     case SqlMicrosoftAfterCommitTransaction:
-                        {
+                    {
                         var operationId = (Guid)TransactionCommitAfter.OperationId.Fetch(evnt.Value);
 
                         DependencyCollectorEventSource.Log.SqlClientDiagnosticSubscriberCallbackCalled(operationId,


### PR DESCRIPTION
Fix Issue #1263  .
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.