### PR TITLE
Adding a flag to enable/disable collection of SQL Command text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Version 2.12.0-beta1
  - [Enhancement to how QuickPulseTelemetryModule shares its ServiceEndpoint with QuickPulseTelemetryProcessor.](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1266)
- - [Adding a flag to DependencyTrackingTelemetryModule to enable/disable collection of SQL Command text](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1285)
+ - [Adding a flag to DependencyTrackingTelemetryModule to enable/disable collection of SQL Command text.](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1285)
+   Collecting SQL Command Text will now be opt-in, so this value will default to false. This is a change from the current behavior on .NET Core. To see how to collect SQL Command Text see here for details: https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-dependencies#advanced-sql-tracking-to-get-full-sql-query
 
 ## Version 2.11.0
  - Updated Base SDK to 2.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.12.0-beta1
  - [Enhancement to how QuickPulseTelemetryModule shares its ServiceEndpoint with QuickPulseTelemetryProcessor.](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1266)
+ - [Adding a flag to DependencyTrackingTelemetryModule to enable/disable collection of SQL Command text](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1285)
 
 ## Version 2.11.0
  - Updated Base SDK to 2.11.0

--- a/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/ProfilerSqlProcessingTest.cs
@@ -43,6 +43,7 @@
         private TelemetryConfiguration configuration;
         private List<ITelemetry> sendItems;
         private ProfilerSqlCommandProcessing sqlCommandProcessingProfiler;
+        private ProfilerSqlCommandProcessing sqlCommandProcessingProfilerWithDisabledCommandText;
         private ProfilerSqlConnectionProcessing sqlConnectionProcessingProfiler;
 
         [TestInitialize]
@@ -52,7 +53,8 @@
             this.sendItems = new List<ITelemetry>();
             this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
-            this.sqlCommandProcessingProfiler = new ProfilerSqlCommandProcessing(this.configuration, null, new ObjectInstanceBasedOperationHolder());
+            this.sqlCommandProcessingProfiler = new ProfilerSqlCommandProcessing(this.configuration, null, new ObjectInstanceBasedOperationHolder(), true);
+            this.sqlCommandProcessingProfilerWithDisabledCommandText = new ProfilerSqlCommandProcessing(this.configuration, null, new ObjectInstanceBasedOperationHolder(), false);
             this.sqlConnectionProcessingProfiler = new ProfilerSqlConnectionProcessing(this.configuration, null, new ObjectInstanceBasedOperationHolder());
         }
 
@@ -301,6 +303,30 @@
             SqlCommand command = GetMoreComplexSqlCommandTestForQuery();
             string actualCommandName = this.sqlCommandProcessingProfiler.GetCommandName(command);
             Assert.AreEqual(command.CommandText, actualCommandName);
+        }
+
+        [TestMethod]
+        public void CommandNameForStoredProcIsCollectedCorrectly()
+        {
+            SqlCommand command = GetSqlCommandTestForStoredProc();
+            string actualCommandName = this.sqlCommandProcessingProfiler.GetCommandName(command);
+            Assert.AreEqual(command.CommandText, actualCommandName);
+        }
+
+        [TestMethod]
+        public void CommandNameForNonStoredProcIsNotCollectedWhenDisabled()
+        {
+            SqlCommand command = GetMoreComplexSqlCommandTestForQuery();
+            string actualCommandName = this.sqlCommandProcessingProfilerWithDisabledCommandText.GetCommandName(command);
+            Assert.AreEqual(string.Empty, actualCommandName);
+        }
+
+        [TestMethod]
+        public void CommandNameForStoredProcIsNotCollectedWhenDisabled()
+        {
+            SqlCommand command = GetSqlCommandTestForStoredProc();
+            string actualCommandName = this.sqlCommandProcessingProfilerWithDisabledCommandText.GetCommandName(command);
+            Assert.AreEqual(string.Empty, actualCommandName);
         }
 
         [TestMethod]

