### PR TITLE
Add metadata support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.12.0-beta2
+ - [Add support for storing EventCounter Metadata as properties of MetricTelemetry](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1287)
+
 ## Version 2.12.0-beta1
  - [Enhancement to how QuickPulseTelemetryModule shares its ServiceEndpoint with QuickPulseTelemetryProcessor.](https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1266)
  - [QuickPulse will support SDK Connection String](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1221)

--- a/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
+++ b/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
@@ -207,7 +207,10 @@
                             foreach (var keyValuePairString in keyValuePairStrings)
                             {
                                 var keyValuePair = keyValuePairString.Split(':');
-                                metricTelemetry.Properties.Add(keyValuePair[0], keyValuePair[1]);
+                                if (!metricTelemetry.Properties.ContainsKey(keyValuePair[0]))
+                                {
+                                    metricTelemetry.Properties.Add(keyValuePair[0], keyValuePair[1]);
+                                }
                             }
                         }
                     }

--- a/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
+++ b/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
@@ -198,6 +198,19 @@
                     {
                         actualCount = Convert.ToInt32(payload.Value, CultureInfo.InvariantCulture);
                     }
+                    else if (key.Equals("Metadata", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var metadata = payload.Value.ToString();
+                        if (!string.IsNullOrEmpty(metadata))
+                        {
+                            var keyValuePairStrings = metadata.Split(',');
+                            foreach (var keyValuePairString in keyValuePairStrings)
+                            {
+                                var keyValuePair = keyValuePairString.Split(':');
+                                metricTelemetry.Properties.Add(keyValuePair[0], keyValuePair[1]);
+                            }
+                        }
+                    }
                 }
 
                 if (calculateRate)


### PR DESCRIPTION
Fix Issue #1287.
Add support for reading Metadata from EventCounter payload.

Some thoughts:

- I could write a unit test for it, but then the test project in `EventCounterCollector.Tests` needs to be .Net Core 3.0 instead of the current .Net Core 2.1
- The metadata is stored in a simple string separated with `,`.  One could potentially add metadata with the characters `,` or `:` in either the name or the value messing things up. I find this unlikely but I do want to mention this.
- We could just store the whole string in a telemetryitem property called "Metadata" but it makes it hard to use when consuming this metrics in Azure Monitor for example.

I tried to mimic the coding style of the rest of the file. If you want me to extract it to a separate method let me know.