### PR TITLE
SQL Collection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.11.1
 - [Fix Sql dependency parent id to match W3CTraceContext format](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1277)
+- [Fix Sql dependency collection bug in .NET Core 3.0 with Microsoft.Data.SqlClient.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1291)
 - [Fix EventCounters so that it appear as CustomMetrics as opposed to PerformanceCounters.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1280)
 
 ## Version 2.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
+## Version 2.11.2
+- [Fix Sql dependency collection bug in .NET Core 3.0 with Microsoft.Data.SqlClient.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1291)
+
 ## Version 2.11.1
 - [Fix Sql dependency parent id to match W3CTraceContext format](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1277)
-- [Fix Sql dependency collection bug in .NET Core 3.0 with Microsoft.Data.SqlClient.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1291)
 - [Fix EventCounters so that it appear as CustomMetrics as opposed to PerformanceCounters.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1280)
 
 ## Version 2.11.0

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -7,7 +7,7 @@
     -->
     <SemanticVersionMajor>2</SemanticVersionMajor>
     <SemanticVersionMinor>11</SemanticVersionMinor>
-    <SemanticVersionPatch>1</SemanticVersionPatch>
+    <SemanticVersionPatch>2</SemanticVersionPatch>
     <!--Valid values: beta1, beta2, EMPTY for stable -->
     <PreReleaseMilestone></PreReleaseMilestone>
     <!-- 

--- a/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticFetcherTypes.cs
+++ b/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticFetcherTypes.cs
@@ -11,7 +11,7 @@
         //// http://github.com/dotnet/corefx/blob/master/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
         //// https://github.com/dotnet/SqlClient/blob/master/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
 
-#region "System.Data fetchers"
+        #region "System.Data fetchers"
 
         /// <summary> Fetchers for execute command before event. </summary>
         internal static class CommandBefore
@@ -41,6 +41,7 @@
             public static readonly PropertyFetcher Command = new PropertyFetcher(nameof(Command));
             public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+            public static readonly PropertyFetcher Number = new PropertyFetcher(nameof(Number));
         }
 
         /// <summary> Fetchers for connection open/close before events. </summary>
@@ -68,6 +69,7 @@
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
             public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+            public static readonly PropertyFetcher Number = new PropertyFetcher(nameof(Number));
         }
 
         /// <summary> Fetchers for transaction commit before events. </summary>
@@ -118,6 +120,7 @@
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
             public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+            public static readonly PropertyFetcher Number = new PropertyFetcher(nameof(Number));
         }
 
         /// <summary> Fetchers for transaction commit error events. </summary>
@@ -127,9 +130,10 @@
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
             public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+            public static readonly PropertyFetcher Number = new PropertyFetcher(nameof(Number));
         }
         #endregion
-        
+
         #region "Microsoft.Data fetchers"
 
         /// <summary> Fetchers for execute command before event. </summary>
@@ -160,6 +164,7 @@
             public static readonly PropertyFetcher Command = new PropertyFetcher(nameof(Command));
             public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+            public static readonly PropertyFetcher Number = new PropertyFetcher(nameof(Number));
         }
 
         /// <summary> Fetchers for connection open/close before events. </summary>
@@ -187,6 +192,7 @@
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
             public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+            public static readonly PropertyFetcher Number = new PropertyFetcher(nameof(Number));
         }
 
         /// <summary> Fetchers for transaction commit before events. </summary>
@@ -237,6 +243,7 @@
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
             public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+            public static readonly PropertyFetcher Number = new PropertyFetcher(nameof(Number));
         }
 
         /// <summary> Fetchers for transaction commit error events. </summary>
@@ -246,6 +253,7 @@
             public static readonly PropertyFetcher Connection = new PropertyFetcher(nameof(Connection));
             public static readonly PropertyFetcher Exception = new PropertyFetcher(nameof(Exception));
             public static readonly PropertyFetcher Timestamp = new PropertyFetcher(nameof(Timestamp));
+            public static readonly PropertyFetcher Number = new PropertyFetcher(nameof(Number));
         }
         #endregion
     }


### PR DESCRIPTION
Fixes #1291 
SQL Listener had references to System.Data types in Microsoft.Data path.

The class is modified to NOT import the system.data namespace now to ensure we rely purely on reflection. This should have been done in the original fix which would have caught this issue there itself.

Fix Issue # .
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.