--- a/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
+++ b/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ApplicationInsights.Tests
             };
 
             this.fakeSqlClientDiagnosticSource = new FakeSqlClientDiagnosticSource();
-            this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(this.configuration);
+            this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(this.configuration, true);
         }
 
         public void Dispose()
@@ -582,7 +582,7 @@ namespace Microsoft.ApplicationInsights.Tests
                 Timestamp = 2000000L
             };
 
-            using (var listener2 = new SqlClientDiagnosticSourceListener(this.configuration))
+            using (var listener2 = new SqlClientDiagnosticSourceListener(this.configuration, true))
             {
                 this.fakeSqlClientDiagnosticSource.Write(
                     SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,
@@ -593,6 +593,46 @@ namespace Microsoft.ApplicationInsights.Tests
                     afterExecuteEventData);
 
                 Assert.Equal(1, this.sendItems.Count(t => t is DependencyTelemetry));
+            }
+        }
+
+        [Fact]
+        public void DoesNotTrackCommandTextWhenDisabled()
+        {
+            var operationId = Guid.NewGuid();
+            var sqlConnection = new SqlConnection(TestConnectionString);
+            var sqlCommand = sqlConnection.CreateCommand();
+            sqlCommand.CommandText = "select * from orders";
+
+            var beforeExecuteEventData = new
+            {
+                OperationId = operationId,
+                Command = sqlCommand,
+                Timestamp = (long?)1000000L
+            };
+
+            var afterExecuteEventData = new
+            {
+                OperationId = operationId,
+                Command = sqlCommand,
+                Timestamp = 2000000L
+            };
+
+            this.sqlClientDiagnosticSourceListener.Dispose();
+
+            using (var listener2 = new SqlClientDiagnosticSourceListener(this.configuration, false))
+            {
+                this.fakeSqlClientDiagnosticSource.Write(
+                    SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,
+                    beforeExecuteEventData);
+
+                this.fakeSqlClientDiagnosticSource.Write(
+                    SqlClientDiagnosticSourceListener.SqlAfterExecuteCommand,
+                    afterExecuteEventData);
+
+                Assert.Equal(1, this.sendItems.Count(t => t is DependencyTelemetry));
+                var telemetry = this.sendItems[0] as DependencyTelemetry;
+                Assert.Equal(string.Empty, telemetry.Data);
             }
         }
 
@@ -630,7 +670,7 @@ namespace Microsoft.ApplicationInsights.Tests
 
             this.sqlClientDiagnosticSourceListener.Dispose();
 
-            using (var listener = new SqlClientDiagnosticSourceListener(this.configuration))
+            using (var listener = new SqlClientDiagnosticSourceListener(this.configuration, true))
             {
                 this.fakeSqlClientDiagnosticSource.Write(
                     SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,
@@ -666,7 +706,7 @@ namespace Microsoft.ApplicationInsights.Tests
                 Timestamp = 2000000L
             };
 
-            using (var listener2 = new SqlClientDiagnosticSourceListener(this.configuration))
+            using (var listener2 = new SqlClientDiagnosticSourceListener(this.configuration, true))
             {
                 this.fakeSqlClientDiagnosticSource.Write(
                     SqlClientDiagnosticSourceListener.SqlBeforeExecuteCommand,

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -69,6 +69,11 @@
         public bool EnableRequestIdHeaderInjectionInW3CMode { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether to track the SQL command text in SQL dependencies.
+        /// </summary>
+        public bool EnableSqlCommandTextInstrumentation { get; set; } = true;
+
+        /// <summary>
         /// Gets the component correlation configuration.
         /// </summary>
         public ICollection<string> ExcludeComponentCorrelationHttpHeadersOnDomains { get; } = new SanitizedHostList();
@@ -140,7 +145,7 @@
                                 this.telemetryDiagnosticSourceListener.Subscribe();
                             }
 
-                            this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(configuration);
+                            this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(configuration, EnableSqlCommandTextInstrumentation);
 
                             DependencyCollectorEventSource.Log.RemoteDependencyModuleVerbose("Initializing DependencyTrackingModule completed successfully.");
                         }
@@ -186,7 +191,7 @@
                 this.ExcludeComponentCorrelationHttpHeadersOnDomains,
                 this.EnableLegacyCorrelationHeadersInjection,
                 this.EnableRequestIdHeaderInjectionInW3CMode);
-            this.sqlCommandProcessing = new ProfilerSqlCommandProcessing(this.telemetryConfiguration, agentVersion, DependencyTableStore.Instance.SqlRequestConditionalHolder);
+            this.sqlCommandProcessing = new ProfilerSqlCommandProcessing(this.telemetryConfiguration, agentVersion, DependencyTableStore.Instance.SqlRequestConditionalHolder, EnableSqlCommandTextInstrumentation);
             this.sqlConnectionProcessing = new ProfilerSqlConnectionProcessing(this.telemetryConfiguration, agentVersion, DependencyTableStore.Instance.SqlRequestConditionalHolder);
 
             ProfilerRuntimeInstrumentation.DecorateProfilerForHttp(ref this.httpProcessing);

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -145,7 +145,7 @@
                                 this.telemetryDiagnosticSourceListener.Subscribe();
                             }
 
