### PR TITLE
Update to Synthetic User-Agent Telemetry Initializer to allow the con…

### DIFF
--- a/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
+++ b/Src/Web/Web.Shared.Net.Tests/SyntheticUserAgentTelemetryInitializerTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Web
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Web;
@@ -105,6 +106,7 @@
             this.AssertSyntheticSourceIsSet("converacrawler 123");
             this.AssertSyntheticSourceIsSet("Sogou Pic Spider 123");
             this.AssertSyntheticSourceIsSet("Innovazion Crawler 123");
+            this.AssertSyntheticSourceIsSet(String.Empty);
         }
 
         [TestMethod]
@@ -118,7 +120,7 @@
                 {
                     { "User-Agent", userAgent }
                 });
-            source.Filters = this.botSubstrings;            
+            source.Filters = this.botSubstrings;
             source.Initialize(eventTelemetry1);
             source.Initialize(eventTelemetry2);
             Assert.AreEqual("Bot", eventTelemetry2.Context.Operation.SyntheticSource, "Incorrect result for " + userAgent);

--- a/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
+++ b/Src/Web/Web.Shared.Net/SyntheticUserAgentTelemetryInitializer.cs
@@ -15,7 +15,7 @@
         private const string SyntheticSourceNameKey = "Microsoft.ApplicationInsights.RequestTelemetry.SyntheticSource";
         private const string SyntheticSourceName = "Bot";
         private string filters = string.Empty;
-        private Boolean markEmptyUserAgentAsSynthetic = true;
+        private Boolean markEmptyUserAgentAsSynthetic = false;
         private string[] filterPatterns;
 
         /// <summary>


### PR DESCRIPTION
…figuration to optionally treat empty user agent strings as synthetic, as needed to handle FrontDoor health probes

Fix Issue #1297 
As no solution to the blank useragent string has been forthcoming from the FrontDoor team I have updated the SyntheticUserAgentTelemetryInitializer to optionally treat empty user agents as synthetic

- [ X] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/develop/CONTRIBUTING.md) instructions to build and test locally.