-                            this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(configuration, EnableSqlCommandTextInstrumentation);
+                            this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(configuration, this.EnableSqlCommandTextInstrumentation);
 
                             DependencyCollectorEventSource.Log.RemoteDependencyModuleVerbose("Initializing DependencyTrackingModule completed successfully.");
                         }
@@ -191,7 +191,7 @@
                 this.ExcludeComponentCorrelationHttpHeadersOnDomains,
                 this.EnableLegacyCorrelationHeadersInjection,
                 this.EnableRequestIdHeaderInjectionInW3CMode);
-            this.sqlCommandProcessing = new ProfilerSqlCommandProcessing(this.telemetryConfiguration, agentVersion, DependencyTableStore.Instance.SqlRequestConditionalHolder, EnableSqlCommandTextInstrumentation);
+            this.sqlCommandProcessing = new ProfilerSqlCommandProcessing(this.telemetryConfiguration, agentVersion, DependencyTableStore.Instance.SqlRequestConditionalHolder, this.EnableSqlCommandTextInstrumentation);
             this.sqlConnectionProcessing = new ProfilerSqlConnectionProcessing(this.telemetryConfiguration, agentVersion, DependencyTableStore.Instance.SqlRequestConditionalHolder);
 
             ProfilerRuntimeInstrumentation.DecorateProfilerForHttp(ref this.httpProcessing);

--- a/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -71,7 +71,7 @@
         /// <summary>
         /// Gets or sets a value indicating whether to track the SQL command text in SQL dependencies.
         /// </summary>
-        public bool EnableSqlCommandTextInstrumentation { get; set; } = true;
+        public bool EnableSqlCommandTextInstrumentation { get; set; } = false;
 
         /// <summary>
         /// Gets the component correlation configuration.
@@ -298,7 +298,7 @@
                 TimeSpan.FromMilliseconds(10));
 
             this.sqlEventListener = RetryPolicy.Retry<InvalidOperationException, TelemetryConfiguration, FrameworkSqlEventListener>(
-                config => new FrameworkSqlEventListener(config, DependencyTableStore.Instance.SqlRequestCacheHolder),
+                config => new FrameworkSqlEventListener(config, DependencyTableStore.Instance.SqlRequestCacheHolder, this.EnableSqlCommandTextInstrumentation),
                 this.telemetryConfiguration,
                 TimeSpan.FromMilliseconds(10));
         }

--- a/Src/DependencyCollector/Shared/Implementation/FrameworkSqlEventListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/FrameworkSqlEventListener.cs
@@ -32,9 +32,15 @@
         /// </summary>
         private const int EndExecuteEventId = 2;
 
-        internal FrameworkSqlEventListener(TelemetryConfiguration configuration, CacheBasedOperationHolder telemetryTupleHolder)
+        /// <summary>
+        /// Indicates whether SQL command text should be collected or not.
+        /// </summary>
+        private readonly bool collectCommandText;
+
+        internal FrameworkSqlEventListener(TelemetryConfiguration configuration, CacheBasedOperationHolder telemetryTupleHolder, bool collectCommandText)
         {
             this.SqlProcessingFramework = new FrameworkSqlProcessing(configuration, telemetryTupleHolder);
+            this.collectCommandText = collectCommandText;
         }
 
         private enum CompositeState
@@ -99,7 +105,7 @@
                 var id = Convert.ToInt64(eventData.Payload[0], CultureInfo.InvariantCulture);
                 var dataSource = Convert.ToString(eventData.Payload[1], CultureInfo.InvariantCulture);
                 var database = Convert.ToString(eventData.Payload[2], CultureInfo.InvariantCulture);
-                var commandText = Convert.ToString(eventData.Payload[3], CultureInfo.InvariantCulture);
+                var commandText = this.collectCommandText ? Convert.ToString(eventData.Payload[3], CultureInfo.InvariantCulture) : string.Empty;
 
                 if (this.SqlProcessingFramework != null)
                 {

--- a/Src/DependencyCollector/Shared/Implementation/ProfilerSqlCommandProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ProfilerSqlCommandProcessing.cs
@@ -10,12 +10,15 @@
     /// </summary>
     internal sealed class ProfilerSqlCommandProcessing : ProfilerSqlProcessingBase
     {
+        private readonly bool collectCommandText;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ProfilerSqlCommandProcessing"/> class.
         /// </summary>
-        internal ProfilerSqlCommandProcessing(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder telemetryTupleHolder)
+        internal ProfilerSqlCommandProcessing(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder telemetryTupleHolder, bool collectCommandText)
             : base(configuration, agentVersion, telemetryTupleHolder)
-        {            
+        {
+            this.collectCommandText = collectCommandText;
         }
 
         /// <summary>
@@ -71,11 +74,14 @@
         /// <returns>Returns the command text or empty.</returns>
         internal override string GetCommandName(object thisObj)
         {
-            SqlCommand command = thisObj as SqlCommand;
-
-            if (command != null)
+            if (collectCommandText)
             {
-                return command.CommandText ?? string.Empty;
+                SqlCommand command = thisObj as SqlCommand;
+
+                if (command != null)
+                {
+                    return command.CommandText ?? string.Empty;
+                }
             }
 
             return string.Empty;

--- a/Src/DependencyCollector/Shared/Implementation/ProfilerSqlCommandProcessing.cs
+++ b/Src/DependencyCollector/Shared/Implementation/ProfilerSqlCommandProcessing.cs
@@ -74,7 +74,7 @@
         /// <returns>Returns the command text or empty.</returns>
         internal override string GetCommandName(object thisObj)
         {
-            if (collectCommandText)
+            if (this.collectCommandText)
             {
                 SqlCommand command = thisObj as SqlCommand;
 

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
@@ -398,7 +398,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
                 var target = string.Empty;
                 var commandType = (CommandType)commandTypeFetcher.Fetch(command);
                 var commandText = string.Empty;
-                if (commandType == CommandType.Text && collectCommandText)
+                if (this.collectCommandText && commandType == CommandType.Text)
                 {
                     commandText = (string)commandTextFetcher.Fetch(command);
                 }


### PR DESCRIPTION
Adding a boolean flag to the DependencyTrackingTelemetryModule which instructs the SQL processors to enable/disable collecting SQL command text.

Also added tests to verify the functionality.

Perhaps there is a better place for that flag than on the module itself since it's propagated down to the other classes, but it made sense to put it there.

This relates to https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/980 as well as
#1282 

- [x] I ran Unit Tests locally.